### PR TITLE
[#384] Reorganize exports by named exports - agents-hosting-storage

### DIFF
--- a/compat/baseline/agents-hosting-storage-blob.api.md
+++ b/compat/baseline/agents-hosting-storage-blob.api.md
@@ -43,14 +43,6 @@ export interface BlobsTranscriptStoreOptions {
     storagePipelineOptions?: StoragePipelineOptions;
 }
 
-// @public
-export function maybeCast<T>(value: unknown, ctor?: {
-    new (...args: any[]): T;
-}): T;
-
-// @public
-export function sanitizeBlobKey(key: string, options?: BlobsTranscriptStoreOptions): string;
-
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/compat/baseline/agents-hosting-storage-cosmos.api.md
+++ b/compat/baseline/agents-hosting-storage-cosmos.api.md
@@ -14,7 +14,6 @@ export class CosmosDbPartitionedStorage implements Storage_2 {
     // (undocumented)
     [key: string]: any;
     delete(keys: string[]): Promise<void>;
-    initialize(): Promise<void>;
     length: number;
     read(keys: string[]): Promise<StoreItems>;
     write(changes: StoreItems): Promise<void>;
@@ -28,11 +27,6 @@ export interface CosmosDbPartitionedStorageOptions {
     cosmosClientOptions?: CosmosClientOptions;
     databaseId: string;
     keySuffix?: string;
-}
-
-// @public
-export class DoOnce<T> {
-    waitFor(key: string, fn: () => Promise<T>): Promise<T>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/agents-hosting-storage-blob/src/blobsTranscriptStore.ts
+++ b/packages/agents-hosting-storage-blob/src/blobsTranscriptStore.ts
@@ -129,7 +129,7 @@ export function sanitizeBlobKey (key: string, options?: BlobsTranscriptStoreOpti
  * const stringValue = maybeCast<string>(someValue);
  * ```
  */
-export function maybeCast<T> (value: unknown, ctor?: { new (...args: any[]): T }): T {
+function maybeCast<T> (value: unknown, ctor?: { new (...args: any[]): T }): T {
   if (ctor != null && value instanceof ctor) {
     return value
   }

--- a/packages/agents-hosting-storage-blob/src/index.ts
+++ b/packages/agents-hosting-storage-blob/src/index.ts
@@ -2,4 +2,5 @@
 // Licensed under the MIT License.
 
 export * from './blobsStorage'
-export * from './blobsTranscriptStore'
+export { BlobsTranscriptStore } from './blobsTranscriptStore'
+export { BlobsTranscriptStoreOptions } from './blobsTranscriptStore'

--- a/packages/agents-hosting-storage-cosmos/src/cosmosDbPartitionedStorage.ts
+++ b/packages/agents-hosting-storage-cosmos/src/cosmosDbPartitionedStorage.ts
@@ -207,7 +207,7 @@ export class CosmosDbPartitionedStorage implements Storage {
   /**
    * Initializes the Cosmos DB container.
    */
-  async initialize (): Promise<void> {
+  private async initialize (): Promise<void> {
     if (!this.container) {
       if (!this.client) {
         this.client = new CosmosClient(this.cosmosDbStorageOptions.cosmosClientOptions!)

--- a/packages/agents-hosting-storage-cosmos/src/index.ts
+++ b/packages/agents-hosting-storage-cosmos/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export * from './cosmosDbPartitionedStorage'
+export { CosmosDbPartitionedStorage } from './cosmosDbPartitionedStorage'
 export * from './cosmosDbPartitionedStorageOptions'


### PR DESCRIPTION
Addresses # 384

## Description
This PR removes from the public API classes and methods that should be private because they are intended for internal use.

> **NOTE**:
**This PR introduces breaking changes, as previously public members are now inaccessible.**

### Detailed Changes
- **agents-hosting-storage-blob**
   - Removed _export_ clause in **_maybeCast_** function.
   - Prevent the export of the **_sanitizeBlobKey_** function by implementing selective exports in _blobsTranscriptStore.ts_.
- **agents-hosting-storage-cosmos**
   - Made initialize function private as it's intended for internal use only. 
   - Avoid exporting the **_DoOnce_** class by selectively exporting members in _cosmosDbPartitionedStorage.ts_.
- Updated API docs to reflect the changes.
## Testing
These images show two samples working. One using BlobStorage as transcriptMiddleware and the other using CosmosDb as the application storage.
<img width="2509" height="1073" alt="image" src="https://github.com/user-attachments/assets/a5c4a782-cb96-4e84-819b-e7131af5e5a3" />
