### PR TITLE
[#366] Add Transcript Middleware to App object

### DIFF
--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -19,8 +19,6 @@ import { RouteSelector } from './routeSelector'
 import { TurnEvents } from './turnEvents'
 import { TurnState } from './turnState'
 import { TranscriptLoggerMiddleware } from '../transcript'
-import { CloudAdapter } from '../cloudAdapter'
-import { AuthConfiguration, loadAuthConfigFromEnv } from '../auth'
 
 const logger = debug('agents:app')
 
@@ -100,7 +98,8 @@ export class AgentApplication<TState extends TurnState> {
    *   storage: myStorage,
    *   adapter: myAdapter,
    *   startTypingTimer: true,
-   *   authorization: { connectionName: 'oauth' }
+   *   authorization: { connectionName: 'oauth' },
+   *   transcriptLogger: myTranscriptLogger,
    * });
    * ```
    */
@@ -129,13 +128,12 @@ export class AgentApplication<TState extends TurnState> {
     }
 
     if (this._options.transcriptLogger) {
-      if (!this._adapter) {
-        const authConfig: AuthConfiguration = loadAuthConfigFromEnv()
-        this._adapter = new CloudAdapter(authConfig)
+      if (!this._options.adapter) {
+        throw new Error('The Application.transcriptLogger property is unavailable because no adapter was configured in the app.')
+      } else {
+        this._adapter?.use(new TranscriptLoggerMiddleware(this._options.transcriptLogger))
       }
-      this._adapter.use(new TranscriptLoggerMiddleware(this._options.transcriptLogger))
     }
-
     logger.debug('AgentApplication created with options:', this._options)
   }
 

--- a/packages/agents-hosting/src/app/agentApplicationOptions.ts
+++ b/packages/agents-hosting/src/app/agentApplicationOptions.ts
@@ -5,6 +5,7 @@
 
 import { CloudAdapter } from '../cloudAdapter'
 import { Storage } from '../storage'
+import { TranscriptLogger } from '../transcript'
 import { AdaptiveCardsOptions } from './adaptiveCards'
 import { InputFileDownloader } from './inputFileDownloader'
 import { AuthorizationHandlers } from './authorization'
@@ -67,4 +68,9 @@ export interface AgentApplicationOptions<TState extends TurnState> {
    * true.
    */
   normalizeMentions?: boolean
+
+  /**
+   * Optional. The transcript logger to use for logging conversations. If not provided, no logging will occur.
+   */
+  transcriptLogger?: TranscriptLogger
 }

--- a/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
+++ b/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
@@ -190,4 +190,10 @@ describe('Application', () => {
     const calledWith = useStub.getCall(0).args[0]
     assert.equal(calledWith.constructor.name, 'TranscriptLoggerMiddleware')
   })
+
+  it('should throw for transcriptLogger when no adapter is provided', async () => {
+    const logger = new ConsoleTranscriptLogger()
+
+    assert.throws(() => new AgentApplication({ transcriptLogger: logger }))
+  })
 })

--- a/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
+++ b/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
@@ -6,6 +6,9 @@ import { TestAdapter } from '../testStubs'
 import { Activity, ActivityTypes } from '@microsoft/agents-activity'
 import { MessageFactory } from '../../../src/messageFactory'
 import { TurnContext } from '../../../src/turnContext'
+import { CloudAdapter } from '../../../src/cloudAdapter'
+import { createStubInstance, SinonStub } from 'sinon'
+import { ConsoleTranscriptLogger } from '../../../src/transcript/consoleTranscriptLogger'
 
 const createTestActivity = () => Activity.fromObject({
   type: 'message',
@@ -40,6 +43,7 @@ describe('Application', () => {
     assert.equal(app.options.storage, undefined)
     assert.equal(app.options.authorization, undefined)
     assert.equal(app.options.startTypingTimer, false)
+    assert.equal(app.options.transcriptLogger, undefined)
   })
 
   it('should route to an activity handler', async () => {
@@ -172,5 +176,18 @@ describe('Application', () => {
     await context.sendActivity('/yo')
     assert.equal(timesCalled, 1)
     assert.equal(handled, true)
+  })
+
+  it('should add TranscriptLoggerMiddleware', async () => {
+    const logger = new ConsoleTranscriptLogger()
+    const adapter: CloudAdapter = createStubInstance(CloudAdapter)
+
+    const app = new AgentApplication({ adapter, transcriptLogger: logger })
+
+    assert.notEqual(app.adapter, undefined)
+    const useStub = adapter.use as SinonStub
+    assert.equal(useStub.calledOnce, true)
+    const calledWith = useStub.getCall(0).args[0]
+    assert.equal(calledWith.constructor.name, 'TranscriptLoggerMiddleware')
   })
 })

--- a/samples/basic/transcriptMiddleware.ts
+++ b/samples/basic/transcriptMiddleware.ts
@@ -1,0 +1,48 @@
+import { startServer } from '@microsoft/agents-hosting-express'
+import { AgentApplication, TranscriptLogger, TurnContext, TurnState } from '@microsoft/agents-hosting'
+import { Activity } from '@microsoft/agents-activity'
+
+class TestLogger implements TranscriptLogger {
+  transcripts: Activity[] = []
+
+  logActivity (activity: any): void {
+    this.transcripts.push(activity)
+  }
+
+  getTranscripts (): Activity[] {
+    return this.transcripts || []
+  }
+
+  deleteTranscript (): void {
+    this.transcripts = []
+  }
+}
+
+const logger: TestLogger = new TestLogger()
+
+const agent = new AgentApplication({ transcriptLogger: logger })
+
+agent.onConversationUpdate('membersAdded', async (context: TurnContext) => {
+  await context.sendActivity('Welcome to the TranscriptMiddleware sample, send "list" to see the logged transcripts and "delete" to clean up the list.')
+})
+
+agent.onMessage('list', async (context: TurnContext) => {
+  const transcripts = logger.getTranscripts()
+  await context.sendActivity('This is the list of logged transcripts:')
+  for (const activity of transcripts) {
+    await context.sendActivity(`Type: ${activity.type}, Text: ${activity.text || 'No text'}`)
+  }
+})
+
+agent.onMessage('delete', async (context: TurnContext) => {
+  logger.deleteTranscript()
+  await context.sendActivity('Transcripts deleted!')
+})
+
+agent.onActivity('message', async (context: TurnContext, state: TurnState) => {
+  let counter: number = state.getValue('conversation.counter') || 0
+  await context.sendActivity(`[${counter++}]You said: ${context.activity.text}`)
+  state.setValue('conversation.counter', counter)
+})
+
+startServer(agent)

--- a/samples/basic/transcriptMiddleware.ts
+++ b/samples/basic/transcriptMiddleware.ts
@@ -1,5 +1,5 @@
 import { startServer } from '@microsoft/agents-hosting-express'
-import { AgentApplication, TranscriptLogger, TurnContext, TurnState } from '@microsoft/agents-hosting'
+import { AgentApplication, CloudAdapter, loadAuthConfigFromEnv, TranscriptLogger, TurnContext, TurnState } from '@microsoft/agents-hosting'
 import { Activity } from '@microsoft/agents-activity'
 
 class TestLogger implements TranscriptLogger {
@@ -19,8 +19,9 @@ class TestLogger implements TranscriptLogger {
 }
 
 const logger: TestLogger = new TestLogger()
+const adapter = new CloudAdapter(loadAuthConfigFromEnv())
 
-const agent = new AgentApplication({ transcriptLogger: logger })
+const agent = new AgentApplication({ adapter, transcriptLogger: logger })
 
 agent.onConversationUpdate('membersAdded', async (context: TurnContext) => {
   await context.sendActivity('Welcome to the TranscriptMiddleware sample, send "list" to see the logged transcripts and "delete" to clean up the list.')


### PR DESCRIPTION
Fixes # 366

## Description
The changes in this PR allow the user to set a `transcriptLogger` option when instanciating the `AgentApplication`. By providing this option, the _TranscriptLoggerMiddleware_ will be added to the adapter.
It also includes a sample to illustrate the feature and two unit tests.

## Detailed Changes
- Added new **_transcriptLogger_** option in `agentApplicationOptions`.
- Added the new option to `AgentApplication` constructor and the condition to add the _TranscriptLoggerMiddleware_ to the adapter when _transcriptLogger_ is provided.
- Added 2 unit tests in `agentApplication.test`.
- Added a new `transcriptMiddleware` sample to illustrate the feature.

## Testing
These images show the sample working and the new unit test passing.
![image](https://github.com/user-attachments/assets/ba7c9a66-6439-4ded-a023-67648f40e8db)
