### PR TITLE
Bump rxjs from 5.5.12 to 7.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5645,13 +5645,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "5.5.12",
-      "license": "Apache-2.0",
+      "version": "7.8.2",
       "dependencies": {
-        "symbol-observable": "1.0.1"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -6149,13 +6145,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tapable": {
@@ -6709,7 +6698,7 @@
         "@microsoft/agents-activity": "file:../agents-activity",
         "axios": "^1.9.0",
         "debug": "^4.3.7",
-        "rxjs": "5.5.12",
+        "rxjs": "7.8.2",
         "uuid": "^11.1.0"
       },
       "engines": {

--- a/packages/agents-copilotstudio-client/package.json
+++ b/packages/agents-copilotstudio-client/package.json
@@ -30,7 +30,7 @@
     "@microsoft/agents-activity": "file:../agents-activity",
     "axios": "^1.9.0",
     "debug": "^4.3.7",
-    "rxjs": "5.5.12",
+    "rxjs": "7.8.2",
     "uuid": "^11.1.0"
   },
   "license": "MIT",

--- a/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
@@ -161,13 +161,12 @@ export class CopilotStudioWebChat {
 }
 
 /**
- * Creates an obserbable that allows executing an asynchronous function.
+ * Creates an observable that allows executing an asynchronous function.
  * @param fn - The function to execute.
  * @returns A new observable.
  */
 function createObservable<T> (fn: (subscriber: Subscriber<T>) => void): Observable<T> {
   return new Observable<T>((subscriber) => {
-    // Do not return a promise to the Observable, as it will not work with the TeardownLogic it receives.
-    fn(subscriber)
+    Promise.resolve(fn(subscriber)).catch((error) => subscriber.error(error))
   })
 }

--- a/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
+++ b/packages/agents-copilotstudio-client/src/copilotStudioWebChat.ts
@@ -6,7 +6,7 @@
 import { v4 as uuid } from 'uuid'
 
 import { Activity, ConversationAccount } from '@microsoft/agents-activity'
-import { Observable, BehaviorSubject, type Observer } from 'rxjs'
+import { Observable, BehaviorSubject, type Subscriber } from 'rxjs'
 
 import { CopilotStudioClient } from './copilotStudioClient'
 
@@ -76,29 +76,27 @@ export class CopilotStudioWebChat {
     settings?: CopilotStudioWebChatSettings
   ):CopilotStudioWebChatConnection {
     let sequence = 0
-    let activityObserver: Observer<Partial<Activity>> | undefined
+    let activitySubscriber: Subscriber<Partial<Activity>> | undefined
     let conversation: ConversationAccount | undefined
 
     const connectionStatus$ = new BehaviorSubject(0)
-    const activity$ = Observable.create(
-      async (observer: Observer<Partial<Activity>>) => {
-        activityObserver = observer
+    const activity$ = createObservable<Partial<Activity>>(async (subscriber) => {
+      activitySubscriber = subscriber
 
-        if (connectionStatus$.value < 2) {
-          connectionStatus$.next(2)
-          return
-        }
-
-        notifyTyping()
-        const activity = await client.startConversationAsync()
-        conversation = activity.conversation
-        sequence = 0
-        notifyActivity(activity)
+      if (connectionStatus$.value < 2) {
+        connectionStatus$.next(2)
+        return
       }
-    )
+
+      notifyTyping()
+      const activity = await client.startConversationAsync()
+      conversation = activity.conversation
+      sequence = 0
+      notifyActivity(activity)
+    })
 
     const notifyActivity = (activity: Partial<Activity>) => {
-      activityObserver?.next({
+      activitySubscriber?.next({
         ...activity,
         timestamp: new Date().toISOString(),
         channelData: {
@@ -127,11 +125,11 @@ export class CopilotStudioWebChat {
           throw new Error('Activity text cannot be empty.')
         }
 
-        if (!activityObserver) {
-          throw new Error('Activity observer is not initialized.')
+        if (!activitySubscriber) {
+          throw new Error('Activity subscriber is not initialized.')
         }
 
-        return Observable.create(async (observer: Observer<string>) => {
+        return createObservable<string>(async (subscriber) => {
           try {
             const id = uuid()
 
@@ -143,22 +141,33 @@ export class CopilotStudioWebChat {
               notifyActivity(responseActivity)
             }
 
-            observer.next(id)
-            observer.complete()
+            subscriber.next(id)
+            subscriber.complete()
           } catch (error) {
-            observer.error(error)
+            subscriber.error(error)
           }
         })
       },
 
       end () {
         connectionStatus$.complete()
-        activity$.complete()
-        if (activityObserver) {
-          activityObserver.complete()
-          activityObserver = undefined
+        if (activitySubscriber) {
+          activitySubscriber.complete()
+          activitySubscriber = undefined
         }
       },
     }
   }
+}
+
+/**
+ * Creates an obserbable that allows executing an asynchronous function.
+ * @param fn - The function to execute.
+ * @returns A new observable.
+ */
+function createObservable<T> (fn: (subscriber: Subscriber<T>) => void): Observable<T> {
+  return new Observable<T>((subscriber) => {
+    // Do not return a promise to the Observable, as it will not work with the TeardownLogic it receives.
+    fn(subscriber)
+  })
 }


### PR DESCRIPTION
Related PR # 406

## Description
This PR updates the rxjs library to the latest version and adapts the WebChat connection functionality to migrate the deprecated `Observable.create` to `new Observable`.

The following image shows the sample working and no errors in the console.
![image](https://github.com/user-attachments/assets/e2958fee-350c-45af-8317-74391b450b38)
