### PR TITLE
[#368] Provide custom scopes for MCS environments

### DIFF
--- a/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioClient.ts
@@ -5,7 +5,7 @@
 
 import { ConnectionSettings } from './connectionSettings'
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
-import { getCopilotStudioConnectionUrl } from './powerPlatformEnvironment'
+import { getCopilotStudioConnectionUrl, getTokenAudience } from './powerPlatformEnvironment'
 import { Activity, ActivityTypes, ConversationAccount } from '@microsoft/agents-activity'
 import { ExecuteTurnRequest } from './executeTurnRequest'
 import createDebug, { Debugger } from 'debug'
@@ -31,6 +31,12 @@ export class CopilotStudioClient {
   private readonly client: AxiosInstance
   /** The logger for debugging. */
   private readonly logger: Debugger
+
+  /**
+   * Returns the Scope URL needed to connect to Copilot Studio from the Connection Settings.
+   * @param settings Copilot Studio Connection Settings.
+   */
+  static scopeFromSettings: (settings: ConnectionSettings) => string = getTokenAudience
 
   /**
    * Creates an instance of CopilotStudioClient.

--- a/packages/agents-copilotstudio-client/src/powerPlatformEnvironment.ts
+++ b/packages/agents-copilotstudio-client/src/powerPlatformEnvironment.ts
@@ -101,12 +101,72 @@ export function getCopilotStudioConnectionUrl (
   return strategy.getConversationUrl(conversationId)
 }
 
+/**
+ * Returns the Power Platform API Audience.
+ * @param settings - Configuration Settings to use.
+ * @param cloud - Optional Power Platform Cloud Hosting Agent.
+ * @param cloudBaseAddress - Optional Power Platform API endpoint to use if Cloud is configured as "other".
+ * @param directConnectUrl - Optional DirectConnection URL to a given Copilot Studio agent, if provided all other settings are ignored.
+ * @returns The Power Platform Audience.
+ * @throws Will throw an error if required settings are missing or invalid.
+ */
+export function getTokenAudience (
+  settings?: ConnectionSettings,
+  cloud: PowerPlatformCloud = PowerPlatformCloud.Unknown,
+  cloudBaseAddress: string = '',
+  directConnectUrl: string = ''): string {
+  if (!directConnectUrl && !settings?.directConnectUrl) {
+    if (cloud === PowerPlatformCloud.Other && !cloudBaseAddress) {
+      throw new Error('cloudBaseAddress must be provided when PowerPlatformCloudCategory is Other')
+    }
+    if (!settings && cloud === PowerPlatformCloud.Unknown) {
+      throw new Error('Either settings or cloud must be provided')
+    }
+    if (settings && settings.cloud && settings.cloud !== PowerPlatformCloud.Unknown) {
+      cloud = settings.cloud
+    }
+    if (cloud === PowerPlatformCloud.Other) {
+      if (cloudBaseAddress && isValidUri(cloudBaseAddress)) {
+        cloud = PowerPlatformCloud.Other
+      } else if (settings?.customPowerPlatformCloud && isValidUri(settings!.customPowerPlatformCloud)) {
+        cloud = PowerPlatformCloud.Other
+        cloudBaseAddress = settings.customPowerPlatformCloud
+      } else {
+        throw new Error('Either CustomPowerPlatformCloud or cloudBaseAddress must be provided when PowerPlatformCloudCategory is Other')
+      }
+    }
+    cloudBaseAddress ??= 'api.unknown.powerplatform.com'
+    return `https://${getEndpointSuffix(cloud, cloudBaseAddress)}/.default`
+  } else {
+    if (!directConnectUrl) {
+      directConnectUrl = settings?.directConnectUrl ?? ''
+    }
+    if (directConnectUrl && isValidUri(directConnectUrl)) {
+      if (decodeCloudFromURI(new URL(directConnectUrl)) === PowerPlatformCloud.Unknown) {
+        const cloudToTest: PowerPlatformCloud = settings?.cloud ?? cloud
+
+        if (cloudToTest === PowerPlatformCloud.Other || cloudToTest === PowerPlatformCloud.Unknown) {
+          throw new Error('Unable to resolve the PowerPlatform Cloud from DirectConnectUrl. The Token Audience resolver requires a specific PowerPlatformCloudCategory.')
+        }
+        if ((cloudToTest as PowerPlatformCloud) !== PowerPlatformCloud.Unknown) {
+          return `https://${getEndpointSuffix(cloudToTest, '')}/.default`
+        } else {
+          throw new Error('Unable to resolve the PowerPlatform Cloud from DirectConnectUrl. The Token Audience resolver requires a specific PowerPlatformCloudCategory.')
+        }
+      }
+      return `https://${getEndpointSuffix(decodeCloudFromURI(new URL(directConnectUrl)), '')}/.default`
+    } else {
+      throw new Error('DirectConnectUrl must be provided when DirectConnectUrl is set')
+    }
+  }
+}
 function isValidUri (uri: string): boolean {
   try {
     const newUri = new URL(uri)
     return !!newUri
   } catch {
-    return false
+    // Accept hostnames without scheme as "relative"
+    return /^[a-zA-Z0-9.-]+(\.[a-zA-Z]{2,})?$/.test(uri)
   }
 }
 
@@ -200,5 +260,36 @@ function getIdSuffixLength (cloud: PowerPlatformCloud): number {
       return 2
     default:
       return 1
+  }
+}
+
+function decodeCloudFromURI (uri: URL): PowerPlatformCloud {
+  const host = uri.host.toLowerCase()
+
+  switch (host) {
+    case 'api.powerplatform.localhost':
+      return PowerPlatformCloud.Local
+    case 'api.exp.powerplatform.com':
+      return PowerPlatformCloud.Exp
+    case 'api.dev.powerplatform.com':
+      return PowerPlatformCloud.Dev
+    case 'api.prv.powerplatform.com':
+      return PowerPlatformCloud.Prv
+    case 'api.test.powerplatform.com':
+      return PowerPlatformCloud.Test
+    case 'api.preprod.powerplatform.com':
+      return PowerPlatformCloud.Preprod
+    case 'api.powerplatform.com':
+      return PowerPlatformCloud.Prod
+    case 'api.gov.powerplatform.microsoft.us':
+      return PowerPlatformCloud.GovFR
+    case 'api.high.powerplatform.microsoft.us':
+      return PowerPlatformCloud.High
+    case 'api.appsplatform.us':
+      return PowerPlatformCloud.DoD
+    case 'api.powerplatform.partner.microsoftonline.cn':
+      return PowerPlatformCloud.Mooncake
+    default:
+      return PowerPlatformCloud.Unknown
   }
 }

--- a/packages/agents-copilotstudio-client/test/copilotStudioClient.test.ts
+++ b/packages/agents-copilotstudio-client/test/copilotStudioClient.test.ts
@@ -1,0 +1,79 @@
+import { strict as assert } from 'assert'
+import { describe, it } from 'node:test'
+import { AgentType, ConnectionSettings, CopilotStudioClient, PowerPlatformCloud } from '../src'
+
+describe('scopeFromSettings', function () {
+  const testCases: Array<{
+    label: string
+    cloud: PowerPlatformCloud
+    cloudBaseAddress: string
+    expectedAuthority: string
+    shouldthrow: boolean
+  }> = [
+    {
+      label: 'Should return scope for PowerPlatformCloud.Prod environment',
+      cloud: PowerPlatformCloud.Prod,
+      cloudBaseAddress: '',
+      expectedAuthority: 'https://api.powerplatform.com/.default',
+      shouldthrow: false
+    },
+    {
+      label: 'Should return scope for PowerPlatformCloud.Preprod environment',
+      cloud: PowerPlatformCloud.Preprod,
+      cloudBaseAddress: '',
+      expectedAuthority: 'https://api.preprod.powerplatform.com/.default',
+      shouldthrow: false
+    },
+    {
+      label: 'Should return scope for PowerPlatformCloud.Mooncake environment',
+      cloud: PowerPlatformCloud.Mooncake,
+      cloudBaseAddress: '',
+      expectedAuthority: 'https://api.powerplatform.partner.microsoftonline.cn/.default',
+      shouldthrow: false
+    },
+    {
+      label: 'Should return scope for PowerPlatformCloud.FirstRelease environment',
+      cloud: PowerPlatformCloud.FirstRelease,
+      cloudBaseAddress: '',
+      expectedAuthority: 'https://api.powerplatform.com/.default',
+      shouldthrow: false
+    },
+    {
+      label: 'Should return scope for PowerPlatformCloud.Other environment',
+      cloud: PowerPlatformCloud.Other,
+      cloudBaseAddress: 'fido.com',
+      expectedAuthority: 'https://fido.com/.default',
+      shouldthrow: false
+    },
+    {
+      label: 'Should throw when cloud is Unknown and no cloudBaseAddress is provided',
+      cloud: PowerPlatformCloud.Unknown,
+      cloudBaseAddress: '',
+      expectedAuthority: '',
+      shouldthrow: true
+    }
+  ]
+
+  testCases.forEach((testCase) => {
+    it(testCase.label, function () {
+      const settings: ConnectionSettings = {
+        appClientId: '123',
+        tenantId: 'test-tenant',
+        environmentId: 'A47151CF-4F34-488F-B377-EBE84E17B478',
+        cloud: testCase.cloud,
+        agentIdentifier: 'Bot01',
+        copilotAgentType: AgentType.Published,
+        customPowerPlatformCloud: testCase.cloudBaseAddress
+      }
+
+      if (testCase.shouldthrow) {
+        assert.throws(() => {
+          CopilotStudioClient.scopeFromSettings(settings)
+        }, Error)
+      } else {
+        const scope = CopilotStudioClient.scopeFromSettings(settings)
+        assert(scope === testCase.expectedAuthority)
+      }
+    })
+  })
+})

--- a/test-agents/copilotstudio-console/src/index.ts
+++ b/test-agents/copilotstudio-console/src/index.ts
@@ -28,7 +28,7 @@ async function acquireS2SToken (baseConfig: msal.Configuration, settings: S2SCon
   })
 
   try {
-    const response = await cca.acquireTokenByClientCredential({ scopes: ['https://api.powerplatform.com/.default'] })
+    const response = await cca.acquireTokenByClientCredential({ scopes: [CopilotStudioClient.scopeFromSettings(settings)] })
     if (!response?.accessToken) {
       throw new Error('Failed to acquire token')
     }
@@ -40,9 +40,9 @@ async function acquireS2SToken (baseConfig: msal.Configuration, settings: S2SCon
   }
 }
 
-async function acquireToken (baseConfig: msal.Configuration): Promise<string> {
+async function acquireToken (baseConfig: msal.Configuration, settings: ConnectionSettings): Promise<string> {
   const tokenRequest = {
-    scopes: ['https://api.powerplatform.com/.default'],
+    scopes: [CopilotStudioClient.scopeFromSettings(settings)],
     redirectUri: 'http://localhost',
     openBrowser: async (url: string) => {
       await open(url)
@@ -91,7 +91,7 @@ function getToken (settings: ConnectionSettings) : Promise<string> {
     return acquireS2SToken(msalConfig, { ...settings, appClientSecret: process.env.appClientSecret })
   }
 
-  return acquireToken(msalConfig)
+  return acquireToken(msalConfig, settings)
 }
 
 const createClient = async (): Promise<CopilotStudioClient> => {

--- a/test-agents/copilotstudio-webchat/acquireToken.js
+++ b/test-agents/copilotstudio-webchat/acquireToken.js
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { CopilotStudioClient } from '@microsoft/agents-copilotstudio-client'
+
 export async function acquireToken (settings) {
   const msalInstance = new window.msal.PublicClientApplication({
     auth: {
@@ -13,7 +15,7 @@ export async function acquireToken (settings) {
 
   await msalInstance.initialize()
   const loginRequest = {
-    scopes: ['https://api.powerplatform.com/.default'],
+    scopes: [CopilotStudioClient.scopeFromSettings(settings)],
     redirectUri: window.location.origin,
   }
 


### PR DESCRIPTION
Fixes # 368

## Description
This PR implements the logic to retrieve the Power Platform API Audience (scope) depending on the environment set for the CopilotStudio Client. 
The changes were ported from Agents-for-net.

## Detailed Changes
- Added `scopeFromSettings` static function in _CopilotStudioClient_.
- Added `getTokenAudience` and `decodeCloudFromURI` functions in _PowerPlatformEnvironment_.
- Fix bug in `isValidUri` function to validate both absolute and relative Uri strings.
- Added the `copilotStudioClient.test` class with unit tests.
- Updated `copilotstudio-console` and `copilot-webchat` samples to use the new _scopeFromSettings_ function for setting the scope.

## Testing
This image shows the new unit tests passing.
![image](https://github.com/user-attachments/assets/8b6fb70a-aa6a-47a5-9a2b-973fc0a50f6b)