### PR TITLE
Send invoke response when there is no active auth flow

### DIFF
--- a/packages/agents-hosting/src/app/auth/authorizationManager.ts
+++ b/packages/agents-hosting/src/app/auth/authorizationManager.ts
@@ -114,7 +114,7 @@ export class AuthorizationManager {
 
     let active = await this.active(storage, getHandlerIds)
 
-    if (activity.name?.startsWith('signin/')) {
+    if (!active && activity.name?.startsWith('signin/')) {
       const reason = `Received '${activity.name}' but no active sign-in flow exists for user '${activity.from?.id}'.`
       logger.warn(reason, activity)
       await sendInvokeResponse(context, {

--- a/packages/agents-hosting/src/app/auth/authorizationManager.ts
+++ b/packages/agents-hosting/src/app/auth/authorizationManager.ts
@@ -10,6 +10,7 @@ import { TurnContext } from '../../turnContext'
 import { HandlerStorage } from './handlerStorage'
 import { ActiveAuthorizationHandler, AuthorizationHandlerStatus, AuthorizationHandler, AuthorizationHandlerSettings, AuthorizationOptions } from './types'
 import { Connections } from '../../auth/connections'
+import { sendInvokeResponse } from './utils'
 
 const logger = debug('agents:authorization:manager')
 
@@ -108,17 +109,28 @@ export class AuthorizationManager {
    * @returns The result of the authorization process.
    */
   public async process (context: TurnContext, getHandlerIds: GetHandlerIds): Promise<AuthorizationManagerProcessResult> {
+    const activity = context.activity
     const storage = new HandlerStorage(this.app.options.storage!, context)
 
     let active = await this.active(storage, getHandlerIds)
 
-    if (active !== undefined && active?.data.activity.conversation?.id !== context.activity.conversation?.id) {
+    if (activity.name?.startsWith('signin/')) {
+      const reason = `Received '${activity.name}' but no active sign-in flow exists for user '${activity.from?.id}'.`
+      logger.warn(reason, activity)
+      await sendInvokeResponse(context, {
+        status: 400,
+        body: { failureDetail: reason }
+      })
+      return { authorized: false, context }
+    }
+
+    if (active !== undefined && active?.data.activity.conversation?.id !== activity.conversation?.id) {
       logger.warn('Discarding the active session due to the conversation has changed during an active sign-in process', active?.data.activity)
       await storage.delete()
       return { authorized: true, context }
     }
 
-    const handlers = active?.handlers ?? this.mapHandlers(await getHandlerIds(context.activity) ?? []) ?? []
+    const handlers = active?.handlers ?? this.mapHandlers(await getHandlerIds(activity) ?? []) ?? []
 
     // Create a shallow copy to modify the activity, since the signin process depends on it and we want to ensure the next handler depends on the initial activity, not the modified one.
     const sharedContext = new TurnContext(context)

--- a/packages/agents-hosting/src/app/auth/handlers/azureBotAuthorization.ts
+++ b/packages/agents-hosting/src/app/auth/handlers/azureBotAuthorization.ts
@@ -11,8 +11,9 @@ import { TurnContext } from '../../../turnContext'
 import { TokenExchangeRequest, TokenExchangeInvokeResponse, TokenResponse, UserTokenClient } from '../../../oauth'
 import jwt, { JwtPayload } from 'jsonwebtoken'
 import { HandlerStorage } from '../handlerStorage'
-import { Activity, ActivityTypes, Channels } from '@microsoft/agents-activity'
-import { InvokeResponse, TokenExchangeInvokeRequest } from '../../../invoke'
+import { Channels } from '@microsoft/agents-activity'
+import { TokenExchangeInvokeRequest } from '../../../invoke'
+import { sendInvokeResponse } from '../utils'
 
 const logger = debug('agents:authorization:azurebot')
 
@@ -323,15 +324,15 @@ export class AzureBotAuthorization implements AuthorizationHandler {
     try {
       const result = await this.setToken(storage, context, active, code)
       if (result !== AuthorizationHandlerStatus.APPROVED) {
-        await this.sendInvokeResponse(context, { status: 404 })
+        await sendInvokeResponse(context, { status: 404 })
         return result
       }
 
-      await this.sendInvokeResponse(context, { status: 200 })
+      await sendInvokeResponse(context, { status: 200 })
       await this._onSuccess?.(context)
       return result
     } catch (error) {
-      await this.sendInvokeResponse(context, { status: 500 })
+      await sendInvokeResponse(context, { status: 500 })
       if (error instanceof Error) {
         error.message = this.prefix(error.message)
       }
@@ -425,7 +426,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
 
       if (!tokenExchangeRequest?.token) {
         const reason = 'The Agent received an InvokeActivity that is missing a TokenExchangeInvokeRequest value. This is required to be sent with the InvokeActivity.'
-        await this.sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
+        await sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
           status: 400,
           body: { connectionName: this._options.name!, failureDetail: reason }
         })
@@ -436,7 +437,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
 
       if (tokenExchangeInvokeRequest.connectionName !== this._options.name) {
         const reason = `The Agent received an InvokeActivity with a TokenExchangeInvokeRequest for a different connection name ('${tokenExchangeInvokeRequest.connectionName}') than expected ('${this._options.name}').`
-        await this.sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
+        await sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
           status: 400,
           body: { id: tokenExchangeInvokeRequest.id, connectionName: this._options.name!, failureDetail: reason }
         })
@@ -448,7 +449,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
       const { token } = await userTokenClient.exchangeTokenAsync(activity.from?.id!, this._options.name!, activity.channelId!, tokenExchangeRequest)
       if (!token) {
         const reason = 'The MS Teams token service didn\'t send back the exchanged token. Waiting for MS Teams to send another signin/tokenExchange request. After multiple failed attempts, the user will be asked to enter the magic code.'
-        await this.sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
+        await sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
           status: 412,
           body: { id: tokenExchangeInvokeRequest.id, connectionName: this._options.name!, failureDetail: reason }
         })
@@ -456,7 +457,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
         return AuthorizationHandlerStatus.PENDING
       }
 
-      await this.sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
+      await sendInvokeResponse<TokenExchangeInvokeResponse>(context, {
         status: 200,
         body: { id: tokenExchangeInvokeRequest.id, connectionName: this._options.name! }
       })
@@ -467,7 +468,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
     }
 
     if (activity.name === 'signin/failure') {
-      await this.sendInvokeResponse(context, { status: 200 })
+      await sendInvokeResponse(context, { status: 200 })
       const reason = 'Failed to sign-in'
       const value = activity.value as SignInFailureValue
       logger.error(this.prefix(reason), value, activity)
@@ -502,7 +503,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
     }
 
     if (state === 'CancelledByUser') {
-      await this.sendInvokeResponse(context, { status: 200 })
+      await sendInvokeResponse(context, { status: 200 })
       logger.warn(this.prefix('Sign-in process was cancelled by the user'), activity)
       return { status: AuthorizationHandlerStatus.REJECTED }
     }
@@ -514,7 +515,7 @@ export class AzureBotAuthorization implements AuthorizationHandler {
       return { status: AuthorizationHandlerStatus.PENDING }
     }
 
-    await this.sendInvokeResponse(context, { status: 200 })
+    await sendInvokeResponse(context, { status: 200 })
     logger.debug(this.prefix('Code verification successful'), activity)
     return { status: AuthorizationHandlerStatus.APPROVED, code: state }
   }
@@ -545,20 +546,6 @@ export class AzureBotAuthorization implements AuthorizationHandler {
       throw new Error(this.prefix('The \'userTokenClient\' is not available in the adapter. Ensure that the adapter supports user token operations.'))
     }
     return userTokenClient
-  }
-
-  /**
-   * Sends an InvokeResponse activity if the channel is Microsoft Teams, including Copilot within MS Teams.
-   */
-  private sendInvokeResponse <T>(context: TurnContext, response: InvokeResponse<T>) {
-    if (context.activity.channelIdChannel !== Channels.Msteams) {
-      return Promise.resolve()
-    }
-
-    return context.sendActivity(Activity.fromObject({
-      type: ActivityTypes.InvokeResponse,
-      value: response
-    }))
   }
 
   /**

--- a/packages/agents-hosting/src/app/auth/utils.ts
+++ b/packages/agents-hosting/src/app/auth/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TurnContext } from '../../turnContext'
+import { InvokeResponse } from '../../invoke'
+import { Activity, ActivityTypes, Channels } from '@microsoft/agents-activity'
+
+/**
+ * Sends an InvokeResponse activity if the channel is Microsoft Teams, including Copilot within MS Teams.
+ */
+export function sendInvokeResponse <T> (context: TurnContext, response: InvokeResponse<T>) {
+  if (context.activity.channelIdChannel !== Channels.Msteams) {
+    return Promise.resolve()
+  }
+
+  return context.sendActivity(Activity.fromObject({
+    type: ActivityTypes.InvokeResponse,
+    value: response
+  }))
+}

--- a/packages/agents-hosting/test/hosting/app/authorizationmanager.test.ts
+++ b/packages/agents-hosting/test/hosting/app/authorizationmanager.test.ts
@@ -12,6 +12,15 @@ import { AuthorizationHandlerStatus } from '../../../src/app/auth/types'
 import { HandlerStorage } from '../../../src/app/auth/handlerStorage'
 import { Connections } from '../../../src/auth/connections'
 
+class RecordingTestAdapter extends TestAdapter {
+  public readonly sentActivities: Activity[] = []
+
+  async sendActivities (context: TurnContext, activities: Activity[]) {
+    this.sentActivities.push(...activities.map(activity => Activity.fromObject(activity)))
+    return await super.sendActivities(context, activities)
+  }
+}
+
 describe('AuthorizationManager', () => {
   let app: AgentApplication<any>
   let context: TurnContext
@@ -113,6 +122,32 @@ describe('AuthorizationManager', () => {
     const storageResult = await handlerStorage.read()
     assert.equal(result.authorized, true)
     assert.equal(storageResult, undefined)
+  })
+
+  it('should reject signin invokes without an active flow and send an invoke response for Teams', async () => {
+    const adapter = new RecordingTestAdapter()
+    const signinActivity = Activity.fromObject({
+      type: ActivityTypes.Invoke,
+      from: { id: 'user-1' },
+      recipient: { id: 'bot-1' },
+      conversation: { id: 'conv-1' },
+      channelId: 'msteams',
+      serviceUrl: 'https://example.test',
+      name: 'signin/verifyState'
+    })
+    const signinContext = new TurnContext(adapter, signinActivity)
+    const handler = manager.handlers['handler1']
+    const signinStub = sinon.stub(handler, 'signin').resolves(AuthorizationHandlerStatus.APPROVED)
+
+    const result = await manager.process(signinContext, getHandlerIds)
+
+    assert.equal(result.authorized, false)
+    assert.equal(getHandlerIds.called, false)
+    assert.equal(signinStub.called, false)
+    assert.equal(adapter.sentActivities.length, 1)
+    assert.equal(adapter.sentActivities[0].type, ActivityTypes.InvokeResponse)
+    assert.equal(adapter.sentActivities[0].value.status, 400)
+    assert.equal(adapter.sentActivities[0].value.body.failureDetail, "Received 'signin/verifyState' but no active sign-in flow exists for user 'user-1'.")
   })
 
   it('should return authorized:true when handler returns APPROVED', async () => {


### PR DESCRIPTION
Port from https://github.com/microsoft/Agents-for-net/pull/ 712

## Description
This PR adds a detection when there is no active auth flow, sending an HTTP 400 invoke response to MS Teams. We added a unit test to validate that, and moved the send invoke function to an utils file to allow reusability.

## Testing
The following image shows the logs and HTTP response body when the scenario happens. (tested with postman to consistently force the scenario)
<img width="1315" height="280" alt="image" src="https://github.com/user-attachments/assets/3d84d31a-456e-4bce-ab30-6f00c2cc6e49" />
