### PR TITLE
Ignore 'No client info' warning from MSAL

### DIFF
--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -82,7 +82,9 @@ export class MsalTokenProvider implements AuthProvider {
             logger.info(message)
             return
           case LogLevel.Warning:
-            logger.warn(message)
+            if (!message.includes('Warning - No client info in response')) {
+              logger.warn(message)
+            }
             return
           case LogLevel.Verbose:
             logger.debug(message)


### PR DESCRIPTION
Fixes # 271

## Description
This PR ignores the `No client info in response` warning from MSAL token provider.
<img width="481" height="142" alt="image" src="https://github.com/user-attachments/assets/e3c6ed14-83be-471d-b2d5-d9a622d444d4" />

## Additional context
The original issue was related to incorrect logging level, showing as info a 'Network error' message from MSAL.
While reviewing this issue, we noticed that the log shared in the description actually consists of two separate messages. The first message, "_Sending token request to endpoint_" is logged by MSAL using `logger.info`. The second message, '_ClientAuthError: network_error: Network request failed_' is an error thrown by MSAL itself (not via `logger.error` or `logger.info`) and raised to `MsalTokenProvider`.

Example:
<img width="1438" height="536" alt="Image" src="https://github.com/user-attachments/assets/20e8dc56-335c-4d71-8428-61f79fcdc882" />