### PR TITLE
[#923] Instrument proactive methods

### DIFF
--- a/packages/agents-hosting/src/app/proactive/proactive.ts
+++ b/packages/agents-hosting/src/app/proactive/proactive.ts
@@ -13,8 +13,9 @@ import type { ProactiveOptions } from './proactiveOptions'
 import type { CreateConversationOptions } from './createConversationOptions'
 import { ExceptionHelper } from '@microsoft/agents-activity'
 import { Conversation } from './conversation'
-import { debug } from '@microsoft/agents-telemetry'
+import { debug, trace } from '@microsoft/agents-telemetry'
 import { Errors } from '../../errorHelper'
+import { ProactiveTraceDefinitions } from '../../observability/traces'
 
 const logger = debug('agents:proactive')
 const STORAGE_KEY_PREFIX = 'proactive/conversations/'
@@ -103,15 +104,18 @@ export class Proactive<TState extends TurnState> {
    */
   storeConversation (conversation: Conversation): Promise<string>
   async storeConversation (contextOrConversation: TurnContext | Conversation): Promise<string> {
-    const conv =
-      contextOrConversation instanceof Conversation
-        ? contextOrConversation
-        : new Conversation(contextOrConversation as TurnContext)
+    return trace(ProactiveTraceDefinitions.storeConversation, async ({ record }) => {
+      const conv =
+        contextOrConversation instanceof Conversation
+          ? contextOrConversation
+          : new Conversation(contextOrConversation as TurnContext)
 
-    conv.validate()
-    const id = conv.reference.conversation.id
-    await this.requireStorage().write({ [`${STORAGE_KEY_PREFIX}${id}`]: { reference: conv.reference, claims: conv.claims } })
-    return id
+      conv.validate()
+      const id = conv.reference.conversation.id
+      record({ conversationId: id })
+      await this.requireStorage().write({ [`${STORAGE_KEY_PREFIX}${id}`]: { reference: conv.reference, claims: conv.claims } })
+      return id
+    })
   }
 
   /**
@@ -128,10 +132,17 @@ export class Proactive<TState extends TurnState> {
    * ```
    */
   async getConversation (conversationId: string): Promise<Conversation | undefined> {
-    const result = await this.requireStorage().read([`${STORAGE_KEY_PREFIX}${conversationId}`])
-    const stored = result[`${STORAGE_KEY_PREFIX}${conversationId}`] as { reference: any; claims: any } | undefined
-    if (!stored) return undefined
-    return new Conversation(stored.claims, stored.reference)
+    return trace(ProactiveTraceDefinitions.getConversation, async ({ record }) => {
+      record({ conversationId })
+      const result = await this.requireStorage().read([`${STORAGE_KEY_PREFIX}${conversationId}`])
+      const stored = result[`${STORAGE_KEY_PREFIX}${conversationId}`] as { reference: any; claims: any } | undefined
+      if (!stored) {
+        record({ found: false })
+        return undefined
+      }
+      record({ found: true })
+      return new Conversation(stored.claims, stored.reference)
+    })
   }
 
   /**
@@ -148,11 +159,14 @@ export class Proactive<TState extends TurnState> {
    * ```
    */
   async getConversationOrThrow (conversationId: string): Promise<Conversation> {
-    const conv = await this.getConversation(conversationId)
-    if (!conv) {
-      throw ExceptionHelper.generateException(Error, Errors.ProactiveConversationNotFound, undefined, { conversationId })
-    }
-    return conv
+    return trace(ProactiveTraceDefinitions.getConversationOrThrow, async ({ record }) => {
+      record({ conversationId })
+      const conv = await this.getConversation(conversationId)
+      if (!conv) {
+        throw ExceptionHelper.generateException(Error, Errors.ProactiveConversationNotFound, undefined, { conversationId })
+      }
+      return conv
+    })
   }
 
   /**
@@ -170,7 +184,10 @@ export class Proactive<TState extends TurnState> {
    * ```
    */
   async deleteConversation (conversationId: string): Promise<void> {
-    await this.requireStorage().delete([`${STORAGE_KEY_PREFIX}${conversationId}`])
+    return trace(ProactiveTraceDefinitions.deleteConversation, async ({ record }) => {
+      record({ conversationId })
+      await this.requireStorage().delete([`${STORAGE_KEY_PREFIX}${conversationId}`])
+    })
   }
 
   // ---------------------------------------------------------------------------
@@ -214,35 +231,43 @@ export class Proactive<TState extends TurnState> {
     conversationOrId: Conversation | string,
     activity: Partial<Activity>
   ): Promise<ResourceResponse> {
-    const conv =
-      typeof conversationOrId === 'string'
-        ? await this.getConversationOrThrow(conversationOrId)
-        : conversationOrId
+    return trace(ProactiveTraceDefinitions.sendActivity, async ({ record }) => {
+      const conv =
+        typeof conversationOrId === 'string'
+          ? await this.getConversationOrThrow(conversationOrId)
+          : conversationOrId
 
-    const activityToSend: Partial<Activity> = { type: 'message', ...activity }
+      const activityToSend: Partial<Activity> = { type: 'message', ...activity }
 
-    logger.info('sendActivity: conversation=%s channel=%s serviceUrl=%s',
-      conv.reference.conversation.id, conv.reference.channelId, conv.reference.serviceUrl)
+      record({
+        conversationId: conv.reference.conversation.id,
+        channelId: conv.reference.channelId,
+        activityType: activityToSend.type ?? 'message',
+      })
 
-    let response: ResourceResponse | undefined
-    let caughtError: unknown
+      logger.info('sendActivity: conversation=%s channel=%s serviceUrl=%s',
+        conv.reference.conversation.id, conv.reference.channelId, conv.reference.serviceUrl)
 
-    await adapter.continueConversation(conv.identity, conv.reference, async (ctx: TurnContext) => {
-      try {
-        const result = await ctx.sendActivity(activityToSend as Activity)
-        response = result as ResourceResponse
-      } catch (err) {
-        caughtError = err
+      let response: ResourceResponse | undefined
+      let caughtError: unknown
+
+      await adapter.continueConversation(conv.identity, conv.reference, async (ctx: TurnContext) => {
+        try {
+          const result = await ctx.sendActivity(activityToSend as Activity)
+          response = result as ResourceResponse
+        } catch (err) {
+          caughtError = err
+        }
+      })
+
+      if (caughtError !== undefined) {
+        logger.warn('sendActivity: failed for conversation=%s: %s', conv.reference.conversation.id, caughtError)
+        throw caughtError
       }
+      if (response === undefined) throw ExceptionHelper.generateException(Error, Errors.ProactiveSendActivityNoResponse)
+      logger.debug('sendActivity: sent activity id=%s', response.id)
+      return response
     })
-
-    if (caughtError !== undefined) {
-      logger.warn('sendActivity: failed for conversation=%s: %s', conv.reference.conversation.id, caughtError)
-      throw caughtError
-    }
-    if (response === undefined) throw ExceptionHelper.generateException(Error, Errors.ProactiveSendActivityNoResponse)
-    logger.debug('sendActivity: sent activity id=%s', response.id)
-    return response
   }
 
   // ---------------------------------------------------------------------------
@@ -320,61 +345,69 @@ export class Proactive<TState extends TurnState> {
     autoSignInHandlers?: string[],
     continuationActivity?: Partial<Activity>
   ): Promise<void> {
-    const conv =
-      typeof conversationOrId === 'string'
-        ? await this.getConversationOrThrow(conversationOrId)
-        : conversationOrId
+    return trace(ProactiveTraceDefinitions.continueConversation, async ({ record }) => {
+      const conv =
+        typeof conversationOrId === 'string'
+          ? await this.getConversationOrThrow(conversationOrId)
+          : conversationOrId
 
-    logger.info('continueConversation: conversation=%s channel=%s serviceUrl=%s',
-      conv.reference.conversation.id, conv.reference.channelId, conv.reference.serviceUrl)
+      record({
+        conversationId: conv.reference.conversation.id,
+        channelId: conv.reference.channelId,
+        hasAutoSignIn: !!autoSignInHandlers?.length,
+      })
 
-    let caughtError: unknown
+      logger.info('continueConversation: conversation=%s channel=%s serviceUrl=%s',
+        conv.reference.conversation.id, conv.reference.channelId, conv.reference.serviceUrl)
 
-    await adapter.continueConversation(conv.identity, conv.reference, async (ctx: TurnContext) => {
-      try {
-        // Merge caller-supplied activity fields (e.g. value, valueType) into the
-        // continuation activity so the handler can read request-time parameters.
-        if (continuationActivity) {
-          Object.assign(ctx.activity, continuationActivity)
-        }
+      let caughtError: unknown
 
-        const state = this._app.options.turnStateFactory()
-        await state.load(ctx, this.requireAppStorage())
+      await adapter.continueConversation(conv.identity, conv.reference, async (ctx: TurnContext) => {
+        try {
+          // Merge caller-supplied activity fields (e.g. value, valueType) into the
+          // continuation activity so the handler can read request-time parameters.
+          if (continuationActivity) {
+            Object.assign(ctx.activity, continuationActivity)
+          }
 
-        // Token acquisition (optional — only when auth is configured)
-        if (autoSignInHandlers?.length && this._app.hasUserAuthorization) {
-          logger.debug('continueConversation: acquiring tokens for handlers: %o', autoSignInHandlers)
-          const results = await Promise.all(
-            autoSignInHandlers.map((handlerId) =>
-              this._app.authorization.getToken(ctx, handlerId).catch(() => ({ token: undefined }))
+          const state = this._app.options.turnStateFactory()
+          await state.load(ctx, this.requireAppStorage())
+
+          // Token acquisition (optional — only when auth is configured)
+          if (autoSignInHandlers?.length && this._app.hasUserAuthorization) {
+            logger.debug('continueConversation: acquiring tokens for handlers: %o', autoSignInHandlers)
+            const results = await Promise.all(
+              autoSignInHandlers.map((handlerId) =>
+                this._app.authorization.getToken(ctx, handlerId).catch(() => ({ token: undefined }))
+              )
             )
-          )
-          const allAcquired = results.every((r) => !!r.token)
-          if (!allAcquired) {
-            logger.warn('continueConversation: not all tokens acquired for conversation=%s handlers=%o',
-              conv.reference.conversation.id, autoSignInHandlers)
-            if (this._options.failOnUnsignedInConnections !== false) {
-              throw ExceptionHelper.generateException(Error, Errors.ProactiveNotAllTokensAcquired)
+            const allAcquired = results.every((r) => !!r.token)
+            if (!allAcquired) {
+              logger.warn('continueConversation: not all tokens acquired for conversation=%s handlers=%o',
+                conv.reference.conversation.id, autoSignInHandlers)
+              if (this._options.failOnUnsignedInConnections !== false) {
+                throw ExceptionHelper.generateException(Error, Errors.ProactiveNotAllTokensAcquired)
+              }
             }
           }
-        }
 
-        await handler(ctx, state)
-        await state.save(ctx, this.requireAppStorage())
-      } catch (err) {
-        caughtError = err
-      } finally {
-        if ((ctx as any).streamingResponse?.isStreamStarted?.()) {
-          await (ctx as any).streamingResponse.endStream()
+          await handler(ctx, state)
+          await state.save(ctx, this.requireAppStorage())
+        } catch (err) {
+          caughtError = err
+        } finally {
+          if ((ctx as any).streamingResponse?.isStreamStarted?.()) {
+            await (ctx as any).streamingResponse.endStream()
+          }
         }
+      })
+
+      if (caughtError !== undefined) {
+        logger.warn('continueConversation: failed for conversation=%s: %s', conv.reference.conversation.id, caughtError)
+        throw caughtError
       }
+      logger.debug('continueConversation: complete for conversation=%s', conv.reference.conversation.id)
     })
-
-    if (caughtError !== undefined) {
-      logger.warn('continueConversation: failed for conversation=%s: %s', conv.reference.conversation.id, caughtError)
-      throw caughtError
-    }
-    logger.debug('continueConversation: complete for conversation=%s', conv.reference.conversation.id)
   }
 
   // ---------------------------------------------------------------------------
@@ -424,58 +457,67 @@ export class Proactive<TState extends TurnState> {
     createOptions: CreateConversationOptions,
     handler?: RouteHandler<TState>
   ): Promise<Conversation> {
-    if (!createOptions.parameters.members?.length) {
-      throw ExceptionHelper.generateException(Error, Errors.ProactiveMembersRequired)
-    }
-
-    // CloudAdapter.createConversationAsync(agentAppId, channelId, serviceUrl, audience, params, logic)
-    // The logic callback IS the handler — context is created internally by the adapter.
-    const cloudAdapter = adapter as any
-    if (typeof cloudAdapter.createConversationAsync !== 'function') {
-      throw ExceptionHelper.generateException(TypeError, Errors.ProactiveCloudAdapterRequired)
-    }
-    logger.info('createConversation: channel=%s serviceUrl=%s members=%d',
-      createOptions.channelId, createOptions.serviceUrl, createOptions.parameters.members?.length ?? 0)
-
-    let capturedConv: Conversation | undefined
-    let caughtError: unknown
-
-    await cloudAdapter.createConversationAsync(
-      createOptions.identity.aud,
-      createOptions.channelId,
-      createOptions.serviceUrl,
-      createOptions.scope,
-      createOptions.parameters,
-      async (ctx: TurnContext) => {
-        try {
-          const conv = new Conversation(createOptions.identity, ctx.activity.getConversationReference())
-          capturedConv = conv
-          logger.debug('createConversation: created conversation=%s', conv.reference.conversation.id)
-
-          if (createOptions.storeConversation) {
-            await this.storeConversation(conv)
-          }
-
-          if (handler) {
-            const state = this._app.options.turnStateFactory()
-            await state.load(ctx, this.requireAppStorage())
-            await handler(ctx, state)
-            await state.save(ctx, this.requireAppStorage())
-          }
-        } catch (err) {
-          caughtError = err
-        }
+    return trace(ProactiveTraceDefinitions.createConversation, async ({ record }) => {
+      if (!createOptions.parameters.members?.length) {
+        throw ExceptionHelper.generateException(Error, Errors.ProactiveMembersRequired)
       }
-    )
 
-    if (caughtError !== undefined) {
-      logger.warn('createConversation: failed for channel=%s: %s', createOptions.channelId, caughtError)
-      throw caughtError
-    }
+      record({
+        channelId: createOptions.channelId,
+        membersCount: createOptions.parameters.members.length,
+        storeConversation: !!createOptions.storeConversation,
+        hasHandler: !!handler,
+      })
 
-    if (!capturedConv) {
-      throw ExceptionHelper.generateException(Error, Errors.ProactiveCallbackNotInvoked)
-    }
-    return capturedConv
+      // CloudAdapter.createConversationAsync(agentAppId, channelId, serviceUrl, audience, params, logic)
+      // The logic callback IS the handler — context is created internally by the adapter.
+      const cloudAdapter = adapter as any
+      if (typeof cloudAdapter.createConversationAsync !== 'function') {
+        throw ExceptionHelper.generateException(TypeError, Errors.ProactiveCloudAdapterRequired)
+      }
+      logger.info('createConversation: channel=%s serviceUrl=%s members=%d',
+        createOptions.channelId, createOptions.serviceUrl, createOptions.parameters.members?.length ?? 0)
+
+      let capturedConv: Conversation | undefined
+      let caughtError: unknown
+
+      await cloudAdapter.createConversationAsync(
+        createOptions.identity.aud,
+        createOptions.channelId,
+        createOptions.serviceUrl,
+        createOptions.scope,
+        createOptions.parameters,
+        async (ctx: TurnContext) => {
+          try {
+            const conv = new Conversation(createOptions.identity, ctx.activity.getConversationReference())
+            capturedConv = conv
+            logger.debug('createConversation: created conversation=%s', conv.reference.conversation.id)
+
+            if (createOptions.storeConversation) {
+              await this.storeConversation(conv)
+            }
+
+            if (handler) {
+              const state = this._app.options.turnStateFactory()
+              await state.load(ctx, this.requireAppStorage())
+              await handler(ctx, state)
+              await state.save(ctx, this.requireAppStorage())
+            }
+          } catch (err) {
+            caughtError = err
+          }
+        }
+      )
+
+      if (caughtError !== undefined) {
+        logger.warn('createConversation: failed for channel=%s: %s', createOptions.channelId, caughtError)
+        throw caughtError
+      }
+
+      if (!capturedConv) {
+        throw ExceptionHelper.generateException(Error, Errors.ProactiveCallbackNotInvoked)
+      }
+      return capturedConv
+    })
   }
 }

--- a/packages/agents-hosting/src/app/proactive/proactive.ts
+++ b/packages/agents-hosting/src/app/proactive/proactive.ts
@@ -458,16 +458,17 @@ export class Proactive<TState extends TurnState> {
     handler?: RouteHandler<TState>
   ): Promise<Conversation> {
     return trace(ProactiveTraceDefinitions.createConversation, async ({ record }) => {
+      record({
+        channelId: createOptions.channelId,
+        storeConversation: !!createOptions.storeConversation,
+        hasHandler: !!handler,
+      })
+
       if (!createOptions.parameters.members?.length) {
         throw ExceptionHelper.generateException(Error, Errors.ProactiveMembersRequired)
       }
 
-      record({
-        channelId: createOptions.channelId,
-        membersCount: createOptions.parameters.members.length,
-        storeConversation: !!createOptions.storeConversation,
-        hasHandler: !!handler,
-      })
+      record({ membersCount: createOptions.parameters.members.length })
 
       // CloudAdapter.createConversationAsync(agentAppId, channelId, serviceUrl, audience, params, logic)
       // The logic callback IS the handler — context is created internally by the adapter.

--- a/packages/agents-hosting/src/observability/metrics.ts
+++ b/packages/agents-hosting/src/observability/metrics.ts
@@ -55,6 +55,11 @@ export const HostingMetrics = {
     description: 'Total number of user token client HTTP requests'
   }),
 
+  proactiveOperationCounter: metric.counter(MetricNames.PROACTIVE_OPERATION_COUNT, {
+    unit: 'operation',
+    description: 'Total number of proactive operations (sendActivity, continueConversation, createConversation)'
+  }),
+
   // Duration Histograms
   adapterProcessDuration: metric.histogram(MetricNames.ADAPTER_PROCESS_DURATION, {
     unit: 'ms',
@@ -89,5 +94,10 @@ export const HostingMetrics = {
   userTokenClientRequestDuration: metric.histogram(MetricNames.USER_TOKEN_CLIENT_REQUEST_DURATION, {
     unit: 'ms',
     description: 'Duration of user token client HTTP requests in milliseconds'
+  }),
+
+  proactiveOperationDuration: metric.histogram(MetricNames.PROACTIVE_OPERATION_DURATION, {
+    unit: 'ms',
+    description: 'Duration of proactive operations in milliseconds'
   })
 }

--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -253,6 +253,141 @@ export const AdapterTraceDefinitions = {
   }),
 }
 
+export const ProactiveTraceDefinitions = {
+  storeConversation: trace.define({
+    name: SpanNames.PROACTIVE_STORE_CONVERSATION,
+    record: {
+      conversationId: '',
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'activity.conversation_id': record.conversationId ?? 'unknown',
+      })
+    }
+  }),
+  getConversation: trace.define({
+    name: SpanNames.PROACTIVE_GET_CONVERSATION,
+    record: {
+      conversationId: '',
+      found: false,
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'activity.conversation_id': record.conversationId ?? 'unknown',
+        'proactive.conversation_found': record.found,
+      })
+    }
+  }),
+  getConversationOrThrow: trace.define({
+    name: SpanNames.PROACTIVE_GET_CONVERSATION_OR_THROW,
+    record: {
+      conversationId: '',
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'activity.conversation_id': record.conversationId ?? 'unknown',
+      })
+    }
+  }),
+  deleteConversation: trace.define({
+    name: SpanNames.PROACTIVE_DELETE_CONVERSATION,
+    record: {
+      conversationId: '',
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'activity.conversation_id': record.conversationId ?? 'unknown',
+      })
+    }
+  }),
+  sendActivity: trace.define({
+    name: SpanNames.PROACTIVE_SEND_ACTIVITY,
+    record: {
+      conversationId: '',
+      channelId: '',
+      activityType: '',
+    },
+    end ({ span, record, duration, error }) {
+      const attributes = {
+        'activity.channel_id': record.channelId ?? 'unknown',
+        'activity.type': record.activityType ?? 'unknown'
+      }
+
+      span.setAttributes({
+        ...attributes,
+        'activity.conversation_id': record.conversationId ?? 'unknown',
+      })
+
+      const metricsAttributes = {
+        ...attributes,
+        operation: 'send_activity',
+        'operation.success': error === undefined,
+      }
+
+      HostingMetrics.proactiveOperationCounter.add(1, metricsAttributes)
+      HostingMetrics.proactiveOperationDuration.record(duration, metricsAttributes)
+    }
+  }),
+  continueConversation: trace.define({
+    name: SpanNames.PROACTIVE_CONTINUE_CONVERSATION,
+    record: {
+      conversationId: '',
+      channelId: '',
+      hasAutoSignIn: false,
+    },
+    end ({ span, record, duration, error }) {
+      const attributes = {
+        'activity.channel_id': record.channelId ?? 'unknown',
+        'proactive.has_auto_sign_in': record.hasAutoSignIn,
+      }
+
+      span.setAttributes({
+        ...attributes,
+        'activity.conversation_id': record.conversationId ?? 'unknown',
+      })
+
+      const metricsAttributes = {
+        ...attributes,
+        operation: 'continue_conversation',
+        'operation.success': error === undefined,
+      }
+
+      HostingMetrics.proactiveOperationCounter.add(1, metricsAttributes)
+      HostingMetrics.proactiveOperationDuration.record(duration, metricsAttributes)
+    }
+  }),
+  createConversation: trace.define({
+    name: SpanNames.PROACTIVE_CREATE_CONVERSATION,
+    record: {
+      channelId: '',
+      membersCount: 0,
+      storeConversation: false,
+      hasHandler: false,
+    },
+    end ({ span, record, duration, error }) {
+      const attributes = {
+        'activity.channel_id': record.channelId ?? 'unknown',
+        'proactive.store_conversation': record.storeConversation,
+        'proactive.has_handler': record.hasHandler,
+      }
+
+      span.setAttributes({
+        ...attributes,
+        'proactive.members_count': record.membersCount,
+      })
+
+      const metricsAttributes = {
+        ...attributes,
+        operation: 'create_conversation',
+        'operation.success': error === undefined,
+      }
+
+      HostingMetrics.proactiveOperationCounter.add(1, metricsAttributes)
+      HostingMetrics.proactiveOperationDuration.record(duration, metricsAttributes)
+    }
+  }),
+}
+
 export const ConnectorClientTraceDefinitions = {
   getConversations: trace.define({
     name: SpanNames.CONNECTOR_GET_CONVERSATIONS,

--- a/packages/agents-telemetry/src/observability/constants.ts
+++ b/packages/agents-telemetry/src/observability/constants.ts
@@ -78,6 +78,15 @@ export const SpanNames = {
   USER_TOKEN_CLIENT_GET_TOKEN_STATUS: 'agents.user_token_client.get_token_status',
   USER_TOKEN_CLIENT_GET_AAD_TOKENS: 'agents.user_token_client.get_aad_tokens',
 
+  // Proactive
+  PROACTIVE_STORE_CONVERSATION: 'agents.proactive.store_conversation',
+  PROACTIVE_GET_CONVERSATION: 'agents.proactive.get_conversation',
+  PROACTIVE_GET_CONVERSATION_OR_THROW: 'agents.proactive.get_conversation_or_throw',
+  PROACTIVE_DELETE_CONVERSATION: 'agents.proactive.delete_conversation',
+  PROACTIVE_SEND_ACTIVITY: 'agents.proactive.send_activity',
+  PROACTIVE_CONTINUE_CONVERSATION: 'agents.proactive.continue_conversation',
+  PROACTIVE_CREATE_CONVERSATION: 'agents.proactive.create_conversation',
+
   // TurnContext
   TURN_SEND_ACTIVITIES: 'agents.turn.send_activities',
 
@@ -126,6 +135,10 @@ export const MetricNames = {
   // UserTokenClient metrics
   USER_TOKEN_CLIENT_REQUESTS: 'agents.user_token_client.request.count',
   USER_TOKEN_CLIENT_REQUEST_DURATION: 'agents.user_token_client.request.duration',
+
+  // Proactive
+  PROACTIVE_OPERATION_COUNT: 'agents.proactive.operation.count',
+  PROACTIVE_OPERATION_DURATION: 'agents.proactive.operation.duration',
 
   // Copilot Studio Client
   CSC_ACTIVITIES_RECEIVED: 'agents.copilot_client.activities.received',


### PR DESCRIPTION
Addresses # 923

## Description
This PR adds comprehensive observability—tracing and metrics—to all major proactive conversation operations in the agents hosting project. It introduces new trace definitions and metrics for proactive actions, and updates the proactive conversation code to record detailed telemetry for each operation. This will help with monitoring, debugging, and analyzing the behavior and performance of proactive features.

### Detailed Changes
**Observability: Tracing and Metrics for Proactive Operations**
- Added new trace definitions for all main proactive operations (store, get, delete, send activity, continue, and create conversation) in `ProactiveTraceDefinitions`, with detailed attributes and metric recording.
- Introduced new metrics in `HostingMetrics` for counting and timing proactive operations, and updated constants in `MetricNames` and `SpanNames` to support these. 

**Proactive Conversation Logic Updates**
- Wrapped all public methods in the `Proactive` class (`storeConversation`, `getConversation`, `getConversationOrThrow`, `deleteConversation`, `sendActivity`, `continueConversation`, `createConversation`) with the new trace definitions, ensuring each operation records relevant attributes and outcomes for observability. 

These changes make proactive operations fully traceable and measurable, improving the ability to monitor and diagnose issues in production.

## Testing
These images show the traces exported to the OTel backend.
<img width="1803" height="1464" alt="image" src="https://github.com/user-attachments/assets/1e9af86a-f0f9-4046-b139-1d6717f978d4" />
<img width="1753" height="741" alt="image" src="https://github.com/user-attachments/assets/57eeb9b4-57bb-4823-9a00-5ebbc9bf3a49" />
<img width="1803" height="832" alt="image" src="https://github.com/user-attachments/assets/51f04e3b-ce3f-4536-aa64-e14060ac0e36" />
