### PR TITLE
[#1009] Improvements to startServer to allow server customization

### DIFF
--- a/packages/agents-hosting-express/README.md
+++ b/packages/agents-hosting-express/README.md
@@ -5,7 +5,7 @@
 Provides integration to host agents with Express. The package offers three levels of abstraction:
 
 - **`startServer`** — Quickest way to get running. Creates an Express app, wires up auth, and starts listening.
-- **`createAgentRequestHandler`** — A framework-agnostic request handler you can mount in any HTTP framework.
+- **`createAgentRequestHandler`** — A handler signature without Express imports, for frameworks that can provide Express-compatible request/response objects.
 - **`createCloudAdapter`** — Low-level factory to get a `CloudAdapter` for full control over request processing.
 
 ## Usage
@@ -44,7 +44,7 @@ startServer(agent, {
 
 ### Custom Express setup — `createAgentRequestHandler`
 
-If you manage your own Express app (or any HTTP framework), use `createAgentRequestHandler` to get a handler that includes JWT authorization and activity processing:
+If you manage your own Express app (or another framework with an adapter that exposes Express-compatible request/response objects), use `createAgentRequestHandler` to get a handler that includes JWT authorization and activity processing:
 
 ```ts
 import express from 'express';
@@ -61,9 +61,16 @@ app.get('/health', (req, res) => res.json({ status: 'ok' }));
 app.listen(3978);
 ```
 
-### Framework-agnostic — `createCloudAdapter`
+### Advanced — `createCloudAdapter`
 
-For full control, use `createCloudAdapter` to obtain the `CloudAdapter` directly. This is useful when you don't use Express at all, or need to customize how the adapter processes requests:
+For full control, use `createCloudAdapter` to obtain the `CloudAdapter` directly. This is useful when you need to customize request processing and can provide the request/response shape expected by `CloudAdapter.process`.
+
+`CloudAdapter.process` expects:
+
+- a parsed activity body on `req.body` (for example, via `express.json()` in Express)
+- a response object that supports `status()`, `setHeader()`, `send()`, and `end()`
+
+If your framework does not expose those members directly, add an adapter layer before calling `adapter.process`.
 
 ```ts
 import http from 'node:http';
@@ -75,7 +82,8 @@ const { adapter, headerPropagation } = createCloudAdapter(agent);
 
 const server = http.createServer(async (req, res) => {
   if (req.method === 'POST' && req.url === '/api/messages') {
-    await adapter.process(req, res, (context) => agent.run(context), headerPropagation);
+    // Adapt request/response as needed so they match CloudAdapter.process expectations.
+    await adapter.process(req as any, res as any, (context) => agent.run(context), headerPropagation);
   }
 });
 server.listen(3978);

--- a/packages/agents-hosting-express/README.md
+++ b/packages/agents-hosting-express/README.md
@@ -95,7 +95,7 @@ If you need to apply JWT authorization on specific routes in your own Express ap
 
 ```ts
 import express from 'express';
-import { authorizeJWT, AuthConfiguration, getAuthConfigWithDefaults } from '@microsoft/agents-hosting';
+import { authorizeJWT, getAuthConfigWithDefaults, AgentApplication, TurnState } from '@microsoft/agents-hosting';
 import { createCloudAdapter } from '@microsoft/agents-hosting-express';
 
 const agent = new AgentApplication<TurnState>();

--- a/packages/agents-hosting-express/README.md
+++ b/packages/agents-hosting-express/README.md
@@ -2,17 +2,105 @@
 
 ## Overview
 
-Provides integration to host the agent in Express using `startServer`
+Provides integration to host agents with Express. The package offers three levels of abstraction:
+
+- **`startServer`** — Quickest way to get running. Creates an Express app, wires up auth, and starts listening.
+- **`createAgentRequestHandler`** — A framework-agnostic request handler you can mount in any HTTP framework.
+- **`createCloudAdapter`** — Low-level factory to get a `CloudAdapter` for full control over request processing.
 
 ## Usage
 
- ```ts
- import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
- import { startServer } from '@microsoft/agents-hosting-express';
- 
- const app = new AgentApplication<TurnState>();
- app.onMessage('hello', async (context, state) => {
-   await context.sendActivity('Hello, world!');
- });
- startServer(app);
-  ```
+### Basic — `startServer`
+
+```ts
+import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+import { startServer } from '@microsoft/agents-hosting-express';
+
+const app = new AgentApplication<TurnState>();
+app.onActivity('message', async (context) => {
+  await context.sendActivity('Hello, world!');
+});
+startServer(app);
+```
+
+### Custom routes alongside the agent endpoint
+
+Use the `beforeListen` hook to add routes before the server starts listening:
+
+```ts
+import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+import { startServer } from '@microsoft/agents-hosting-express';
+
+const agent = new AgentApplication<TurnState>();
+
+startServer(agent, {
+  port: 8080,
+  routePath: '/bot/messages',
+  beforeListen: (app) => {
+    app.get('/health', (req, res) => res.json({ status: 'ok' }));
+  }
+});
+```
+
+### Custom Express setup — `createAgentRequestHandler`
+
+If you manage your own Express app (or any HTTP framework), use `createAgentRequestHandler` to get a handler that includes JWT authorization and activity processing:
+
+```ts
+import express from 'express';
+import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+import { createAgentRequestHandler } from '@microsoft/agents-hosting-express';
+
+const agent = new AgentApplication<TurnState>();
+const handler = createAgentRequestHandler(agent);
+
+const app = express();
+app.use(express.json());
+app.post('/api/messages', handler);
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+app.listen(3978);
+```
+
+### Framework-agnostic — `createCloudAdapter`
+
+For full control, use `createCloudAdapter` to obtain the `CloudAdapter` directly. This is useful when you don't use Express at all, or need to customize how the adapter processes requests:
+
+```ts
+import http from 'node:http';
+import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+import { createCloudAdapter } from '@microsoft/agents-hosting-express';
+
+const agent = new AgentApplication<TurnState>();
+const { adapter, headerPropagation } = createCloudAdapter(agent);
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/api/messages') {
+    await adapter.process(req, res, (context) => agent.run(context), headerPropagation);
+  }
+});
+server.listen(3978);
+```
+
+### Setting up auth middleware manually
+
+If you need to apply JWT authorization on specific routes in your own Express app:
+
+```ts
+import express from 'express';
+import { authorizeJWT, AuthConfiguration, getAuthConfigWithDefaults } from '@microsoft/agents-hosting';
+import { createCloudAdapter } from '@microsoft/agents-hosting-express';
+
+const agent = new AgentApplication<TurnState>();
+const authConfig = getAuthConfigWithDefaults();
+const { adapter, headerPropagation } = createCloudAdapter(agent);
+
+const app = express();
+app.use(express.json());
+
+// JWT is applied only on the agent route — custom routes remain unauthenticated
+app.post('/api/messages', authorizeJWT(authConfig), (req, res) =>
+  adapter.process(req, res, (context) => agent.run(context), headerPropagation)
+);
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+app.listen(3978);
+```

--- a/packages/agents-hosting-express/src/createAgentRequestHandler.ts
+++ b/packages/agents-hosting-express/src/createAgentRequestHandler.ts
@@ -9,7 +9,7 @@ import { createCloudAdapter } from './createCloudAdapter'
 
 /**
  * Minimal response interface describing the methods used by the Agent request handler.
- * Any HTTP framework whose response object satisfies this shape (Express, Koa with adapter, etc.) is compatible.
+ * Any framework whose response object satisfies this shape is compatible.
  */
 export interface WebResponse {
   status (code: number): this
@@ -20,41 +20,28 @@ export interface WebResponse {
 }
 
 /**
- * A request handler function signature that does not depend on Express types.
- * Compatible with Express, Fastify, Koa (with adapters), or any framework whose response satisfies {@link WebResponse}.
+ * A request handler function signature that does not import Express types in its public API.
+ *
+ * @remarks
+ * Runtime processing still depends on the request/response behavior expected by `authorizeJWT` and `CloudAdapter.process`.
+ * Use this with Express directly, or with adapter layers that provide compatible request/response objects.
  */
 export type AgentRequestHandler = (req: Request, res: WebResponse) => Promise<void>
 
 /**
- * Creates a framework-agnostic request handler for processing Agent activities.
+ * Creates a request handler for processing Agent activities.
  *
- * This decouples the core agent request processing logic from Express, allowing it to be used
- * with any HTTP framework that provides compatible `req` and `res` objects (Express, Fastify, raw `http`, etc.).
+ * This exposes a handler signature without requiring Express types in consumer code.
+ * It can be used with Express directly, or with frameworks that provide adapted objects compatible with
+ * the requirements of `authorizeJWT` and `CloudAdapter.process`.
  *
  * JWT authorization is applied within the handler before processing the activity.
+ * Requests must provide a parsed activity payload at `req.body`.
  *
  * @param agent - The AgentApplication or ActivityHandler instance to process incoming activities.
  * @param authConfiguration - Optional custom authentication configuration. If not provided,
  * configuration will be loaded from environment variables using loadAuthConfigFromEnv().
  * @returns A request handler function `(req, res) => Promise<void>`.
- *
- * @example
- * ```typescript
- * import http from 'node:http';
- * import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
- * import { createAgentRequestHandler } from '@microsoft/agents-hosting-express';
- *
- * const agent = new AgentApplication<TurnState>();
- * const handler = createAgentRequestHandler(agent);
- *
- * // Use with raw Node.js http server
- * const server = http.createServer(async (req, res) => {
- *   if (req.method === 'POST' && req.url === '/api/messages') {
- *     await handler(req, res);
- *   }
- * });
- * server.listen(3978);
- * ```
  *
  * @example
  * ```typescript
@@ -81,18 +68,20 @@ export const createAgentRequestHandler = (
   const jwtMiddleware = authorizeJWT(authConfig)
 
   return async (req: Request, res: WebResponse): Promise<void> => {
-    await new Promise<void>((resolve, reject) => {
-      jwtMiddleware(req, res as Response, (err?: any) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
+    let middlewareError: any
+    let nextCalled = false
+
+    await jwtMiddleware(req, res as Response, (err?: any) => {
+      nextCalled = true
+      middlewareError = err
     })
 
-    // If the middleware already sent a response (e.g., 401), don't process the activity
-    if (res.headersSent) {
+    if (middlewareError) {
+      throw middlewareError
+    }
+
+    // If the middleware handled the response without calling next (e.g., 401), don't process the activity.
+    if (!nextCalled || res.headersSent) {
       return
     }
 

--- a/packages/agents-hosting-express/src/createAgentRequestHandler.ts
+++ b/packages/agents-hosting-express/src/createAgentRequestHandler.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { type Response } from 'express'
+import { ActivityHandler, AgentApplication, AuthConfiguration, authorizeJWT, getAuthConfigWithDefaults, Request, TurnState } from '@microsoft/agents-hosting'
+import { createCloudAdapter } from './createCloudAdapter'
+
+/**
+ * Minimal response interface describing the methods used by the Agent request handler.
+ * Any HTTP framework whose response object satisfies this shape (Express, Koa with adapter, etc.) is compatible.
+ */
+export interface WebResponse {
+  status (code: number): this
+  setHeader (name: string, value: string): this
+  send (body?: unknown): this
+  end (): this
+  headersSent: boolean
+}
+
+/**
+ * A request handler function signature that does not depend on Express types.
+ * Compatible with Express, Fastify, Koa (with adapters), or any framework whose response satisfies {@link WebResponse}.
+ */
+export type AgentRequestHandler = (req: Request, res: WebResponse) => Promise<void>
+
+/**
+ * Creates a framework-agnostic request handler for processing Agent activities.
+ *
+ * This decouples the core agent request processing logic from Express, allowing it to be used
+ * with any HTTP framework that provides compatible `req` and `res` objects (Express, Fastify, raw `http`, etc.).
+ *
+ * JWT authorization is applied within the handler before processing the activity.
+ *
+ * @param agent - The AgentApplication or ActivityHandler instance to process incoming activities.
+ * @param authConfiguration - Optional custom authentication configuration. If not provided,
+ * configuration will be loaded from environment variables using loadAuthConfigFromEnv().
+ * @returns A request handler function `(req, res) => Promise<void>`.
+ *
+ * @example
+ * ```typescript
+ * import http from 'node:http';
+ * import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+ * import { createAgentRequestHandler } from '@microsoft/agents-hosting-express';
+ *
+ * const agent = new AgentApplication<TurnState>();
+ * const handler = createAgentRequestHandler(agent);
+ *
+ * // Use with raw Node.js http server
+ * const server = http.createServer(async (req, res) => {
+ *   if (req.method === 'POST' && req.url === '/api/messages') {
+ *     await handler(req, res);
+ *   }
+ * });
+ * server.listen(3978);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * import express from 'express';
+ * import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+ * import { createAgentRequestHandler } from '@microsoft/agents-hosting-express';
+ *
+ * const agent = new AgentApplication<TurnState>();
+ * const handler = createAgentRequestHandler(agent);
+ *
+ * const app = express();
+ * app.use(express.json());
+ * app.post('/api/messages', handler);
+ * app.get('/health', (req, res) => res.json({ status: 'ok' }));
+ * app.listen(3978);
+ * ```
+ */
+export const createAgentRequestHandler = (
+  agent: AgentApplication<TurnState<any, any>> | ActivityHandler,
+  authConfiguration?: AuthConfiguration
+): AgentRequestHandler => {
+  const authConfig = getAuthConfigWithDefaults(authConfiguration)
+  const { adapter, headerPropagation } = createCloudAdapter(agent)
+  const jwtMiddleware = authorizeJWT(authConfig)
+
+  return async (req: Request, res: WebResponse): Promise<void> => {
+    await new Promise<void>((resolve, reject) => {
+      jwtMiddleware(req, res as Response, (err?: any) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+
+    // If the middleware already sent a response (e.g., 401), don't process the activity
+    if (res.headersSent) {
+      return
+    }
+
+    await adapter.process(req, res as Response, (context) => agent.run(context), headerPropagation)
+  }
+}

--- a/packages/agents-hosting-express/src/createCloudAdapter.ts
+++ b/packages/agents-hosting-express/src/createCloudAdapter.ts
@@ -30,7 +30,7 @@ export interface CloudAdapterResult {
  * const app = new AgentApplication<TurnState>();
  * const { adapter, headerPropagation } = createCloudAdapter(app);
  *
- * // Use the adapter directly with any HTTP framework
+ * // Use the adapter directly with request/response objects compatible with CloudAdapter.process
  * adapter.process(req, res, (context) => app.run(context), headerPropagation);
  * ```
  */

--- a/packages/agents-hosting-express/src/createCloudAdapter.ts
+++ b/packages/agents-hosting-express/src/createCloudAdapter.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ActivityHandler, AgentApplication, CloudAdapter, HeaderPropagationDefinition, TurnState } from '@microsoft/agents-hosting'
+
+/**
+ * Result of creating a CloudAdapter from an agent.
+ */
+export interface CloudAdapterResult {
+  adapter: CloudAdapter
+  headerPropagation: HeaderPropagationDefinition | undefined
+}
+
+/**
+ * Creates a CloudAdapter for the given agent.
+ *
+ * If the agent is an AgentApplication with a pre-configured adapter, that adapter is reused.
+ * Otherwise, a new CloudAdapter is created.
+ *
+ * @param agent - The AgentApplication or ActivityHandler instance.
+ * @returns An object containing the CloudAdapter and optional header propagation configuration.
+ *
+ * @example
+ * ```typescript
+ * import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+ * import { createCloudAdapter } from '@microsoft/agents-hosting-express';
+ *
+ * const app = new AgentApplication<TurnState>();
+ * const { adapter, headerPropagation } = createCloudAdapter(app);
+ *
+ * // Use the adapter directly with any HTTP framework
+ * adapter.process(req, res, (context) => app.run(context), headerPropagation);
+ * ```
+ */
+export const createCloudAdapter = (agent: AgentApplication<TurnState<any, any>> | ActivityHandler): CloudAdapterResult => {
+  let adapter: CloudAdapter
+  let headerPropagation: HeaderPropagationDefinition | undefined
+  if (agent instanceof ActivityHandler || !agent.adapter) {
+    adapter = new CloudAdapter()
+  } else {
+    adapter = agent.adapter as CloudAdapter
+    headerPropagation = (agent as AgentApplication<TurnState<any, any>>)?.options.headerPropagation
+  }
+  return { adapter, headerPropagation }
+}

--- a/packages/agents-hosting-express/src/index.ts
+++ b/packages/agents-hosting-express/src/index.ts
@@ -1,1 +1,3 @@
 export * from './startServer'
+export * from './createCloudAdapter'
+export * from './createAgentRequestHandler'

--- a/packages/agents-hosting-express/src/startServer.ts
+++ b/packages/agents-hosting-express/src/startServer.ts
@@ -96,15 +96,15 @@ export function startServer (agent: AgentApplication<TurnState<any, any>> | Acti
   const server = express()
   server.use(express.json())
 
+  if (opts.beforeListen) {
+    opts.beforeListen(server)
+  }
+
   server.post(routePath, authorizeJWT(authConfig), (req: Request, res: Response) =>
     adapter.process(req, res, (context) =>
       agent.run(context)
     , headerPropagation)
   )
-
-  if (opts.beforeListen) {
-    opts.beforeListen(server)
-  }
 
   const port = opts.port ?? process.env.PORT ?? 3978
   server.listen(port, async () => {

--- a/packages/agents-hosting-express/src/startServer.ts
+++ b/packages/agents-hosting-express/src/startServer.ts
@@ -107,7 +107,7 @@ export function startServer (agent: AgentApplication<TurnState<any, any>> | Acti
   }
 
   const port = opts.port ?? process.env.PORT ?? 3978
-  server.listen(Number(port), async () => {
+  server.listen(port, async () => {
     console.log(`\nServer listening to port ${port} on sdk ${version} for appId ${authConfig.clientId} debug ${process.env.DEBUG}`)
   }).on('error', console.error)
   return server

--- a/packages/agents-hosting-express/src/startServer.ts
+++ b/packages/agents-hosting-express/src/startServer.ts
@@ -4,58 +4,110 @@
  */
 
 import express, { Response } from 'express'
-import { ActivityHandler, AgentApplication, AuthConfiguration, authorizeJWT, CloudAdapter, getAuthConfigWithDefaults, HeaderPropagationDefinition, Request, TurnState } from '@microsoft/agents-hosting'
+import { ActivityHandler, AgentApplication, AuthConfiguration, authorizeJWT, getAuthConfigWithDefaults, Request, TurnState } from '@microsoft/agents-hosting'
 import { version } from '@microsoft/agents-hosting/package.json'
+import { createCloudAdapter } from './createCloudAdapter'
+
+/**
+ * Options for configuring the Express server started by `startServer`.
+ */
+export interface StartServerOptions {
+  /**
+   * Optional custom authentication configuration.
+   * If not provided, configuration will be loaded from environment variables using loadAuthConfigFromEnv().
+   */
+  authConfig?: AuthConfiguration
+
+  /**
+   * The port to listen on. Defaults to `process.env.PORT` or `3978`.
+   */
+  port?: number | string
+
+  /**
+   * The route path for the agent messages endpoint. Defaults to `'/api/messages'`.
+   */
+  routePath?: string
+
+  /**
+   * A callback invoked with the Express app before `listen()` is called.
+   * Use this to add custom routes, middleware, or static file serving.
+   *
+   * @example
+   * ```typescript
+   * startServer(agent, {
+   *   beforeListen: (app) => {
+   *     app.get('/health', (req, res) => res.json({ status: 'ok' }));
+   *   }
+   * });
+   * ```
+   */
+  beforeListen?: (app: express.Express) => void
+}
+
 /**
  * Starts an Express server for handling Agent requests.
  *
  * @param agent - The AgentApplication or ActivityHandler instance to process incoming activities.
- * @param authConfiguration - Optional custom authentication configuration. If not provided,
- * configuration will be loaded from environment variables using loadAuthConfigFromEnv().
- * @returns {express.Express} - The Express server instance.
+ * @param options - Optional configuration. Accepts either a `StartServerOptions` object or
+ * an `AuthConfiguration` for backward compatibility.
+ * @returns The Express server instance.
  *
  * @remarks
  * This function sets up an Express server with the necessary middleware and routes for handling
- * agent requests. It configures JWT authorization middleware and sets up the message endpoint.
- * The server will listen on the port specified in the PORT environment variable (or 3978 by default)
- * and logs startup information including the SDK version and configured app ID.
+ * agent requests. It configures JWT authorization middleware on the messages route and sets up the endpoint.
+ * The server will listen on the port specified in options, the PORT environment variable, or 3978 by default.
  *
  * @example
  * ```typescript
+ * // Basic usage
  * import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
  * import { startServer } from '@microsoft/agents-hosting-express';
  *
  * const app = new AgentApplication<TurnState>();
- * app.onMessage('hello', async (context, state) => {
- *   await context.sendActivity('Hello, world!');
- * });
- *
  * startServer(app);
  * ```
  *
+ * @example
+ * ```typescript
+ * // With options
+ * import { AgentApplication, TurnState } from '@microsoft/agents-hosting';
+ * import { startServer } from '@microsoft/agents-hosting-express';
+ *
+ * const app = new AgentApplication<TurnState>();
+ * startServer(app, {
+ *   port: 8080,
+ *   routePath: '/bot/messages',
+ *   beforeListen: (server) => {
+ *     server.get('/health', (req, res) => res.json({ status: 'ok' }));
+ *   }
+ * });
+ * ```
  */
-export const startServer = (agent: AgentApplication<TurnState<any, any>> | ActivityHandler, authConfiguration?: AuthConfiguration) : express.Express => {
-  const authConfig: AuthConfiguration = getAuthConfigWithDefaults(authConfiguration)
-  let adapter: CloudAdapter
-  let headerPropagation: HeaderPropagationDefinition | undefined
-  if (agent instanceof ActivityHandler || !agent.adapter) {
-    adapter = new CloudAdapter()
-  } else {
-    adapter = agent.adapter as CloudAdapter
-    headerPropagation = (agent as AgentApplication<TurnState<any, any>>)?.options.headerPropagation
-  }
+export function startServer (agent: AgentApplication<TurnState<any, any>> | ActivityHandler, options?: StartServerOptions): express.Express
+export function startServer (agent: AgentApplication<TurnState<any, any>> | ActivityHandler, authConfiguration?: AuthConfiguration): express.Express
+export function startServer (agent: AgentApplication<TurnState<any, any>> | ActivityHandler, optionsOrAuth?: StartServerOptions | AuthConfiguration): express.Express {
+  const isOptions = optionsOrAuth != null && ('authConfig' in optionsOrAuth || 'port' in optionsOrAuth || 'routePath' in optionsOrAuth || 'beforeListen' in optionsOrAuth)
+  const opts: StartServerOptions = isOptions ? optionsOrAuth as StartServerOptions : { authConfig: optionsOrAuth as AuthConfiguration | undefined }
+
+  const authConfig: AuthConfiguration = getAuthConfigWithDefaults(opts.authConfig)
+  const routePath = opts.routePath ?? '/api/messages'
+  const { adapter, headerPropagation } = createCloudAdapter(agent)
 
   const server = express()
   server.use(express.json())
 
-  server.post('/api/messages', authorizeJWT(authConfig), (req: Request, res: Response) =>
+  server.post(routePath, authorizeJWT(authConfig), (req: Request, res: Response) =>
     adapter.process(req, res, (context) =>
       agent.run(context)
     , headerPropagation)
   )
 
-  const port = process.env.PORT || 3978
-  server.listen(port, async () => {
+  if (opts.beforeListen) {
+    opts.beforeListen(server)
+  }
+
+  const port = opts.port ?? process.env.PORT ?? 3978
+  server.listen(Number(port), async () => {
     console.log(`\nServer listening to port ${port} on sdk ${version} for appId ${authConfig.clientId} debug ${process.env.DEBUG}`)
   }).on('error', console.error)
   return server

--- a/packages/agents-hosting-express/src/startServer.ts
+++ b/packages/agents-hosting-express/src/startServer.ts
@@ -47,9 +47,8 @@ export const startServer = (agent: AgentApplication<TurnState<any, any>> | Activ
 
   const server = express()
   server.use(express.json())
-  server.use(authorizeJWT(authConfig))
 
-  server.post('/api/messages', (req: Request, res: Response) =>
+  server.post('/api/messages', authorizeJWT(authConfig), (req: Request, res: Response) =>
     adapter.process(req, res, (context) =>
       agent.run(context)
     , headerPropagation)

--- a/packages/agents-hosting-express/test/createAgentRequestHandler.test.ts
+++ b/packages/agents-hosting-express/test/createAgentRequestHandler.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'assert'
+import { createServer, type Server } from 'node:http'
+import express, { type Request, type Response } from 'express'
+import { authorizeJWT } from '@microsoft/agents-hosting'
+import { createAgentRequestHandler } from '../src/createAgentRequestHandler'
+
+describe('createAgentRequestHandler', () => {
+  describe('JWT enforcement', () => {
+    let server: Server
+    let port: number
+
+    before(() => new Promise<void>((resolve, reject) => {
+      const app = express()
+      app.use(express.json())
+
+      // Use createAgentRequestHandler with a lightweight mock:
+      // We only test that JWT middleware is applied correctly (rejects without token).
+      // We simulate the handler by mounting authorizeJWT directly since creating a full
+      // CloudAdapter + agent pipeline would require a real Bot Framework connection.
+      app.post('/api/messages', authorizeJWT({ clientId: 'test-app-id' }), (_req: Request, res: Response) => {
+        res.status(200).send('processed')
+      })
+
+      server = createServer(app)
+      server.listen(0, () => {
+        const addr = server.address()
+        if (addr && typeof addr === 'object') {
+          port = addr.port
+          resolve()
+        } else {
+          reject(new Error('Failed to get server address'))
+        }
+      })
+      server.on('error', reject)
+    }))
+
+    after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+
+    it('should reject requests without JWT token', async () => {
+      const res = await fetch(`http://localhost:${port}/api/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'message', text: 'hello' })
+      })
+      assert.strictEqual(res.status, 401)
+    })
+  })
+
+  it('should return a function', () => {
+    // createAgentRequestHandler should return a callable handler
+    // Using a minimal ActivityHandler to avoid full adapter initialization
+    const { ActivityHandler } = require('@microsoft/agents-hosting')
+    const handler = createAgentRequestHandler(new ActivityHandler())
+    assert.strictEqual(typeof handler, 'function')
+  })
+})

--- a/packages/agents-hosting-express/test/createAgentRequestHandler.test.ts
+++ b/packages/agents-hosting-express/test/createAgentRequestHandler.test.ts
@@ -3,59 +3,78 @@
  * Licensed under the MIT License.
  */
 
-import { describe, it, before, after } from 'node:test'
+import { describe, it } from 'node:test'
 import assert from 'assert'
-import { createServer, type Server } from 'node:http'
-import express, { type Request, type Response } from 'express'
-import { authorizeJWT } from '@microsoft/agents-hosting'
+import { ActivityHandler, type Request } from '@microsoft/agents-hosting'
 import { createAgentRequestHandler } from '../src/createAgentRequestHandler'
+import { type WebResponse } from '../src/createAgentRequestHandler'
 
 describe('createAgentRequestHandler', () => {
-  describe('JWT enforcement', () => {
-    let server: Server
-    let port: number
+  const createMockResponse = (): WebResponse & { statusCode?: number, body?: unknown } => {
+    return {
+      headersSent: false,
+      statusCode: undefined,
+      body: undefined,
+      status (code: number) {
+        this.statusCode = code
+        return this
+      },
+      setHeader (_name: string, _value: string) {
+        return this
+      },
+      send (body?: unknown) {
+        this.body = body
+        this.headersSent = true
+        return this
+      },
+      end () {
+        this.headersSent = true
+        return this
+      }
+    }
+  }
 
-    before(() => new Promise<void>((resolve, reject) => {
-      const app = express()
-      app.use(express.json())
+  it('should complete without hanging when JWT middleware rejects request', async () => {
+    const handler = createAgentRequestHandler(new ActivityHandler(), { clientId: 'test-app-id' })
+    const req: Request = {
+      method: 'POST',
+      headers: {},
+      body: { type: 'message', text: 'hello' }
+    }
+    const res = createMockResponse()
 
-      // Use createAgentRequestHandler with a lightweight mock:
-      // We only test that JWT middleware is applied correctly (rejects without token).
-      // We simulate the handler by mounting authorizeJWT directly since creating a full
-      // CloudAdapter + agent pipeline would require a real Bot Framework connection.
-      app.post('/api/messages', authorizeJWT({ clientId: 'test-app-id' }), (_req: Request, res: Response) => {
-        res.status(200).send('processed')
-      })
-
-      server = createServer(app)
-      server.listen(0, () => {
-        const addr = server.address()
-        if (addr && typeof addr === 'object') {
-          port = addr.port
-          resolve()
-        } else {
-          reject(new Error('Failed to get server address'))
-        }
-      })
-      server.on('error', reject)
-    }))
-
-    after(() => new Promise<void>((resolve) => server.close(() => resolve())))
-
-    it('should reject requests without JWT token', async () => {
-      const res = await fetch(`http://localhost:${port}/api/messages`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type: 'message', text: 'hello' })
-      })
-      assert.strictEqual(res.status, 401)
+    await assert.doesNotReject(async () => {
+      await Promise.race([
+        handler(req, res),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('handler timed out')), 1000))
+      ])
     })
+
+    assert.strictEqual(res.statusCode, 401)
+    assert.strictEqual(res.headersSent, true)
+  })
+
+  it('should reach adapter.process when middleware allows anonymous auth', async () => {
+    const handler = createAgentRequestHandler(new ActivityHandler(), {})
+    const req: Request = {
+      method: 'POST',
+      headers: {}
+    }
+    const res = createMockResponse()
+
+    await assert.rejects(async () => {
+      await handler(req, res)
+    }, (error: any) => {
+      return error instanceof TypeError &&
+        typeof error.message === 'string' &&
+        error.message.includes('`request.body` parameter required')
+    })
+
+    assert.strictEqual(res.statusCode, undefined)
+    assert.strictEqual(res.headersSent, false)
   })
 
   it('should return a function', () => {
-    // createAgentRequestHandler should return a callable handler
-    // Using a minimal ActivityHandler to avoid full adapter initialization
-    const { ActivityHandler } = require('@microsoft/agents-hosting')
     const handler = createAgentRequestHandler(new ActivityHandler())
     assert.strictEqual(typeof handler, 'function')
   })

--- a/packages/agents-hosting-express/test/createAgentRequestHandler.test.ts
+++ b/packages/agents-hosting-express/test/createAgentRequestHandler.test.ts
@@ -46,7 +46,7 @@ describe('createAgentRequestHandler', () => {
     await assert.doesNotReject(async () => {
       await Promise.race([
         handler(req, res),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('handler timed out')), 1000))
+        new Promise((resolve, reject) => setTimeout(() => reject(new Error('handler timed out')), 1000))
       ])
     })
 
@@ -65,9 +65,7 @@ describe('createAgentRequestHandler', () => {
     await assert.rejects(async () => {
       await handler(req, res)
     }, (error: any) => {
-      return error instanceof TypeError &&
-        typeof error.message === 'string' &&
-        error.message.includes('`request.body` parameter required')
+      return error instanceof TypeError
     })
 
     assert.strictEqual(res.statusCode, undefined)

--- a/packages/agents-hosting-express/test/createCloudAdapter.test.ts
+++ b/packages/agents-hosting-express/test/createCloudAdapter.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'assert'
+import { ActivityHandler, CloudAdapter } from '@microsoft/agents-hosting'
+import { createCloudAdapter } from '../src/createCloudAdapter'
+
+describe('createCloudAdapter', () => {
+  it('should create a new CloudAdapter for an ActivityHandler', () => {
+    const handler = new ActivityHandler()
+    const result = createCloudAdapter(handler)
+
+    assert.ok(result.adapter instanceof CloudAdapter)
+    assert.strictEqual(result.headerPropagation, undefined)
+  })
+
+  it('should return adapter and headerPropagation properties', () => {
+    const handler = new ActivityHandler()
+    const result = createCloudAdapter(handler)
+
+    assert.ok('adapter' in result)
+    assert.ok('headerPropagation' in result)
+  })
+})

--- a/packages/agents-hosting-express/test/startServer.test.ts
+++ b/packages/agents-hosting-express/test/startServer.test.ts
@@ -61,3 +61,93 @@ describe('JWT middleware scoped to /api/messages', () => {
     assert.strictEqual(res.status, 401)
   })
 })
+
+describe('StartServerOptions', () => {
+  describe('custom routePath', () => {
+    let server: Server
+    let port: number
+
+    before(() => new Promise<void>((resolve, reject) => {
+      const app = express()
+      app.use(express.json())
+
+      // Simulate startServer with a custom routePath
+      app.post('/bot/messages', authorizeJWT(TEST_AUTH_CONFIG), (_req: Request, res: Response) => {
+        res.status(200).send('ok')
+      })
+
+      server = createServer(app)
+      server.listen(0, () => {
+        const addr = server.address()
+        if (addr && typeof addr === 'object') {
+          port = addr.port
+          resolve()
+        } else {
+          reject(new Error('Failed to get server address'))
+        }
+      })
+      server.on('error', reject)
+    }))
+
+    after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+
+    it('should mount the agent on the custom route path', async () => {
+      const res = await fetch(`http://localhost:${port}/bot/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'message', text: 'hello' })
+      })
+      // 401 means the route matched and JWT middleware was applied
+      assert.strictEqual(res.status, 401)
+    })
+
+    it('should not respond on the default /api/messages path', async () => {
+      const res = await fetch(`http://localhost:${port}/api/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'message', text: 'hello' })
+      })
+      assert.strictEqual(res.status, 404)
+    })
+  })
+
+  describe('beforeListen hook', () => {
+    let server: Server
+    let port: number
+
+    before(() => new Promise<void>((resolve, reject) => {
+      const app = express()
+      app.use(express.json())
+
+      app.post('/api/messages', authorizeJWT(TEST_AUTH_CONFIG), (_req: Request, res: Response) => {
+        res.status(200).send('ok')
+      })
+
+      // Simulate beforeListen adding a custom route
+      app.get('/health', (_req: Request, res: Response) => {
+        res.status(200).json({ status: 'healthy' })
+      })
+
+      server = createServer(app)
+      server.listen(0, () => {
+        const addr = server.address()
+        if (addr && typeof addr === 'object') {
+          port = addr.port
+          resolve()
+        } else {
+          reject(new Error('Failed to get server address'))
+        }
+      })
+      server.on('error', reject)
+    }))
+
+    after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+
+    it('should make routes added via beforeListen accessible without JWT', async () => {
+      const res = await fetch(`http://localhost:${port}/health`)
+      assert.strictEqual(res.status, 200)
+      const body = await res.json() as { status: string }
+      assert.strictEqual(body.status, 'healthy')
+    })
+  })
+})

--- a/packages/agents-hosting-express/test/startServer.test.ts
+++ b/packages/agents-hosting-express/test/startServer.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'assert'
+import { createServer, type Server } from 'node:http'
+import express, { type Request, type Response } from 'express'
+import { authorizeJWT } from '@microsoft/agents-hosting'
+
+// Using a clientId ensures JWT is enforced (non-empty clientId prevents anonymous fallback)
+const TEST_AUTH_CONFIG = { clientId: 'test-app-id' }
+
+describe('JWT middleware scoped to /api/messages', () => {
+  let server: Server
+  let port: number
+
+  before(() => new Promise<void>((resolve, reject) => {
+    const app = express()
+    app.use(express.json())
+
+    // Simulate the fixed startServer pattern: JWT only on /api/messages
+    app.post('/api/messages', authorizeJWT(TEST_AUTH_CONFIG), (_req: Request, res: Response) => {
+      res.status(200).send('ok')
+    })
+
+    // A custom route added by the user — should NOT require JWT
+    app.get('/health', (_req: Request, res: Response) => {
+      res.status(200).json({ status: 'ok' })
+    })
+
+    server = createServer(app)
+    server.listen(0, () => {
+      const addr = server.address()
+      if (addr && typeof addr === 'object') {
+        port = addr.port
+        resolve()
+      } else {
+        reject(new Error('Failed to get server address'))
+      }
+    })
+    server.on('error', reject)
+  }))
+
+  after(() => new Promise<void>((resolve) => server.close(() => resolve())))
+
+  it('should not require JWT for custom routes', async () => {
+    const res = await fetch(`http://localhost:${port}/health`)
+    assert.strictEqual(res.status, 200)
+    const body = await res.json() as { status: string }
+    assert.strictEqual(body.status, 'ok')
+  })
+
+  it('should require JWT for /api/messages when no token is provided', async () => {
+    const res = await fetch(`http://localhost:${port}/api/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'message', text: 'hello' })
+    })
+    assert.strictEqual(res.status, 401)
+  })
+})

--- a/packages/agents-hosting-express/test/startServer.test.ts
+++ b/packages/agents-hosting-express/test/startServer.test.ts
@@ -6,60 +6,86 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'assert'
 import { createServer, type Server } from 'node:http'
-import express, { type Request, type Response } from 'express'
+import express, { type Express, type Request, type Response } from 'express'
 import { ActivityHandler, authorizeJWT } from '@microsoft/agents-hosting'
 import { startServer } from '../src/startServer'
 
 // Using a clientId ensures JWT is enforced (non-empty clientId prevents anonymous fallback)
 const TEST_AUTH_CONFIG = { clientId: 'test-app-id' }
-
-describe('JWT middleware scoped to /api/messages', () => {
+describe('startServer', () => {
   let server: Server
   let port: number
-
+  let beforeListenCalled = false
+  const originalListen = express.application.listen
   before(() => new Promise<void>((resolve, reject) => {
-    const app = express()
-    app.use(express.json())
-
-    // Simulate the fixed startServer pattern: JWT only on /api/messages
-    app.post('/api/messages', authorizeJWT(TEST_AUTH_CONFIG), (_req: Request, res: Response) => {
-      res.status(200).send('ok')
-    })
-
-    // A custom route added by the user — should NOT require JWT
-    app.get('/health', (_req: Request, res: Response) => {
-      res.status(200).json({ status: 'ok' })
-    })
-
-    server = createServer(app)
-    server.listen(0, () => {
-      const addr = server.address()
-      if (addr && typeof addr === 'object') {
-        port = addr.port
-        resolve()
-      } else {
-        reject(new Error('Failed to get server address'))
-      }
-    })
-    server.on('error', reject)
+    const patchedListen = function (this: Express, ...args: unknown[]) {
+      const callback = typeof args[args.length - 1] === 'function'
+        ? args.pop() as (() => void)
+        : undefined
+      const listeningServer = originalListen.call(this, 0, () => {
+        const addr = listeningServer.address()
+        if (addr && typeof addr === 'object') {
+          port = addr.port
+          callback?.()
+          resolve()
+        } else {
+          reject(new Error('Failed to get server address'))
+        }
+      })
+      listeningServer.on('error', reject)
+      server = listeningServer
+      return listeningServer
+    }
+    ;(express.application.listen as unknown as typeof patchedListen) = patchedListen
+    try {
+      startServer(new ActivityHandler(), {
+        ...TEST_AUTH_CONFIG,
+        routePath: '/custom/messages',
+        beforeListen: (app: Express) => {
+          beforeListenCalled = true
+          app.get('/health', (_req, res) => {
+            res.status(200).json({ status: 'ok' })
+          })
+        }
+      } as never)
+    } catch (error) {
+      reject(error)
+    }
   }))
-
-  after(() => new Promise<void>((resolve) => server.close(() => resolve())))
-
-  it('should not require JWT for custom routes', async () => {
+  after(() => new Promise<void>((resolve, reject) => {
+    express.application.listen = originalListen
+    if (!server) {
+      resolve()
+      return
+    }
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  }))
+  it('should invoke beforeListen and not require JWT for custom routes', async () => {
+    assert.strictEqual(beforeListenCalled, true)
     const res = await fetch(`http://localhost:${port}/health`)
     assert.strictEqual(res.status, 200)
     const body = await res.json() as { status: string }
     assert.strictEqual(body.status, 'ok')
   })
-
-  it('should require JWT for /api/messages when no token is provided', async () => {
-    const res = await fetch(`http://localhost:${port}/api/messages`, {
+  it('should honor routePath and require JWT for the configured messages route', async () => {
+    const protectedRes = await fetch(`http://localhost:${port}/custom/messages`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: 'message', text: 'hello' })
     })
-    assert.strictEqual(res.status, 401)
+    assert.strictEqual(protectedRes.status, 401)
+    const defaultRouteRes = await fetch(`http://localhost:${port}/api/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'message', text: 'hello' })
+    })
+    assert.strictEqual(defaultRouteRes.status, 404)
   })
 })
 

--- a/packages/agents-hosting-express/test/startServer.test.ts
+++ b/packages/agents-hosting-express/test/startServer.test.ts
@@ -39,7 +39,7 @@ describe('startServer', () => {
     ;(express.application.listen as unknown as typeof patchedListen) = patchedListen
     try {
       startServer(new ActivityHandler(), {
-        ...TEST_AUTH_CONFIG,
+        authConfig: TEST_AUTH_CONFIG,
         routePath: '/custom/messages',
         beforeListen: (app: Express) => {
           beforeListenCalled = true

--- a/packages/agents-hosting-express/test/startServer.test.ts
+++ b/packages/agents-hosting-express/test/startServer.test.ts
@@ -7,7 +7,8 @@ import { describe, it, before, after } from 'node:test'
 import assert from 'assert'
 import { createServer, type Server } from 'node:http'
 import express, { type Request, type Response } from 'express'
-import { authorizeJWT } from '@microsoft/agents-hosting'
+import { ActivityHandler, authorizeJWT } from '@microsoft/agents-hosting'
+import { startServer } from '../src/startServer'
 
 // Using a clientId ensures JWT is enforced (non-empty clientId prevents anonymous fallback)
 const TEST_AUTH_CONFIG = { clientId: 'test-app-id' }
@@ -148,6 +149,34 @@ describe('StartServerOptions', () => {
       assert.strictEqual(res.status, 200)
       const body = await res.json() as { status: string }
       assert.strictEqual(body.status, 'healthy')
+    })
+  })
+
+  describe('port handling', () => {
+    it('should pass non-numeric string listen target unchanged', () => {
+      const target = '\\\\.\\pipe\\agents-hosting-express-test'
+      let capturedListenTarget: string | number | undefined
+
+      const originalListen = express.application.listen
+      ;(express.application as any).listen = function (listenTarget: string | number) {
+        capturedListenTarget = listenTarget
+        return {
+          on: function () {
+            return this
+          }
+        }
+      }
+
+      try {
+        startServer(new ActivityHandler(), {
+          port: target,
+          authConfig: { clientId: 'test-app-id' }
+        })
+
+        assert.strictEqual(capturedListenTarget, target)
+      } finally {
+        ;(express.application as any).listen = originalListen
+      }
     })
   })
 })

--- a/packages/agents-hosting-express/tsconfig.json
+++ b/packages/agents-hosting-express/tsconfig.json
@@ -2,11 +2,13 @@
   "extends": "../../tsconfig.json",
   "include": [
     "src/**/*",
+    "test/**/*",
     "package.json"
   ],
   "compilerOptions": {
     "rootDirs": [
-      "src/"
+      "src/",
+      "test/"
     ],
     "outDir": "dist",
     "paths": {

--- a/test-agents/application-style/src/index.ts
+++ b/test-agents/application-style/src/index.ts
@@ -6,7 +6,6 @@ const adapter = new CloudAdapter(authConfig)
 
 const server = express()
 server.use(express.json())
-server.use(authorizeJWT(authConfig))
 
 async function loadApp () {
   const moduleName = process.env.agentName || 'webChat'
@@ -29,7 +28,7 @@ async function loadApp () {
   }
 }
 
-server.post('/api/messages', async (req: Request, res: Response) => {
+server.post('/api/messages', authorizeJWT(authConfig), async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => {
     const app = await loadApp()
     await app.run(context)

--- a/test-agents/custom-dialogs/src/index.ts
+++ b/test-agents/custom-dialogs/src/index.ts
@@ -28,9 +28,8 @@ const myAgent = new DialogHandler(conversationState, userState, dialog)
 const app = express()
 
 app.use(express.json())
-app.use(authorizeJWT(authConfig))
 
-app.post('/api/messages', async (req: Request, res: Response) => {
+app.post('/api/messages', authorizeJWT(authConfig), async (req: Request, res: Response) => {
   // console.log(req.body)
   // console.log('req.user', req.user)
   await adapter.process(req, res, async (context) => await myAgent.run(context))

--- a/test-agents/multi-turn-prompt/src/index.ts
+++ b/test-agents/multi-turn-prompt/src/index.ts
@@ -25,9 +25,8 @@ const myAgent = new DialogHandler(conversationState, userState, dialog)
 const app = express()
 
 app.use(express.json())
-app.use(authorizeJWT(authConfig))
 
-app.post('/api/messages', async (req: Request, res: Response) => {
+app.post('/api/messages', authorizeJWT(authConfig), async (req: Request, res: Response) => {
   // console.log(req.body)
   // console.log('req.user', req.user)
   await adapter.process(req, res, async (context) => await myAgent.run(context))

--- a/test-agents/root-agent/src/index.ts
+++ b/test-agents/root-agent/src/index.ts
@@ -24,12 +24,12 @@ const myAgent = new RootHandlerWithBlobStorageMemory(conversationState, userStat
 const app = express()
 
 app.use(express.json())
-app.use(authorizeJWT(authConfig))
 
-app.post('/api/messages', async (req: Request, res: Response) => {
+app.post('/api/messages', authorizeJWT(authConfig), async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => await myAgent.run(context))
 })
 
+app.use('/api/agentresponse', authorizeJWT(authConfig))
 configureResponseController(app, adapter, myAgent, conversationState)
 
 const port = process.env.PORT || 3978

--- a/test-agents/state-agent/src/index.ts
+++ b/test-agents/state-agent/src/index.ts
@@ -40,9 +40,8 @@ const adapter = new CloudAdapter(authConfig)
 const app = express()
 
 app.use(express.json())
-app.use(authorizeJWT(authConfig))
 
-app.post('/api/messages', async (req: Request, res: Response) => {
+app.post('/api/messages', authorizeJWT(authConfig), async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => await myAgent.run(context))
 })
 

--- a/test-agents/web-chat/src/index.ts
+++ b/test-agents/web-chat/src/index.ts
@@ -60,9 +60,8 @@ const myAgent = createAgent(agentName)
 const app = express()
 
 app.use(express.json())
-app.use(authorizeJWT(authConfig))
 
-app.get('/api/notify', async (_req: Request, res: Response) => {
+app.get('/api/notify', authorizeJWT(authConfig), async (_req: Request, res: Response) => {
   for (const conversationReference of Object.values(conversationReferences)) {
     await adapter.continueConversation(_req.user!, conversationReference, async context => {
       await context.sendActivity('proactive hello')
@@ -75,7 +74,7 @@ app.get('/api/notify', async (_req: Request, res: Response) => {
   res.end()
 })
 
-app.post('/api/messages', async (req: Request, res: Response) => {
+app.post('/api/messages', authorizeJWT(authConfig), async (req: Request, res: Response) => {
   await adapter.process(req, res, async (context) => await myAgent.run(context))
 })
 


### PR DESCRIPTION
Fixes # 1009

## Description
This PR significantly expands and refines the `@microsoft/agents-hosting-express` package by introducing new abstractions and improving flexibility for hosting agents in Express and other frameworks. 
  - The `authorizeJWT` verification was moved from a global Express middleware to a route-level **on /api/messages only**. 
 - Additionally, it provides multiple integration levels, adds new APIs for advanced customization, and updates documentation and tests to reflect these enhancements.

**Key changes include:**

### Improvements to `startServer`

- The `authorizeJWT` verification was moved from a global Express middleware to a route-level **on /api/messages only**.
- Refactored `startServer` to support a new `StartServerOptions` object, enabling configuration of the port, route path, and a `beforeListen` hook for adding custom routes or middleware. Maintains backward compatibility with the previous signature.

### New APIs and Abstractions

- Added `createAgentRequestHandler`, a new API that provides an Express-compatible request handler without requiring Express types in consumer code, allowing use with other frameworks or custom adapters. This includes a minimal `WebResponse` interface and thorough documentation.
- Added `createCloudAdapter`, a utility to obtain a `CloudAdapter` (and optional header propagation config) from an agent, supporting advanced and low-level integration scenarios.
- Exported the new APIs from the package entry point (`index.ts`).

### Documentation Updates

- Completely rewrote the `README.md` to document the new integration levels (`startServer`, `createAgentRequestHandler`, `createCloudAdapter`), provide usage examples, and clarify how to set up custom routes and authentication.

### Testing

- Added comprehensive tests for `createAgentRequestHandler` and `createCloudAdapter` to ensure correct behavior and compatibility.

## Testing
We tested the different configuration alternatives and they all worked.
<img width="1700" height="1780" alt="image" src="https://github.com/user-attachments/assets/4acda093-6a44-4c18-bb03-4415c2972a68" />
