### PR TITLE
adapter.process() Causes Error: Cannot set headers after they are sent to the client

### DIFF
--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -336,6 +336,10 @@ export class CloudAdapter extends BaseAdapter {
     }
 
     const end = (status: StatusCodes, body?: unknown, isInvokeResponseOrExpectReplies: boolean = false) => {
+      if (res.headersSent || res.writableEnded) {
+        return
+      }
+
       res.status(status)
       if (isInvokeResponseOrExpectReplies) {
         res.setHeader('content-type', 'application/json')

--- a/packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts
@@ -40,6 +40,8 @@ describe('CloudAdapter', function () {
       body: {}
     }
     res = {
+      headersSent: false,
+      writableEnded: false,
       status: sinon.stub().returnsThis(),
       send: sinon.stub().returnsThis(),
       end: sinon.stub().returnsThis(),
@@ -164,6 +166,30 @@ describe('CloudAdapter', function () {
       sinon.assert.notCalled((res as any).setHeader)
       sinon.assert.notCalled((res as any).send)
       sinon.assert.calledOnce(createConnectorClientWithIdentitySpy)
+
+      stubfromObject.restore()
+    })
+
+    it('Should not touch the response after logic already committed it', async function () {
+      const activity = createActivity(ActivityTypes.Message)
+      activity.deliveryMode = DeliveryModes.ExpectReplies
+      activity.text = 'test-message'
+      activity.serviceUrl = undefined
+
+      const stubfromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+
+      const logic = async (_context: TurnContext) => {
+        ;(res as any).headersSent = true
+        ;(res as any).writableEnded = true
+      }
+
+      await cloudAdapter.process(req as Request, res as Response, logic)
+
+      sinon.assert.notCalled((res as any).status)
+      sinon.assert.notCalled((res as any).setHeader)
+      sinon.assert.notCalled((res as any).send)
+      sinon.assert.notCalled((res as any).end)
+      sinon.assert.notCalled(createConnectorClientWithIdentitySpy)
 
       stubfromObject.restore()
     })


### PR DESCRIPTION
This pull request improves the robustness of the `CloudAdapter` response handling and adds corresponding test coverage. The main focus is to ensure that the adapter does not attempt to modify the HTTP response if it has already been committed, preventing potential errors and unexpected behavior.

Key changes:

**CloudAdapter response handling:**
* Updated the `end` function in `CloudAdapter` to check `res.headersSent` and `res.writableEnded` before attempting to modify the response, ensuring no further actions are taken if the response has already been sent.

**Test enhancements:**
* Added `headersSent` and `writableEnded` properties to the mock `res` object in the CloudAdapter tests to support the new logic.
* Introduced a new test case to verify that the adapter does not attempt to modify the response if it has already been committed, ensuring the new guard clause works as intended.

**Testing**
The following image shows the sample working.
<img width="1355" height="699" alt="image" src="https://github.com/user-attachments/assets/87b7cc3f-4b34-4788-b2ea-b34c8eaf8626" />
