### PR TITLE
Update OBO token flow to show specific span trace and add unit tests

### DIFF
--- a/packages/agents-hosting/src/app/auth/handlers/azureBotAuthorization.ts
+++ b/packages/agents-hosting/src/app/auth/handlers/azureBotAuthorization.ts
@@ -14,7 +14,6 @@ import { TokenExchangeInvokeRequest } from '../../../invoke'
 import { sendInvokeResponse } from '../utils'
 import { Channels, ExceptionHelper } from '@microsoft/agents-activity'
 import { trace, debug } from '@microsoft/agents-telemetry'
-import { AuthProvider } from '../../../auth'
 import { AuthorizationTraceDefinitions } from '../../../observability'
 import { Errors } from '../../../errorHelper'
 
@@ -199,36 +198,20 @@ export class AzureBotAuthorization implements AuthorizationHandler {
    * @returns The token response containing the token or undefined if not available.
    */
   async token (context: TurnContext, options?: AuthorizationHandlerTokenOptions): Promise<TokenResponse> {
+    const oboScopes = options?.scopes && options.scopes.length > 0 ? options.scopes : this.options.oboScopes
+
+    // OBO token acquisition
+    if (oboScopes && oboScopes.length > 0) {
+      const oboConnection = options?.connection ?? this.options.oboConnectionName
+      const token = await this.getOBOToken(context, oboConnection, oboScopes)
+      return { token }
+    }
+
+    // Regular token acquisition
     return trace(AuthorizationTraceDefinitions.azureBotToken, async ({ record }) => {
-      let { token } = this.getContext(context)
-      const traceContext = { connection: this.options.azureBotOAuthConnectionName, scopes: [] }
-
-      try {
-        if (!token?.trim()) {
-          const { activity } = context
-
-          const userTokenClient = await this.getUserTokenClient(context)
-          // Using getTokenOrSignInResource instead of getUserToken to avoid HTTP 404 errors.
-          const { tokenResponse } = await userTokenClient.getTokenOrSignInResource(activity.from?.id!, this.options.azureBotOAuthConnectionName!, activity.channelId!, activity.getConversationReference(), activity.relatesTo!, '')
-          token = tokenResponse?.token
-        }
-
-        if (!token?.trim()) {
-          return { token: undefined }
-        }
-
-        return await this.handleOBO(token, options, traceContext)
-      } finally {
-        record({
-          handlerId: this.id,
-          connectionName: traceContext.connection ?? 'unknown',
-          authFlow: traceContext.scopes && traceContext.scopes.length > 0 ? 'obo' : '',
-          authScopes: traceContext.scopes ?? []
-        })
-        if (traceContext.scopes && traceContext.scopes.length > 0) {
-          record({ authFlow: 'obo', authScopes: traceContext.scopes })
-        }
-      }
+      record({ handlerId: this.id, connectionName: this.options.azureBotOAuthConnectionName })
+      const token = await this.getBaseToken(context)
+      return { token }
     })
   }
 
@@ -340,35 +323,51 @@ export class AzureBotAuthorization implements AuthorizationHandler {
   }
 
   /**
-   * Handles on-behalf-of token acquisition.
+   * Retrieves the base token from the turn state or the user token client.
+   * @param context The turn context.
+   * @returns The token string or undefined if not available.
    */
-  private async handleOBO (token: string, options?: AuthorizationHandlerTokenOptions, traceContext: { connection?: string, scopes?: string[] } = {}): Promise<TokenResponse> {
-    const oboConnection = options?.connection ?? this.options.oboConnectionName
-    const oboScopes = options?.scopes && options.scopes.length > 0 ? options.scopes : this.options.oboScopes
+  private async getBaseToken (context: TurnContext) {
+    const { token } = this.getContext(context)
 
-    if (!oboScopes || oboScopes.length === 0) {
-      traceContext.connection = this.options.azureBotOAuthConnectionName
-      traceContext.scopes = undefined
-      return { token }
+    if (!token?.trim()) {
+      const { activity } = context
+      const userTokenClient = await this.getUserTokenClient(context)
+      // Using getTokenOrSignInResource instead of getUserToken to avoid HTTP 404 errors.
+      const { tokenResponse } = await userTokenClient.getTokenOrSignInResource(activity.from?.id!, this.options.azureBotOAuthConnectionName!, activity.channelId!, activity.getConversationReference(), activity.relatesTo!, '')
+      return tokenResponse?.token
     }
 
-    if (!this.isExchangeable(token)) {
-      throw ExceptionHelper.generateException(Error, Errors.AzureBotConnectionTokenNotExchangeable, undefined, { connectionName: this.options.azureBotOAuthConnectionName! })
-    }
+    return token
+  }
 
-    let provider: AuthProvider | undefined
-    try {
-      provider = oboConnection ? this.settings.connections.getConnection(oboConnection) : this.settings.connections.getDefaultConnection()
-      const newToken = await provider.acquireTokenOnBehalfOf(oboScopes, token)
-      logger.debug(this.prefix('Successfully acquired on-behalf-of token'), { connection: oboConnection, scopes: oboScopes })
-      return { token: newToken }
-    } catch (error) {
-      logger.error(this.prefix('Failed to exchange on-behalf-of token'), { connection: oboConnection, scopes: oboScopes }, error)
-      return { token: undefined }
-    } finally {
-      traceContext.connection = provider?.connectionSettings?.connectionName ?? oboConnection
-      traceContext.scopes = oboScopes
-    }
+  /**
+   * Acquires an on-behalf-of token for the user based on the provided scopes and connection.
+   */
+  private async getOBOToken (context: TurnContext, oboConnection: string | undefined, oboScopes: string[]) {
+    return trace(AuthorizationTraceDefinitions.azureBotOBOToken, async ({ record }) => {
+      record({ handlerId: this.id, connectionName: oboConnection, authScopes: oboScopes })
+      const token = await this.getBaseToken(context)
+      if (!token) {
+        return
+      }
+
+      if (!this.isExchangeable(token)) {
+        throw ExceptionHelper.generateException(Error, Errors.AzureBotConnectionTokenNotExchangeable, undefined, { connectionName: this.options.azureBotOAuthConnectionName! })
+      }
+
+      try {
+        const provider = oboConnection ? this.settings.connections.getConnection(oboConnection) : this.settings.connections.getDefaultConnection()
+        // Record the connection name again in case it changes.
+        record({ connectionName: provider?.connectionSettings?.connectionName })
+        const newToken = await provider.acquireTokenOnBehalfOf(oboScopes, token)
+        logger.debug(this.prefix('Successfully acquired on-behalf-of token'), { connection: oboConnection, scopes: oboScopes })
+        return newToken
+      } catch (error) {
+        logger.error(this.prefix('Failed to exchange on-behalf-of token'), { connection: oboConnection, scopes: oboScopes }, error)
+        throw error
+      }
+    })
   }
 
   /**
@@ -380,7 +379,8 @@ export class AzureBotAuthorization implements AuthorizationHandler {
     }
     const payload = jwt.decode(token) as JwtPayload
     const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud]
-    return audiences.some(aud => typeof aud === 'string' && aud.startsWith('api://'))
+    const appid = payload.azp ?? payload.appid
+    return audiences.some(aud => aud?.includes(appid))
   }
 
   /**

--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -513,7 +513,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
      */
   AzureBotConnectionTokenNotExchangeable: {
     code: -120592,
-    description: "The current token for the '{connectionName}' AzureBot connection is not exchangeable for an on-behalf-of flow. Ensure the token exchange URL starts with 'api://'."
+    description: "The current token for the '{connectionName}' AzureBot connection is not exchangeable for an on-behalf-of flow."
   },
 
   // ============================================================================

--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -595,22 +595,27 @@ export const AuthorizationTraceDefinitions = {
     record: {
       handlerId: '',
       connectionName: '',
-      authFlow: '',
-      authScopes: [] as string[],
     },
     end ({ span, record }) {
       span.setAttributes({
         'auth.handler.id': record.handlerId ?? 'unknown',
         'auth.connection.name': record.connectionName ?? 'unknown',
       })
-
-      if (record.authFlow) {
-        span.setAttribute('auth.flow', record.authFlow)
-      }
-
-      if (record.authScopes.length > 0) {
-        span.setAttribute('auth.scopes', record.authScopes)
-      }
+    }
+  }),
+  azureBotOBOToken: trace.define({
+    name: SpanNames.AUTHORIZATION_AZURE_BOT_OBO_TOKEN,
+    record: {
+      handlerId: '',
+      connectionName: '',
+      authScopes: [] as string[],
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'auth.handler.id': record.handlerId ?? 'unknown',
+        'auth.connection.name': record.connectionName ?? 'unknown',
+        'auth.scopes': record.authScopes
+      })
     }
   }),
   azureBotSignout: trace.define({

--- a/packages/agents-hosting/test/hosting/app/azureBotAuthorization.test.ts
+++ b/packages/agents-hosting/test/hosting/app/azureBotAuthorization.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'assert'
 import { beforeEach, describe, it } from 'node:test'
 import sinon from 'sinon'
+import jwt from 'jsonwebtoken'
 
 import { AzureBotAuthorization } from '../../../src/app/auth/handlers/azureBotAuthorization'
 import type { AzureBotAuthorizationSettings } from '../../../src/app/auth/handlers/azureBotAuthorization'
@@ -12,17 +13,29 @@ import { Activity } from '@microsoft/agents-activity'
 import { AuthorizationHandlerStatus } from '../../../src/app/auth/types'
 import { ActivityTypes } from '../../../../agents-activity/src'
 
-const createSettings = (): AzureBotAuthorizationSettings => ({
+type MockConnection = {
+  acquireTokenOnBehalfOf: sinon.SinonStub<[string[], string], Promise<string>>
+}
+
+const createConnection = (): MockConnection => ({
+  acquireTokenOnBehalfOf: sinon.stub<[string[], string], Promise<string>>().resolves('obo-token')
+})
+
+const createSettings = (defaultConnection: MockConnection, namedConnection: MockConnection): AzureBotAuthorizationSettings => ({
   storage: new MemoryStorage(),
   connections: {
-    getDefaultConnection: () => ({ acquireTokenOnBehalfOf: sinon.stub().resolves('obo-token') }),
-    getConnection: () => ({ acquireTokenOnBehalfOf: sinon.stub().resolves('obo-token') })
+    getDefaultConnection: () => defaultConnection,
+    getConnection: () => namedConnection
   } as any
 })
+
+const createToken = (audience: string, appid = 'resource-app') => jwt.sign({ sub: 'user-1', appid }, 'secret', { audience })
 
 describe('AzureBotAuthorization', () => {
   let settings: AzureBotAuthorizationSettings
   let mockClient: sinon.SinonStubbedInstance<UserTokenClient>
+  let defaultConnection: MockConnection
+  let namedConnection: MockConnection
   const baseAdapter = new TestAdapter()
   const baseActivity = Activity.fromObject({
     type: ActivityTypes.Message,
@@ -34,7 +47,9 @@ describe('AzureBotAuthorization', () => {
   const active = { id: 'auth', activity: baseActivity, attemptsLeft: 2 }
 
   beforeEach(() => {
-    settings = createSettings()
+    defaultConnection = createConnection()
+    namedConnection = createConnection()
+    settings = createSettings(defaultConnection, namedConnection)
     mockClient = sinon.createStubInstance(UserTokenClient)
   })
 
@@ -46,6 +61,55 @@ describe('AzureBotAuthorization', () => {
     const result = await handler.token(context)
     assert.deepEqual(result, { token: 'token' })
     assert.equal(mockClient.getTokenOrSignInResource.calledOnce, true)
+  })
+
+  it('token should exchange a base token for an OBO token when scopes are provided', async () => {
+    const baseToken = createToken('api://resource-app')
+    mockClient.getTokenOrSignInResource.resolves({ tokenResponse: { token: baseToken } } as any)
+    const handler = new AzureBotAuthorization('auth', { azureBotOAuthConnectionName: 'connection' }, settings)
+    const context = new TurnContext(baseAdapter, baseActivity)
+    context.turnState.set(baseAdapter.UserTokenClientKey, mockClient)
+
+    const result = await handler.token(context, { connection: 'obo-connection', scopes: ['scope.read'] })
+
+    assert.deepEqual(result, { token: 'obo-token' })
+    assert.equal(mockClient.getTokenOrSignInResource.calledOnce, true)
+    assert.equal(defaultConnection.acquireTokenOnBehalfOf.notCalled, true)
+    sinon.assert.calledOnce(namedConnection.acquireTokenOnBehalfOf)
+    sinon.assert.calledWithExactly(namedConnection.acquireTokenOnBehalfOf, ['scope.read'], baseToken)
+  })
+
+  it('token should reject OBO when the base token is not exchangeable', async () => {
+    mockClient.getTokenOrSignInResource.resolves({ tokenResponse: { token: createToken('https://graph.microsoft.com') } } as any)
+    const handler = new AzureBotAuthorization('auth', { azureBotOAuthConnectionName: 'connection' }, settings)
+    const context = new TurnContext(baseAdapter, baseActivity)
+    context.turnState.set(baseAdapter.UserTokenClientKey, mockClient)
+
+    await assert.rejects(
+      handler.token(context, { scopes: ['scope.read'] }),
+      /not exchangeable/
+    )
+
+    assert.equal(defaultConnection.acquireTokenOnBehalfOf.notCalled, true)
+    assert.equal(namedConnection.acquireTokenOnBehalfOf.notCalled, true)
+  })
+
+  it('token should throw when OBO exchange fails', async () => {
+    const baseToken = createToken('api://resource-app')
+    mockClient.getTokenOrSignInResource.resolves({ tokenResponse: { token: baseToken } } as any)
+    defaultConnection.acquireTokenOnBehalfOf.rejects(new Error('exchange failed'))
+    const handler = new AzureBotAuthorization('auth', { azureBotOAuthConnectionName: 'connection' }, settings)
+    const context = new TurnContext(baseAdapter, baseActivity)
+    context.turnState.set(baseAdapter.UserTokenClientKey, mockClient)
+
+    await assert.rejects(
+      handler.token(context, { scopes: ['scope.read'] }),
+      /exchange failed/
+    )
+
+    sinon.assert.calledOnce(defaultConnection.acquireTokenOnBehalfOf)
+    sinon.assert.calledWithExactly(defaultConnection.acquireTokenOnBehalfOf, ['scope.read'], baseToken)
+    assert.equal(namedConnection.acquireTokenOnBehalfOf.notCalled, true)
   })
 
   it('signout should call UserTokenClient.signOut', async () => {

--- a/packages/agents-telemetry/src/observability/constants.ts
+++ b/packages/agents-telemetry/src/observability/constants.ts
@@ -66,6 +66,7 @@ export const SpanNames = {
   // Authorization
   AUTHORIZATION_AGENTIC_TOKEN: 'agents.authorization.agentic_token',
   AUTHORIZATION_AZURE_BOT_TOKEN: 'agents.authorization.azure_bot_token',
+  AUTHORIZATION_AZURE_BOT_OBO_TOKEN: 'agents.authorization.azure_bot_obo_token',
   AUTHORIZATION_AZURE_BOT_SIGNIN: 'agents.authorization.azure_bot_signin',
   AUTHORIZATION_AZURE_BOT_SIGNOUT: 'agents.authorization.azure_bot_signout',
 


### PR DESCRIPTION
This pull request refactors and enhances the Azure Bot authorization handler to better support On-Behalf-Of (OBO) token flows, improve code clarity, and add comprehensive tests for OBO scenarios. The changes include separating base token acquisition, improving OBO handling, and expanding test coverage.

**Enhancements to OBO token flow and authorization logic:**

- Refactored the `token` method in `AzureBotAuthorization` to explicitly handle OBO token acquisition when scopes are provided, using a new tracing span (`AUTHORIZATION_AZURE_BOT_OBO_TOKEN`). The method now delegates base token retrieval to a new `getBaseToken` helper, improving separation of concerns.
- Simplified the `handleOBO` method to directly accept the OBO connection and scopes, removing unnecessary parameters and improving error handling and tracing.
- Added a new span name constant `AUTHORIZATION_AZURE_BOT_OBO_TOKEN` for improved telemetry and traceability of OBO flows.
- Fixed issue with v2 tokens considering the token to exchange as not exchangeable because it didnt have the 'api://' audience. Fix ported from .NET.

**Testing improvements:**

- Added comprehensive tests for OBO token exchange, including successful exchange, rejection when the base token is not exchangeable, and handling of OBO exchange failures. These tests use stubs for token acquisition and JWTs for simulating tokens. [[1]](diffhunk://#diff-7a2144bbbd4d597a0bf3cb6dbcb31dfd8a5f11c4f326cc5141b4a9924e54a19bL15-R38) [[2]](diffhunk://#diff-7a2144bbbd4d597a0bf3cb6dbcb31dfd8a5f11c4f326cc5141b4a9924e54a19bR66-R112)
- Improved test setup by introducing reusable mock connection factories and JWT token creation helpers, ensuring tests are more robust and maintainable. [[1]](diffhunk://#diff-7a2144bbbd4d597a0bf3cb6dbcb31dfd8a5f11c4f326cc5141b4a9924e54a19bL15-R38) [[2]](diffhunk://#diff-7a2144bbbd4d597a0bf3cb6dbcb31dfd8a5f11c4f326cc5141b4a9924e54a19bL37-R52)

**Testing**
The following image shows the normal and obo tokens working.
<img width="1969" height="1034" alt="imagen" src="https://github.com/user-attachments/assets/f1d80ac7-f1a2-448f-bf15-ee68cffc6bf5" />