### PR TITLE
[#923] Add unit tests for agents-telemetry

### DIFF
--- a/packages/agents-telemetry/src/utils/attempt.ts
+++ b/packages/agents-telemetry/src/utils/attempt.ts
@@ -24,18 +24,22 @@ export function attempt<TResult> (options: {
       return result
         .then((res) => options.then?.(res) ?? res)
         .catch((error) => {
-          options.catch?.(error)
-          throw error
+          if (options.catch) {
+            return options.catch(error)
+          } else {
+            throw error
+          }
         })
         .finally(options.finally) as any
     }
 
     return options.then?.(result) ?? result
   } catch (error) {
-    if (!_isPromise) {
-      options.catch?.(error)
+    if (options.catch) {
+      return options.catch(error) as TResult
+    } else {
+      throw error
     }
-    throw error
   } finally {
     if (!_isPromise) {
       options.finally?.()

--- a/packages/agents-telemetry/src/utils/attempt.ts
+++ b/packages/agents-telemetry/src/utils/attempt.ts
@@ -13,7 +13,7 @@ export function isPromise<T> (value: T | Promise<T>): value is Promise<T> {
 export function attempt<TResult> (options: {
   try: () => TResult,
   then?: (result: TResult) => TResult | void,
-  catch?: (error: unknown) => void,
+  catch?: (error: unknown) => TResult | never,
   finally?: () => void
 }): TResult {
   let _isPromise = false
@@ -36,7 +36,7 @@ export function attempt<TResult> (options: {
     return options.then?.(result) ?? result
   } catch (error) {
     if (options.catch) {
-      return options.catch(error) as TResult
+      return options.catch(error)
     } else {
       throw error
     }

--- a/packages/agents-telemetry/test/category.test.ts
+++ b/packages/agents-telemetry/test/category.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { beforeEach, afterEach, describe, it } from 'node:test'
+import { SpanNames } from '../src/constants'
+
+describe('isSpanDisabled', () => {
+  let originalEnv = process.env
+  let warnStub: sinon.SinonStub<unknown[], unknown> | sinon.SinonStub<any[], any>
+  let debugStub: sinon.SinonStub<any[], any> | sinon.SinonStub<unknown[], unknown>
+
+  beforeEach(() => {
+    // Store original environment variables
+    originalEnv = { ...process.env }
+    // Reset environment variables before each test
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = ''
+    // Clear the require cache for category and logger
+    delete require.cache[require.resolve('../src/category')]
+    delete require.cache[require.resolve('../src/utils/logger')]
+    // Stub logger methods
+    const logger = require('../src/utils/logger').logger
+    debugStub = sinon.stub(logger, 'debug')
+    warnStub = sinon.stub(logger, 'warn')
+  })
+
+  afterEach(() => {
+    // Restore original environment variables
+    process.env = originalEnv
+    debugStub.restore()
+    warnStub.restore()
+    delete require.cache[require.resolve('../src/category')]
+    delete require.cache[require.resolve('../src/utils/logger')]
+  })
+
+  it('returns false if no env var set', () => {
+    const { isSpanDisabled } = require('../src/category')
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), false)
+  })
+
+  it('returns false if category is invalid', () => {
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'INVALID'
+    const { isSpanDisabled } = require('../src/category')
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), false)
+    assert.ok(warnStub.calledOnce)
+  })
+
+  it('disables all spans in a valid category', () => {
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'STORAGE'
+    const { isSpanDisabled } = require('../src/category')
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), true)
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_WRITE), true)
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_DELETE), true)
+    assert.strictEqual(isSpanDisabled(SpanNames.AGENTS_APP_RUN), false)
+    assert.ok(debugStub.calledWithMatch(sinon.match.string, sinon.match.array))
+  })
+
+  it('handles multiple categories (comma/space separated)', () => {
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'STORAGE,AUTHENTICATION'
+    const { isSpanDisabled } = require('../src/category')
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), true)
+    assert.strictEqual(isSpanDisabled(SpanNames.AUTHENTICATION_GET_ACCESS_TOKEN), true)
+    assert.strictEqual(isSpanDisabled(SpanNames.AGENTS_APP_RUN), false)
+  })
+
+  it('is case-insensitive and trims whitespace', () => {
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = '  storage  '
+    const { isSpanDisabled } = require('../src/category')
+    assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), true)
+  })
+
+  it('does not duplicate disabled spans for overlapping prefixes', () => {
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'AUTHORIZATION'
+    const { isSpanDisabled } = require('../src/category')
+    // Both AUTHORIZATION_ and USER_TOKEN_CLIENT_ prefixes
+    assert.strictEqual(isSpanDisabled(SpanNames.AUTHORIZATION_AGENTIC_TOKEN), true)
+    assert.strictEqual(isSpanDisabled(SpanNames.USER_TOKEN_CLIENT_GET_USER_TOKEN), true)
+  })
+})

--- a/packages/agents-telemetry/test/category.test.ts
+++ b/packages/agents-telemetry/test/category.test.ts
@@ -3,52 +3,59 @@
 
 import assert from 'assert'
 import sinon from 'sinon'
+import { createRequire } from 'node:module'
 import { beforeEach, afterEach, describe, it } from 'node:test'
 import { SpanNames } from '../src/constants'
 
+const cjsRequire = createRequire(__filename)
+
 describe('isSpanDisabled', () => {
-  let originalEnv = process.env
+  let originalDisabledCategories: string | undefined
   let warnStub: sinon.SinonStub<unknown[], unknown> | sinon.SinonStub<any[], any>
   let debugStub: sinon.SinonStub<any[], any> | sinon.SinonStub<unknown[], unknown>
 
   beforeEach(() => {
-    // Store original environment variables
-    originalEnv = { ...process.env }
-    // Reset environment variables before each test
+    // Store original environment variable
+    originalDisabledCategories = process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES
+    // Reset environment variable before each test
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = ''
     // Clear the require cache for category and logger
-    delete require.cache[require.resolve('../src/category')]
-    delete require.cache[require.resolve('../src/utils/logger')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/category')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/utils/logger')]
     // Stub logger methods
-    const logger = require('../src/utils/logger').logger
+    const logger = cjsRequire('../src/utils/logger').logger
     debugStub = sinon.stub(logger, 'debug')
     warnStub = sinon.stub(logger, 'warn')
   })
 
   afterEach(() => {
-    // Restore original environment variables
-    process.env = originalEnv
+    // Restore original environment variable
+    if (originalDisabledCategories === undefined) {
+      delete process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES
+    } else {
+      process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = originalDisabledCategories
+    }
     debugStub.restore()
     warnStub.restore()
-    delete require.cache[require.resolve('../src/category')]
-    delete require.cache[require.resolve('../src/utils/logger')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/category')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/utils/logger')]
   })
 
   it('returns false if no env var set', () => {
-    const { isSpanDisabled } = require('../src/category')
+    const { isSpanDisabled } = cjsRequire('../src/category')
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), false)
   })
 
   it('returns false if category is invalid', () => {
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'INVALID'
-    const { isSpanDisabled } = require('../src/category')
+    const { isSpanDisabled } = cjsRequire('../src/category')
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), false)
     assert.ok(warnStub.calledOnce)
   })
 
   it('disables all spans in a valid category', () => {
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'STORAGE'
-    const { isSpanDisabled } = require('../src/category')
+    const { isSpanDisabled } = cjsRequire('../src/category')
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), true)
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_WRITE), true)
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_DELETE), true)
@@ -58,7 +65,7 @@ describe('isSpanDisabled', () => {
 
   it('handles multiple categories (comma/space separated)', () => {
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'STORAGE,AUTHENTICATION'
-    const { isSpanDisabled } = require('../src/category')
+    const { isSpanDisabled } = cjsRequire('../src/category')
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), true)
     assert.strictEqual(isSpanDisabled(SpanNames.AUTHENTICATION_GET_ACCESS_TOKEN), true)
     assert.strictEqual(isSpanDisabled(SpanNames.AGENTS_APP_RUN), false)
@@ -66,13 +73,13 @@ describe('isSpanDisabled', () => {
 
   it('is case-insensitive and trims whitespace', () => {
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = '  storage  '
-    const { isSpanDisabled } = require('../src/category')
+    const { isSpanDisabled } = cjsRequire('../src/category')
     assert.strictEqual(isSpanDisabled(SpanNames.STORAGE_READ), true)
   })
 
   it('does not duplicate disabled spans for overlapping prefixes', () => {
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'AUTHORIZATION'
-    const { isSpanDisabled } = require('../src/category')
+    const { isSpanDisabled } = cjsRequire('../src/category')
     // Both AUTHORIZATION_ and USER_TOKEN_CLIENT_ prefixes
     assert.strictEqual(isSpanDisabled(SpanNames.AUTHORIZATION_AGENTIC_TOKEN), true)
     assert.strictEqual(isSpanDisabled(SpanNames.USER_TOKEN_CLIENT_GET_USER_TOKEN), true)

--- a/packages/agents-telemetry/test/load.test.ts
+++ b/packages/agents-telemetry/test/load.test.ts
@@ -3,21 +3,27 @@
 
 import assert from 'assert'
 import sinon from 'sinon'
-import { describe, it, beforeEach } from 'node:test'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 import { loadTelemetryDependencies } from '../src/utils/load'
+import { logger } from '../src/utils/logger'
 
-const logger = require('../src/utils/logger').logger
-const warnStub = sinon.spy(logger, 'warn')
-const errorStub = sinon.spy(logger, 'error')
 const primaryOtel = { api: 'otel' }
 const primaryLogs = { api: 'logs' }
 const fallbackOtel = { api: 'otel-fallback' }
 const fallbackLogs = { api: 'logs-fallback' }
 
 describe('loadTelemetryDependencies', () => {
+  let warnStub: sinon.SinonSpy
+  let errorStub: sinon.SinonSpy
+
   beforeEach(() => {
-    warnStub.resetHistory()
-    errorStub.resetHistory()
+    warnStub = sinon.spy(logger, 'warn')
+    errorStub = sinon.spy(logger, 'error')
+  })
+
+  afterEach(() => {
+    warnStub.restore()
+    errorStub.restore()
   })
 
   it('returns primary otel and logs if both succeed', () => {

--- a/packages/agents-telemetry/test/load.test.ts
+++ b/packages/agents-telemetry/test/load.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { describe, it, beforeEach } from 'node:test'
+import { loadTelemetryDependencies } from '../src/utils/load'
+
+const logger = require('../src/utils/logger').logger
+const warnStub = sinon.spy(logger, 'warn')
+const errorStub = sinon.spy(logger, 'error')
+const primaryOtel = { api: 'otel' }
+const primaryLogs = { api: 'logs' }
+const fallbackOtel = { api: 'otel-fallback' }
+const fallbackLogs = { api: 'logs-fallback' }
+
+describe('loadTelemetryDependencies', () => {
+  beforeEach(() => {
+    warnStub.resetHistory()
+    errorStub.resetHistory()
+  })
+
+  it('returns primary otel and logs if both succeed', () => {
+    const [otel, logs] = loadTelemetryDependencies([
+      () => primaryOtel,
+      () => fallbackOtel
+    ], [
+      () => primaryLogs,
+      () => fallbackLogs
+    ])
+    assert.strictEqual(otel, primaryOtel)
+    assert.strictEqual(logs, primaryLogs)
+    assert.ok(warnStub.notCalled)
+    assert.ok(errorStub.notCalled)
+  })
+
+  it('uses fallback if primary otel fails', () => {
+    const [otel, logs] = loadTelemetryDependencies([
+      () => { throw new Error('fail otel') },
+      () => fallbackOtel
+    ], [
+      () => primaryLogs,
+      () => fallbackLogs
+    ])
+    assert.strictEqual(otel, fallbackOtel)
+    assert.strictEqual(logs, primaryLogs)
+    assert.ok(warnStub.calledWithMatch('Missing OpenTelemetry API'))
+    assert.ok(errorStub.notCalled)
+  })
+
+  it('uses fallback if primary logs fails', () => {
+    const [otel, logs] = loadTelemetryDependencies([
+      () => primaryOtel,
+      () => { throw new Error('should not be called') }
+    ], [
+      () => { throw new Error('fail logs') },
+      () => fallbackLogs
+    ])
+    assert.strictEqual(otel, primaryOtel)
+    assert.strictEqual(logs, fallbackLogs)
+    assert.ok(warnStub.calledWithMatch('Missing OpenTelemetry Logs API'))
+    assert.ok(errorStub.notCalled)
+  })
+
+  it('throws if both primary and fallback otel fail', () => {
+    const fallbackOtelError = new Error('fallback otel fail')
+    assert.throws(() => {
+      loadTelemetryDependencies([
+        () => { throw new Error('fail otel') },
+        () => { throw fallbackOtelError }
+      ], [
+        () => fallbackLogs,
+        () => fallbackLogs
+      ])
+    }, fallbackOtelError)
+    assert.ok(warnStub.calledWithMatch('Missing OpenTelemetry API'))
+    assert.ok(errorStub.calledWithMatch('Failed to load bundled OpenTelemetry API fallback'))
+  })
+
+  it('throws if both primary and fallback logs fail', () => {
+    const fallbackLogsError = new Error('fallback logs fail')
+    assert.throws(() => {
+      loadTelemetryDependencies([
+        () => primaryOtel,
+        () => primaryOtel
+      ], [
+        () => { throw new Error('fail logs') },
+        () => { throw fallbackLogsError }
+      ])
+    }, fallbackLogsError)
+    assert.ok(warnStub.calledWithMatch('Missing OpenTelemetry Logs API'))
+    assert.ok(errorStub.calledWithMatch('Failed to load bundled OpenTelemetry Logs API fallback'))
+  })
+})

--- a/packages/agents-telemetry/test/trace.test.ts
+++ b/packages/agents-telemetry/test/trace.test.ts
@@ -3,9 +3,12 @@
 
 import assert from 'assert'
 import sinon from 'sinon'
+import { createRequire } from 'node:module'
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import { traceFactory } from '../src/trace'
 import { SpanNames } from '../src/constants'
+
+const cjsRequire = createRequire(__filename)
 
 describe('traceFactory', () => {
   let otel: any
@@ -63,10 +66,10 @@ describe('traceFactory', () => {
     process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'STORAGE'
 
     // Clear module caches so category re-evaluates disabled spans
-    delete require.cache[require.resolve('../src/category')]
-    delete require.cache[require.resolve('../src/trace')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/category')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/trace')]
 
-    const { traceFactory: factory } = require('../src/trace')
+    const { traceFactory: factory } = cjsRequire('../src/trace')
     const localTrace = factory(otel) as ReturnType<typeof traceFactory>
 
     const noopSpan = { noop: true }
@@ -82,9 +85,13 @@ describe('traceFactory', () => {
     assert.ok(otel.trace.getTracer.notCalled)
 
     // Restore env and module caches
-    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = originalEnv ?? ''
-    delete require.cache[require.resolve('../src/category')]
-    delete require.cache[require.resolve('../src/trace')]
+    if (originalEnv === undefined) {
+      delete process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES
+    } else {
+      process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = originalEnv
+    }
+    delete cjsRequire.cache[cjsRequire.resolve('../src/category')]
+    delete cjsRequire.cache[cjsRequire.resolve('../src/trace')]
   })
 
   it('records exception and sets ERROR status on throw', () => {

--- a/packages/agents-telemetry/test/trace.test.ts
+++ b/packages/agents-telemetry/test/trace.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert'
+import sinon from 'sinon'
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import { traceFactory } from '../src/trace'
+import { SpanNames } from '../src/constants'
+
+describe('traceFactory', () => {
+  let otel: any
+  let mockSpan: any
+  let trace: ReturnType<typeof traceFactory>
+
+  beforeEach(() => {
+    mockSpan = {
+      setStatus: sinon.stub(),
+      recordException: sinon.stub(),
+      end: sinon.stub(),
+    }
+
+    otel = {
+      trace: {
+        getTracer: sinon.stub().returns({
+          startActiveSpan: sinon.stub().callsFake((_name: string, fn: Function) => fn(mockSpan)),
+        }),
+        wrapSpanContext: sinon.stub().returns({ noop: true }),
+      },
+      INVALID_SPAN_CONTEXT: { traceId: '', spanId: '', traceFlags: 0 },
+      SpanStatusCode: {
+        OK: 1,
+        ERROR: 2,
+      },
+    }
+
+    trace = traceFactory(otel)
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('throws for unrecognized span name', () => {
+    assert.throws(
+      () => trace('invalid.span.name' as any, () => {}),
+      /Unrecognized span name "invalid\.span\.name"/
+    )
+  })
+
+  it('calls fn with real span and sets OK status', () => {
+    const result = trace(SpanNames.ADAPTER_PROCESS, (span) => {
+      assert.strictEqual(span, mockSpan)
+      return 42
+    })
+
+    assert.strictEqual(result, 42)
+    assert.ok(mockSpan.setStatus.calledOnceWith({ code: otel.SpanStatusCode.OK }))
+    assert.ok(mockSpan.end.calledOnce)
+  })
+
+  it('calls fn with noop span if span is disabled', () => {
+    const originalEnv = process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = 'STORAGE'
+
+    // Clear module caches so category re-evaluates disabled spans
+    delete require.cache[require.resolve('../src/category')]
+    delete require.cache[require.resolve('../src/trace')]
+
+    const { traceFactory: factory } = require('../src/trace')
+    const localTrace = factory(otel) as ReturnType<typeof traceFactory>
+
+    const noopSpan = { noop: true }
+    otel.trace.wrapSpanContext.returns(noopSpan)
+
+    const result = localTrace(SpanNames.STORAGE_READ, (span) => {
+      assert.strictEqual(span, noopSpan)
+      return 'noop-result'
+    })
+
+    assert.strictEqual(result, 'noop-result')
+    assert.ok(otel.trace.wrapSpanContext.calledOnceWith(otel.INVALID_SPAN_CONTEXT))
+    assert.ok(otel.trace.getTracer.notCalled)
+
+    // Restore env and module caches
+    process.env.AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES = originalEnv ?? ''
+    delete require.cache[require.resolve('../src/category')]
+    delete require.cache[require.resolve('../src/trace')]
+  })
+
+  it('records exception and sets ERROR status on throw', () => {
+    const error = new Error('test error')
+
+    assert.throws(
+      () => trace(SpanNames.ADAPTER_PROCESS, () => { throw error }),
+      (err) => err === error
+    )
+
+    assert.ok(mockSpan.recordException.calledOnceWith(error))
+    assert.ok(mockSpan.setStatus.calledOnceWith({
+      code: otel.SpanStatusCode.ERROR,
+      message: 'test error',
+    }))
+    assert.ok(mockSpan.end.calledOnce)
+  })
+
+  it('records non-Error exception with string conversion', () => {
+    assert.throws(
+      () => trace(SpanNames.ADAPTER_PROCESS, () => { throw 'string error' }), // eslint-disable-line no-throw-literal
+      (err) => err === 'string error'
+    )
+
+    assert.ok(mockSpan.recordException.calledOnceWith({ name: 'string', message: 'string error' }))
+    assert.ok(mockSpan.setStatus.calledOnceWith({
+      code: otel.SpanStatusCode.ERROR,
+      message: 'string error',
+    }))
+    assert.ok(mockSpan.end.calledOnce)
+  })
+
+  it('handles async fn and sets OK status', async () => {
+    const result = await trace(SpanNames.ADAPTER_PROCESS, async (span) => {
+      assert.strictEqual(span, mockSpan)
+      return 'async-result'
+    })
+
+    assert.strictEqual(result, 'async-result')
+    assert.ok(mockSpan.setStatus.calledOnceWith({ code: otel.SpanStatusCode.OK }))
+    assert.ok(mockSpan.end.calledOnce)
+  })
+
+  it('handles async fn rejection', async () => {
+    const error = new Error('async error')
+
+    await assert.rejects(
+      () => trace(SpanNames.ADAPTER_PROCESS, async () => { throw error }),
+      (err: unknown) => err === error
+    )
+
+    assert.ok(mockSpan.recordException.calledOnceWith(error))
+    assert.ok(mockSpan.setStatus.calledOnceWith({
+      code: otel.SpanStatusCode.ERROR,
+      message: 'async error',
+    }))
+    assert.ok(mockSpan.end.calledOnce)
+  })
+})


### PR DESCRIPTION
Addresses # 923

## Description
Adds initial unit test coverage for the @microsoft/agents-telemetry package, focusing on span tracing behavior, span-category disabling, and OpenTelemetry dependency loading/fallback behavior.

### Detailed Changes:

- Add new traceFactory unit tests (success, error, async, disabled spans, and invalid span names).
- Add new unit tests for span-category disabling driven by AGENTS_TELEMETRY_DISABLED_SPAN_CATEGORIES.
- Add new unit tests for loadTelemetryDependencies primary/fallback loader behavior, and update attempt() error-handling semantics to support recovery.

## Testing
This image shows the unit tests passing.
<img width="777" height="903" alt="image" src="https://github.com/user-attachments/assets/098a885e-985e-4594-92b0-c3bbbe59a407" />
