### PR TITLE
[#1029] Pin version of dependencies to handle upgrades deliberately

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,24 +13,24 @@
         "test-agents/*"
       ],
       "devDependencies": {
-        "@microsoft/api-extractor": "^7.57.7",
-        "@microsoft/m365agentsplayground": "^0.2.23",
-        "@microsoft/microsoft-graph-types": "^2.43.1",
-        "@types/debug": "^4.1.12",
-        "@types/express": "^5.0.6",
-        "@types/node": "^25.5.0",
-        "@types/sinon": "^21.0.0",
-        "@types/uuid": "^10.0.0",
-        "esbuild": "^0.27.3",
-        "eslint": "^9.39.2",
-        "knip": "^5.86.0",
-        "neostandard": "^0.13.0",
-        "nerdbank-gitversioning": "^3.9.50",
-        "npm-run-all": "^4.1.5",
-        "sinon": "^21.0.3",
-        "tsx": "^4.21.0",
-        "typedoc": "^0.28.18",
-        "typescript": "^5.9.3"
+        "@microsoft/api-extractor": "7.58.2",
+        "@microsoft/m365agentsplayground": "0.2.23",
+        "@microsoft/microsoft-graph-types": "2.43.1",
+        "@types/debug": "4.1.12",
+        "@types/express": "5.0.6",
+        "@types/node": "25.5.0",
+        "@types/sinon": "21.0.0",
+        "@types/uuid": "10.0.0",
+        "esbuild": "0.27.3",
+        "eslint": "9.39.2",
+        "knip": "5.86.0",
+        "neostandard": "0.13.0",
+        "nerdbank-gitversioning": "3.9.50",
+        "npm-run-all": "4.1.5",
+        "sinon": "21.0.3",
+        "tsx": "4.21.0",
+        "typedoc": "0.28.18",
+        "typescript": "5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1182,17 +1182,19 @@
       "link": true
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.58.1",
+      "version": "7.58.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.2.tgz",
+      "integrity": "sha512-qmqWa0Fx1xn3irQy8MyuAKUs8e3CdwMJOujaPkM8gx5v/V7RcLhTjBU0/uL2kdhmROpW+5WG1FD98O441kkvQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.33.5",
+        "@microsoft/api-extractor-model": "7.33.6",
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.21.0",
+        "@rushstack/node-core-library": "5.22.0",
         "@rushstack/rig-package": "0.7.2",
-        "@rushstack/terminal": "0.22.4",
-        "@rushstack/ts-command-line": "5.3.4",
+        "@rushstack/terminal": "0.22.5",
+        "@rushstack/ts-command-line": "5.3.5",
         "diff": "~8.0.2",
         "lodash": "~4.18.1",
         "minimatch": "10.2.3",
@@ -1206,15 +1208,15 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.33.5",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.5.tgz",
-      "integrity": "sha512-Xh4dXuusndVQqVz4nEN9xOp0DyzsKxeD2FFJkSPg4arAjDSKPcy6cAc7CaeBPA7kF2wV1fuDlo2p/bNMpVr8yg==",
+      "version": "7.33.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.6.tgz",
+      "integrity": "sha512-E9iI4yGEVVusbTAqSLetVFxDuBVCVqCigcoQwdJuOjsLq5Hry3MkBgUQhSZNzLCu17pgjk58MI80GRDJLht/1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.16.0",
         "@microsoft/tsdoc-config": "~0.18.1",
-        "@rushstack/node-core-library": "5.21.0"
+        "@rushstack/node-core-library": "5.22.0"
       }
     },
     "node_modules/@microsoft/m365agentsplayground": {
@@ -3812,9 +3814,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.21.0.tgz",
-      "integrity": "sha512-LFzN+1lyWROit/P8Md6yxAth7lLYKn37oCKJHirEE2TQB25NDUM7bALf0ar+JAtwFfRCH+D+DGOA7DAzIi2r+g==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.22.0.tgz",
+      "integrity": "sha512-S/Dm/N+8tkbasS6yM5cF6q4iDFt14mQQniiVIwk1fd0zpPwWESspO4qtPyIl8szEaN86XOYC1HRRzZrOowxjtw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "~8.18.0",
@@ -3861,12 +3863,12 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.4.tgz",
-      "integrity": "sha512-fhtLjnXCc/4WleVbVl6aoc7jcWnU6yqjS1S8WoaNREG3ycu/viZ9R/9QM7Y/b4CDvcXoiDyMNIay7JMwBptM3g==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.22.5.tgz",
+      "integrity": "sha512-umej8J6A+WRbfQV1G/uNfnz4bMa8CzFU9IJzQb/ZcH4j7Ybg3BQ8UBKOCF3o5U3/2yah1TDU/zE71ugg2JJv+Q==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.21.0",
+        "@rushstack/node-core-library": "5.22.0",
         "@rushstack/problem-matcher": "0.2.1",
         "supports-color": "~8.1.1"
       },
@@ -3880,13 +3882,13 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.4.tgz",
-      "integrity": "sha512-MLkVKVEN6/2clKTrjN2B2KqKCuPxRwnNsWY7a+FCAq2EMdkj10cM8YgiBSMeGFfzM0mDMzargpHNnNzaBi9Whg==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.5.tgz",
+      "integrity": "sha512-ToJQu3+o6aEdDoApGrwb/RsbwDi/NSC7jIEaAezzWM470TRrsXfSHoYAm1eWkhh34xJ+kZxU1ZzKSHiOMlOFPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.22.4",
+        "@rushstack/terminal": "0.22.5",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -10344,8 +10346,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.3",
-        "uuid": "^11.1.0",
+        "debug": "4.4.3",
+        "uuid": "11.1.0",
         "zod": "3.25.75"
       },
       "engines": {
@@ -10358,9 +10360,9 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/agents-activity": "file:../agents-activity",
-        "eventsource-client": "^1.2.0",
+        "eventsource-client": "1.2.0",
         "rxjs": "7.8.2",
-        "uuid": "^11.1.0"
+        "uuid": "11.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10371,17 +10373,17 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-auth": "^1.10.1",
-        "@azure/msal-node": "^5.0.6",
+        "@azure/core-auth": "1.10.1",
+        "@azure/msal-node": "5.0.6",
         "@microsoft/agents-activity": "file:../agents-activity",
-        "axios": "^1.15.0",
-        "jsonwebtoken": "^9.0.3",
-        "jwks-rsa": "^4.0.1",
-        "object-path": "^0.11.8",
+        "axios": "1.15.0",
+        "jsonwebtoken": "9.0.3",
+        "jwks-rsa": "4.0.1",
+        "object-path": "0.11.8",
         "zod": "3.25.75"
       },
       "devDependencies": {
-        "@types/object-path": "^0.11.4"
+        "@types/object-path": "0.11.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10394,14 +10396,14 @@
       "dependencies": {
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../agents-hosting",
-        "@microsoft/recognizers-text-choice": "^1.3.1",
-        "@microsoft/recognizers-text-date-time": "^1.3.2",
-        "@microsoft/recognizers-text-number": "^1.3.1",
-        "@microsoft/recognizers-text-suite": "^1.3.1",
-        "@types/lodash": "^4.17.24",
-        "dependency-graph": "^1.0.0",
-        "globalize": "^1.7.1",
-        "zod": "^3.25.75"
+        "@microsoft/recognizers-text-choice": "1.3.1",
+        "@microsoft/recognizers-text-date-time": "1.3.2",
+        "@microsoft/recognizers-text-number": "1.3.1",
+        "@microsoft/recognizers-text-suite": "1.3.1",
+        "@types/lodash": "4.17.24",
+        "dependency-graph": "1.0.0",
+        "globalize": "1.7.1",
+        "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10413,7 +10415,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/agents-hosting": "file:../agents-hosting",
-        "express": "^5.2.1"
+        "express": "5.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10426,8 +10428,8 @@
       "dependencies": {
         "@microsoft/agents-activity": "file:../agents-activity",
         "@microsoft/agents-hosting": "file:../agents-hosting",
-        "axios": "^1.15.0",
-        "zod": "^3.25.75"
+        "axios": "1.15.0",
+        "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10438,11 +10440,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-auth": "^1.10.1",
-        "@azure/storage-blob": "^12.31.0",
+        "@azure/core-auth": "1.10.1",
+        "@azure/storage-blob": "12.31.0",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
-        "zod": "^3.25.75"
+        "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10453,7 +10455,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/cosmos": "^4.9.1",
+        "@azure/cosmos": "4.9.1",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting"
       },
@@ -10468,7 +10470,7 @@
       "dependencies": {
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-        "jsonwebtoken": "^9.0.3"
+        "jsonwebtoken": "9.0.3"
       }
     },
     "test-agents/application-style": {
@@ -10480,18 +10482,18 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
         "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
-        "@microsoft/microsoft-graph-client": "^3.0.7",
-        "express": "^5.2.1"
+        "@microsoft/microsoft-graph-client": "3.0.7",
+        "express": "5.2.1"
       }
     },
     "test-agents/copilotstudio-console": {
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "^5.0.6",
+        "@azure/msal-node": "5.0.6",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-copilotstudio-client": "file:../../packages/agents-copilotstudio-client",
-        "open": "^11.0.0"
+        "open": "11.0.0"
       }
     },
     "test-agents/custom-dialogs": {
@@ -10501,7 +10503,7 @@
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-dialogs": "file:../../packages/agents-hosting-dialogs",
-        "express": "^5.2.1"
+        "express": "5.2.1"
       }
     },
     "test-agents/empty-agent": {
@@ -10520,7 +10522,7 @@
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-dialogs": "file:../../packages/agents-hosting-dialogs",
-        "express": "^5.2.1"
+        "express": "5.2.1"
       }
     },
     "test-agents/otelAgent": {
@@ -10528,17 +10530,141 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
+        "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.71.0",
-        "@opentelemetry/resources": "^2.6.1",
-        "@opentelemetry/sdk-metrics": "^2.5.0",
-        "@opentelemetry/sdk-node": "^0.213.0",
-        "@opentelemetry/sdk-trace-base": "^2.6.0",
-        "@opentelemetry/sdk-trace-node": "^2.5.0",
-        "@opentelemetry/semantic-conventions": "^1.40.0"
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/auto-instrumentations-node": "0.71.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.5.0",
+        "@opentelemetry/sdk-node": "0.213.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0",
+        "@opentelemetry/sdk-trace-node": "2.5.0",
+        "@opentelemetry/semantic-conventions": "1.40.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.0.tgz",
+      "integrity": "sha512-BeJLtU+f5Gf905cJX9vXFQorAr6TAfK3SPvTFqP+scfIpDQEJfRaGJWta7sJgP+m4dNtBf9y3yvBKVAZZtJQVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.5.0.tgz",
+      "integrity": "sha512-O6N/ejzburFm2C84aKNrwJVPpt6HSTSq8T0ZUMq3xT2XmqT4cwxUItcL5UWGThYuq8RTcbH8u1sfj6dmRci0Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.5.0",
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/sdk-trace-base": "2.5.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.0.tgz",
+      "integrity": "sha512-uOXpVX0ZjO7heSVjhheW2XEPrhQAWr2BScDPoZ9UDycl5iuHG+Usyc3AIfG6kZeC1GyLpMInpQ6X5+9n69yOFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.0.tgz",
+      "integrity": "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/resources": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "test-agents/otelAgent/node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.0.tgz",
+      "integrity": "sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.5.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "test-agents/proactive-agent": {
@@ -10547,7 +10673,7 @@
       "dependencies": {
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-        "jsonwebtoken": "^9.0.3"
+        "jsonwebtoken": "9.0.3"
       }
     },
     "test-agents/root-agent": {
@@ -10557,7 +10683,7 @@
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
-        "express": "^5.2.1"
+        "express": "5.2.1"
       }
     },
     "test-agents/state-agent": {
@@ -10568,7 +10694,7 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
         "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
-        "express": "^5.2.1"
+        "express": "5.2.1"
       }
     },
     "test-agents/web-chat": {
@@ -10578,10 +10704,10 @@
       "dependencies": {
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
-        "@microsoft/microsoft-graph-client": "^3.0.7",
-        "adaptivecards-templating": "^2.3.1",
-        "axios": "^1.15.0",
-        "express": "^5.2.1"
+        "@microsoft/microsoft-graph-client": "3.0.7",
+        "adaptivecards-templating": "2.3.1",
+        "axios": "1.15.0",
+        "express": "5.2.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -922,6 +922,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
       "version": "3.1.5",
       "dev": true,
@@ -990,6 +1008,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -4461,29 +4497,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -4945,9 +4958,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.52",
@@ -4987,12 +5005,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5916,6 +5938,24 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/minimatch": {
       "version": "3.1.5",
       "dev": true,
@@ -5996,6 +6036,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -7889,29 +7947,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -8202,6 +8237,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-all/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/npm-run-all/node_modules/chalk": {
@@ -9406,10 +9459,11 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
-      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
       },
@@ -9914,29 +9968,6 @@
       },
       "peerDependencies": {
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
-      }
-    },
-    "node_modules/typedoc/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -39,24 +39,24 @@
     "test-agents/*"
   ],
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.57.7",
-    "@microsoft/m365agentsplayground": "^0.2.23",
-    "@microsoft/microsoft-graph-types": "^2.43.1",
-    "@types/debug": "^4.1.12",
-    "@types/express": "^5.0.6",
-    "@types/node": "^25.5.0",
-    "@types/sinon": "^21.0.0",
-    "@types/uuid": "^10.0.0",
-    "esbuild": "^0.27.3",
-    "eslint": "^9.39.2",
-    "knip": "^5.86.0",
-    "neostandard": "^0.13.0",
-    "nerdbank-gitversioning": "^3.9.50",
-    "npm-run-all": "^4.1.5",
-    "sinon": "^21.0.3",
-    "tsx": "^4.21.0",
-    "typedoc": "^0.28.18",
-    "typescript": "^5.9.3"
+    "@microsoft/api-extractor": "7.58.2",
+    "@microsoft/m365agentsplayground": "0.2.23",
+    "@microsoft/microsoft-graph-types": "2.43.1",
+    "@types/debug": "4.1.12",
+    "@types/express": "5.0.6",
+    "@types/node": "25.5.0",
+    "@types/sinon": "21.0.0",
+    "@types/uuid": "10.0.0",
+    "esbuild": "0.27.3",
+    "eslint": "9.39.2",
+    "knip": "5.86.0",
+    "neostandard": "0.13.0",
+    "nerdbank-gitversioning": "3.9.50",
+    "npm-run-all": "4.1.5",
+    "sinon": "21.0.3",
+    "tsx": "4.21.0",
+    "typedoc": "0.28.18",
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "@rushstack/terminal": "*"
@@ -67,7 +67,7 @@
   "overrides": {
     "adaptivecards-templating": {
       "adaptive-expressions": {
-        "fast-xml-parser": "^5.5.7"
+        "fast-xml-parser": "5.5.7"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     }
   },
   "overridesComments": {
-    "adaptivecards-templating/adaptive-expressions/fast-xml-parser": "Override to ^5.5.7 because adaptive-expressions pulls vulnerable 4.5.3 (test-agents/web-chat)"
+    "adaptivecards-templating/adaptive-expressions/fast-xml-parser": "Override to 5.5.7 because adaptive-expressions pulls vulnerable 4.5.3 (test-agents/web-chat)"
   }
 }

--- a/packages/agents-activity/package.json
+++ b/packages/agents-activity/package.json
@@ -19,8 +19,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "debug": "^4.4.3",
-    "uuid": "^11.1.0",
+    "debug": "4.4.3",
+    "uuid": "11.1.0",
     "zod": "3.25.75"
   },
   "license": "MIT",

--- a/packages/agents-copilotstudio-client/package.json
+++ b/packages/agents-copilotstudio-client/package.json
@@ -28,9 +28,9 @@
   },
   "dependencies": {
     "@microsoft/agents-activity": "file:../agents-activity",
-    "eventsource-client": "^1.2.0",
+    "eventsource-client": "1.2.0",
     "rxjs": "7.8.2",
-    "uuid": "^11.1.0"
+    "uuid": "11.1.0"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-dialogs/package.json
+++ b/packages/agents-hosting-dialogs/package.json
@@ -18,14 +18,14 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../agents-hosting",
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
-    "@types/lodash": "^4.17.24",
-    "dependency-graph": "^1.0.0",
-    "@microsoft/recognizers-text-suite": "^1.3.1",
-    "@microsoft/recognizers-text-number": "^1.3.1",
-    "@microsoft/recognizers-text-date-time": "^1.3.2",
-    "@microsoft/recognizers-text-choice": "^1.3.1",
-    "globalize": "^1.7.1",
-    "zod": "^3.25.75"
+    "@types/lodash": "4.17.24",
+    "dependency-graph": "1.0.0",
+    "@microsoft/recognizers-text-suite": "1.3.1",
+    "@microsoft/recognizers-text-number": "1.3.1",
+    "@microsoft/recognizers-text-date-time": "1.3.2",
+    "@microsoft/recognizers-text-choice": "1.3.1",
+    "globalize": "1.7.1",
+    "zod": "3.25.75"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-express/package.json
+++ b/packages/agents-hosting-express/package.json
@@ -20,7 +20,7 @@
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "@microsoft/agents-hosting": "file:../agents-hosting",
-    "express": "^5.2.1"
+    "express": "5.2.1"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-extensions-teams/package.json
+++ b/packages/agents-hosting-extensions-teams/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../agents-hosting",
     "@microsoft/agents-activity": "file:../agents-activity",
-    "axios": "^1.15.0",
-    "zod": "^3.25.75"
+    "axios": "1.15.0",
+    "zod": "3.25.75"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-storage-blob/package.json
+++ b/packages/agents-hosting-storage-blob/package.json
@@ -16,11 +16,11 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@azure/core-auth": "^1.10.1",
-    "@azure/storage-blob": "^12.31.0",
+    "@azure/core-auth": "1.10.1",
+    "@azure/storage-blob": "12.31.0",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
-    "zod": "^3.25.75"
+    "zod": "3.25.75"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-storage-cosmos/package.json
+++ b/packages/agents-hosting-storage-cosmos/package.json
@@ -16,7 +16,7 @@
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@azure/cosmos": "^4.9.1",
+    "@azure/cosmos": "4.9.1",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-activity": "file:../../packages/agents-activity"
   },

--- a/packages/agents-hosting/package.json
+++ b/packages/agents-hosting/package.json
@@ -19,13 +19,13 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@azure/core-auth": "^1.10.1",
-    "@azure/msal-node": "^5.0.6",
+    "@azure/core-auth": "1.10.1",
+    "@azure/msal-node": "5.0.6",
     "@microsoft/agents-activity": "file:../agents-activity",
-    "axios": "^1.15.0",
-    "jsonwebtoken": "^9.0.3",
-    "jwks-rsa": "^4.0.1",
-    "object-path": "^0.11.8",
+    "axios": "1.15.0",
+    "jsonwebtoken": "9.0.3",
+    "jwks-rsa": "4.0.1",
+    "object-path": "0.11.8",
     "zod": "3.25.75"
   },
   "license": "MIT",
@@ -47,6 +47,6 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@types/object-path": "^0.11.4"
+    "@types/object-path": "0.11.4"
   }
 }

--- a/test-agents/agentic-ai/package.json
+++ b/test-agents/agentic-ai/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "9.0.3"
   }
 }

--- a/test-agents/application-style/package.json
+++ b/test-agents/application-style/package.json
@@ -23,7 +23,7 @@
         "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
         "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
-        "@microsoft/microsoft-graph-client": "^3.0.7",
-        "express": "^5.2.1"
+        "@microsoft/microsoft-graph-client": "3.0.7",
+        "express": "5.2.1"
     }
 }

--- a/test-agents/copilotstudio-console/package.json
+++ b/test-agents/copilotstudio-console/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/agents-copilotstudio-client": "file:../../packages/agents-copilotstudio-client",
-    "@azure/msal-node": "^5.0.6",
-    "open": "^11.0.0"
+    "@azure/msal-node": "5.0.6",
+    "open": "11.0.0"
   }
 }

--- a/test-agents/custom-dialogs/package.json
+++ b/test-agents/custom-dialogs/package.json
@@ -18,6 +18,6 @@
         "@microsoft/agents-hosting-dialogs": "file:../../packages/agents-hosting-dialogs",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
-        "express": "^5.2.1"
+        "express": "5.2.1"
     }
 }

--- a/test-agents/multi-turn-prompt/package.json
+++ b/test-agents/multi-turn-prompt/package.json
@@ -18,6 +18,6 @@
         "@microsoft/agents-hosting-dialogs": "file:../../packages/agents-hosting-dialogs",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
-        "express": "^5.2.1"
+        "express": "5.2.1"
     }
 }

--- a/test-agents/otelAgent/package.json
+++ b/test-agents/otelAgent/package.json
@@ -15,16 +15,16 @@
     "docker": "docker build -t \"$npm_package_name:$npm_package_version\" ."
   },
   "dependencies": {
-    "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.71.0",
-    "@opentelemetry/resources": "^2.6.1",
-    "@opentelemetry/sdk-metrics": "^2.5.0",
-    "@opentelemetry/sdk-node": "^0.213.0",
-    "@opentelemetry/sdk-trace-base": "^2.6.0",
-    "@opentelemetry/sdk-trace-node": "^2.5.0",
-    "@opentelemetry/semantic-conventions": "^1.40.0"
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "0.71.0",
+    "@opentelemetry/resources": "2.6.1",
+    "@opentelemetry/sdk-metrics": "2.5.0",
+    "@opentelemetry/sdk-node": "0.213.0",
+    "@opentelemetry/sdk-trace-base": "2.6.0",
+    "@opentelemetry/sdk-trace-node": "2.5.0",
+    "@opentelemetry/semantic-conventions": "1.40.0"
   }
 }

--- a/test-agents/proactive-agent/package.json
+++ b/test-agents/proactive-agent/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-hosting-express": "file:../../packages/agents-hosting-express",
-    "jsonwebtoken": "^9.0.3"
+    "jsonwebtoken": "9.0.3"
   }
 }

--- a/test-agents/root-agent/package.json
+++ b/test-agents/root-agent/package.json
@@ -18,6 +18,6 @@
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
-    "express": "^5.2.1"
+    "express": "5.2.1"
   }
 }

--- a/test-agents/state-agent/package.json
+++ b/test-agents/state-agent/package.json
@@ -19,6 +19,6 @@
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-hosting-storage-blob": "file:../../packages/agents-hosting-storage-blob",
     "@microsoft/agents-hosting-storage-cosmos": "file:../../packages/agents-hosting-storage-cosmos",
-    "express": "^5.2.1"
+    "express": "5.2.1"
   }
 }

--- a/test-agents/web-chat/package.json
+++ b/test-agents/web-chat/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
-    "@microsoft/microsoft-graph-client": "^3.0.7",
-    "adaptivecards-templating": "^2.3.1",
-    "axios": "^1.15.0",
-    "express": "^5.2.1"
+    "@microsoft/microsoft-graph-client": "3.0.7",
+    "adaptivecards-templating": "2.3.1",
+    "axios": "1.15.0",
+    "express": "5.2.1"
   }
 }


### PR DESCRIPTION
Fixes # 1029

## Description

This pull request standardizes dependency versions across all `package.json` files in the repository by replacing caret (`^`) and other range specifiers with exact version numbers. This change ensures consistent and repeatable builds by preventing accidental upgrades to newer versions of dependencies, which can help avoid unexpected bugs or incompatibilities.

### Detailed Changes

**Dependency Version Pinning:**

* All dependencies and devDependencies in `package.json` files throughout the repo now use exact versions instead of version ranges (e.g., `"^1.2.3"` → `"1.2.3"`). This affects all core packages and test agents, including third-party libraries such as `express`, `axios`, `uuid`, `jsonwebtoken`, and various Microsoft/Azure packages. 
* Upgraded @microsoft/api-extractor to version 7.58.2 to avoid a regression issue re-inserting a vulnerable version of lodash.

**Overrides and Nested Dependencies:**

* The `overrides` section in the root `package.json` is updated to use an exact version for `fast-xml-parser` within the `adaptive-expressions` dependency, further ensuring deterministic dependency resolution.

These changes collectively improve the reliability of package installations and reduce the risk of issues caused by unintentional dependency upgrades.

## Testing
This image shows the audit command output with no issues.
<img width="644" height="104" alt="image" src="https://github.com/user-attachments/assets/0369b9f7-14b2-4bed-8496-72a6673b3a91" />
