### PR TITLE
[#372] Review onTurnError use cases - Add sample

### DIFF
--- a/samples/basic/errorHandling.ts
+++ b/samples/basic/errorHandling.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { startServer } from '@microsoft/agents-hosting-express'
+import { AgentApplication, MemoryStorage, TurnContext, TurnState } from '@microsoft/agents-hosting'
+
+const agent = new AgentApplication<TurnState>({ storage: new MemoryStorage() })
+
+// The multi-level call is for checking the stacktrace logging.
+function levelOne () {
+  levelTwo()
+}
+
+function levelTwo () {
+  levelThree()
+}
+
+function levelThree () {
+  // We'll force an error by reading a property of undefined.
+  const obj: any = undefined
+  console.log(obj.property)
+}
+
+agent.onConversationUpdate('membersAdded', async (context: TurnContext) => {
+  await context.sendActivity('Welcome to the Error Handling sample, send `/error` to force an error and see how it is handled.')
+})
+
+agent.onMessage('/error', async () => {
+  levelOne()
+})
+
+agent.onActivity('message', async (context: TurnContext) => {
+  await context.sendActivity(`You said: ${context.activity.text}`)
+})
+
+// This handler will replace the adapter's default onTurnError function.
+agent.onError(async (context: TurnContext, error: Error) => {
+  console.error(`An error occurred: ${error}`)
+  await context.sendActivity('Sorry, something went wrong!')
+})
+
+startServer(agent)


### PR DESCRIPTION
Fixes # 372

## Description
This PR adds a sample to showcase how to configure a custom error handler in the _AgentApplication_ to replace the default _onTurnError_ function from the adapter.

## Detailed Changes
- Created a new sample under `samples/basic` named _errorHandling.ts_.

## Testing
These images show the sample working:
- Here the custom error handler is executed, logging the error to the console and sending a message to the user.
<img width="1689" height="1024" alt="image" src="https://github.com/user-attachments/assets/c5deec76-a852-4a7b-9cb3-6fe01f1fc0c2" />

- Here the default onTurnError is executed with the DEBUG=* setting in the .env file. A trace activity is sent, and the detailed error is logged.
<img width="1689" height="1357" alt="image" src="https://github.com/user-attachments/assets/9ad37ee8-1ec9-4869-9500-c45616dddd06" />
