### PR TITLE
[#1044] Align Workload identity configuration support to current Connection Configuration Specification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@microsoft/microsoft-graph-types": "2.43.1",
         "@types/debug": "4.1.12",
         "@types/express": "5.0.6",
-        "@types/node": "25.5.0",
+        "@types/node": "25.6.0",
         "@types/sinon": "21.0.0",
         "@types/uuid": "10.0.0",
         "esbuild": "0.27.3",
@@ -1957,12 +1957,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/object-path": {
@@ -7461,9 +7461,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@microsoft/microsoft-graph-types": "2.43.1",
     "@types/debug": "4.1.12",
     "@types/express": "5.0.6",
-    "@types/node": "25.5.0",
+    "@types/node": "25.6.0",
     "@types/sinon": "21.0.0",
     "@types/uuid": "10.0.0",
     "esbuild": "0.27.3",

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -11,6 +11,19 @@ const logger = debug('agents:authConfiguration')
 const DEFAULT_CONNECTION = 'serviceConnection'
 
 /**
+ * Supported authentication types for agent connections.
+ */
+export enum AuthType {
+  Certificate = 'Certificate',
+  CertificateSubjectName = 'CertificateSubjectName',
+  ClientSecret = 'ClientSecret',
+  UserManagedIdentity = 'UserManagedIdentity',
+  SystemManagedIdentity = 'SystemManagedIdentity',
+  FederatedCredentials = 'FederatedCredentials',
+  WorkloadIdentity = 'WorkloadIdentity'
+}
+
+/**
  * Represents the authentication configuration.
  */
 export interface AuthConfiguration {
@@ -88,8 +101,19 @@ export interface AuthConfiguration {
 
   /**
    * The path to K8s provided token.
+   * @deprecated Use `authtype` set to `'WorkloadIdentity'` and `federatedtokenfile` instead.
    */
   WIDAssertionFile?: string
+
+  /**
+   * The authentication type for the connection.
+   */
+  authtype?: AuthType | string
+
+  /**
+   * The path to the federated token file used for Workload Identity authentication.
+   */
+  federatedtokenfile?: string
 }
 
 /**
@@ -196,6 +220,8 @@ export const loadPrevAuthConfigFromEnv: () => AuthConfiguration = () => {
       issuers: getDefaultIssuers(process.env.MicrosoftAppTenantId ?? '', authority),
       altBlueprintConnectionName: process.env.altBlueprintConnectionName,
       WIDAssertionFile: process.env.WIDAssertionFile,
+      authtype: process.env.authtype,
+      federatedtokenfile: process.env.federatedtokenfile,
     }
     envConnections.connections.set(DEFAULT_CONNECTION, authConfig)
     envConnections.connectionsMap.push({
@@ -352,7 +378,9 @@ function buildLegacyAuthConfig (envPrefix: string = '', customConfig?: AuthConfi
     scope: customConfig?.scope ?? process.env[`${prefix}scope`],
     issuers: customConfig?.issuers ?? getDefaultIssuers(tenantId as string, authority),
     altBlueprintConnectionName: customConfig?.altBlueprintConnectionName ?? process.env[`${prefix}altBlueprintConnectionName`],
-    WIDAssertionFile: customConfig?.WIDAssertionFile ?? process.env[`${prefix}WIDAssertionFile`]
+    WIDAssertionFile: customConfig?.WIDAssertionFile ?? process.env[`${prefix}WIDAssertionFile`],
+    authtype: customConfig?.authtype ?? process.env[`${prefix}authtype`],
+    federatedtokenfile: customConfig?.federatedtokenfile ?? process.env[`${prefix}federatedtokenfile`]
   }
 }
 

--- a/packages/agents-hosting/src/auth/msalConnectionManager.ts
+++ b/packages/agents-hosting/src/auth/msalConnectionManager.ts
@@ -5,7 +5,7 @@
 
 import { Activity, RoleTypes } from '@microsoft/agents-activity'
 import { debug } from '@microsoft/agents-telemetry'
-import { AuthConfiguration, resolveAuthority } from './authConfiguration'
+import { AuthConfiguration, AuthType, resolveAuthority } from './authConfiguration'
 import { Connections } from './connections'
 import { MsalTokenProvider } from './msalTokenProvider'
 import { JwtPayload } from 'jsonwebtoken'
@@ -48,7 +48,7 @@ export class MsalConnectionManager implements Connections {
         ? 'certificate'
         : cfg?.clientSecret
           ? 'clientSecret'
-          : cfg?.WIDAssertionFile || cfg?.FICClientId
+          : cfg?.authtype === AuthType.WorkloadIdentity || cfg?.WIDAssertionFile || cfg?.FICClientId
             ? 'workloadIdentity'
             : 'none'
       logger.debug('connection "%s" clientId=%s tenantId=%s authType=%s', name, cfg?.clientId ?? '<none>', cfg?.tenantId ?? '<none>', authType)

--- a/packages/agents-hosting/src/auth/msalConnectionManager.ts
+++ b/packages/agents-hosting/src/auth/msalConnectionManager.ts
@@ -5,7 +5,7 @@
 
 import { Activity, RoleTypes } from '@microsoft/agents-activity'
 import { debug } from '@microsoft/agents-telemetry'
-import { AuthConfiguration, AuthType, resolveAuthority } from './authConfiguration'
+import { AuthConfiguration, resolveAuthority } from './authConfiguration'
 import { Connections } from './connections'
 import { MsalTokenProvider } from './msalTokenProvider'
 import { JwtPayload } from 'jsonwebtoken'
@@ -44,13 +44,14 @@ export class MsalConnectionManager implements Connections {
 
     for (const [name, provider] of this._connections.entries()) {
       const cfg = provider.connectionSettings
-      const authType = cfg?.certPemFile
-        ? 'certificate'
-        : cfg?.clientSecret
-          ? 'clientSecret'
-          : cfg?.authtype === AuthType.WorkloadIdentity || cfg?.WIDAssertionFile || cfg?.FICClientId
-            ? 'workloadIdentity'
-            : 'none'
+      const authType = cfg?.authtype ??
+        (cfg?.certPemFile
+          ? 'certificate'
+          : cfg?.clientSecret
+            ? 'clientSecret'
+            : cfg?.WIDAssertionFile || cfg?.FICClientId
+              ? 'workloadIdentity'
+              : 'none')
       logger.debug('connection "%s" clientId=%s tenantId=%s authType=%s', name, cfg?.clientId ?? '<none>', cfg?.tenantId ?? '<none>', authType)
     }
 

--- a/packages/agents-hosting/src/auth/msalConnectionManager.ts
+++ b/packages/agents-hosting/src/auth/msalConnectionManager.ts
@@ -5,7 +5,7 @@
 
 import { Activity, RoleTypes } from '@microsoft/agents-activity'
 import { debug } from '@microsoft/agents-telemetry'
-import { AuthConfiguration, resolveAuthority } from './authConfiguration'
+import { AuthConfiguration, AuthType, resolveAuthority } from './authConfiguration'
 import { Connections } from './connections'
 import { MsalTokenProvider } from './msalTokenProvider'
 import { JwtPayload } from 'jsonwebtoken'
@@ -46,11 +46,11 @@ export class MsalConnectionManager implements Connections {
       const cfg = provider.connectionSettings
       const authType = cfg?.authtype ??
         (cfg?.certPemFile
-          ? 'certificate'
+          ? AuthType.Certificate
           : cfg?.clientSecret
-            ? 'clientSecret'
+            ? AuthType.ClientSecret
             : cfg?.WIDAssertionFile || cfg?.FICClientId
-              ? 'workloadIdentity'
+              ? AuthType.WorkloadIdentity
               : 'none')
       logger.debug('connection "%s" clientId=%s tenantId=%s authType=%s', name, cfg?.clientId ?? '<none>', cfg?.tenantId ?? '<none>', authType)
     }

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -5,7 +5,7 @@
 
 import { ConfidentialClientApplication, LogLevel, ManagedIdentityApplication, NodeSystemOptions } from '@azure/msal-node'
 import axios from 'axios'
-import { AuthConfiguration, resolveAuthority as resolveAuthorityUtil } from './authConfiguration'
+import { AuthConfiguration, AuthType, resolveAuthority as resolveAuthorityUtil } from './authConfiguration'
 import { AuthProvider } from './authProvider'
 import { debug, trace } from '@microsoft/agents-telemetry'
 import { v4 } from 'uuid'
@@ -70,7 +70,7 @@ export class MsalTokenProvider implements AuthProvider {
       }
 
       let token
-      if (authConfig.WIDAssertionFile !== undefined) {
+      if (authConfig.authtype === AuthType.WorkloadIdentity || authConfig.WIDAssertionFile !== undefined) {
         record({ method: 'wid' })
         logger.debug('getAccessToken via WID clientId=%s scope=%s', authConfig.clientId, actualScope)
         token = await this.acquireAccessTokenViaWID(authConfig, actualScope)
@@ -305,8 +305,9 @@ export class MsalTokenProvider implements AuthProvider {
 
     let clientAssertion
 
-    if (this.connectionSettings.WIDAssertionFile !== undefined) {
-      clientAssertion = fs.readFileSync(this.connectionSettings.WIDAssertionFile as string, 'utf8')
+    if (this.connectionSettings.authtype === AuthType.WorkloadIdentity || this.connectionSettings.WIDAssertionFile !== undefined) {
+      const tokenFilePath = this.connectionSettings.federatedtokenfile ?? this.connectionSettings.WIDAssertionFile
+      clientAssertion = fs.readFileSync(tokenFilePath as string, 'utf8')
     } else if (this.connectionSettings.FICClientId !== undefined) {
       clientAssertion = await this.fetchExternalToken(this.connectionSettings.FICClientId as string)
     } else if (this.connectionSettings.certPemFile !== undefined &&
@@ -517,7 +518,8 @@ export class MsalTokenProvider implements AuthProvider {
    */
   private async acquireAccessTokenViaWID (authConfig: AuthConfiguration, scope: string) : Promise<string> {
     const scopes = [`${scope}/.default`]
-    const clientAssertion = fs.readFileSync(authConfig.WIDAssertionFile as string, 'utf8')
+    const tokenFilePath = authConfig.federatedtokenfile ?? authConfig.WIDAssertionFile
+    const clientAssertion = fs.readFileSync(tokenFilePath as string, 'utf8')
     const cca = new ConfidentialClientApplication({
       auth: {
         clientId: authConfig.clientId as string,

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -70,7 +70,39 @@ export class MsalTokenProvider implements AuthProvider {
       }
 
       let token
-      if (authConfig.authtype === AuthType.WorkloadIdentity || authConfig.WIDAssertionFile !== undefined) {
+      if (authConfig.authtype) {
+        switch (authConfig.authtype) {
+          case AuthType.WorkloadIdentity:
+            record({ method: 'wid' })
+            logger.debug('getAccessToken via WID clientId=%s scope=%s', authConfig.clientId, actualScope)
+            token = await this.acquireAccessTokenViaWID(authConfig, actualScope)
+            break
+          case AuthType.FederatedCredentials:
+            record({ method: 'fic' })
+            logger.debug('getAccessToken via FIC clientId=%s scope=%s', authConfig.clientId, actualScope)
+            token = await this.acquireAccessTokenViaFIC(authConfig, actualScope)
+            break
+          case AuthType.ClientSecret:
+            record({ method: 'secret' })
+            logger.debug('getAccessToken via secret clientId=%s scope=%s', authConfig.clientId, actualScope)
+            token = await this.acquireAccessTokenViaSecret(authConfig, actualScope)
+            break
+          case AuthType.Certificate:
+          case AuthType.CertificateSubjectName:
+            record({ method: 'certificate' })
+            logger.debug('getAccessToken via certificate clientId=%s scope=%s', authConfig.clientId, actualScope)
+            token = await this.acquireTokenWithCertificate(authConfig, actualScope)
+            break
+          case AuthType.UserManagedIdentity:
+          case AuthType.SystemManagedIdentity:
+            record({ method: 'managed_identity' })
+            logger.debug('getAccessToken via managed identity clientId=%s scope=%s', authConfig.clientId, actualScope)
+            token = await this.acquireTokenWithUserAssignedIdentity(authConfig, actualScope)
+            break
+          default:
+            throw new Error(`Unsupported authtype: ${authConfig.authtype}`)
+        }
+      } else if (authConfig.WIDAssertionFile !== undefined) {
         record({ method: 'wid' })
         logger.debug('getAccessToken via WID clientId=%s scope=%s', authConfig.clientId, actualScope)
         token = await this.acquireAccessTokenViaWID(authConfig, actualScope)
@@ -305,7 +337,22 @@ export class MsalTokenProvider implements AuthProvider {
 
     let clientAssertion
 
-    if (this.connectionSettings.authtype === AuthType.WorkloadIdentity || this.connectionSettings.WIDAssertionFile !== undefined) {
+    if (this.connectionSettings.authtype) {
+      switch (this.connectionSettings.authtype) {
+        case AuthType.WorkloadIdentity: {
+          const tokenFilePath = this.connectionSettings.federatedtokenfile ?? this.connectionSettings.WIDAssertionFile
+          clientAssertion = fs.readFileSync(tokenFilePath as string, 'utf8')
+          break
+        }
+        case AuthType.FederatedCredentials:
+          clientAssertion = await this.fetchExternalToken(this.connectionSettings.FICClientId as string)
+          break
+        case AuthType.Certificate:
+        case AuthType.CertificateSubjectName:
+          clientAssertion = this.getAssertionFromCert(this.connectionSettings)
+          break
+      }
+    } else if (this.connectionSettings.WIDAssertionFile !== undefined) {
       const tokenFilePath = this.connectionSettings.federatedtokenfile ?? this.connectionSettings.WIDAssertionFile
       clientAssertion = fs.readFileSync(tokenFilePath as string, 'utf8')
     } else if (this.connectionSettings.FICClientId !== undefined) {

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -104,8 +104,10 @@ export class MsalTokenProvider implements AuthProvider {
             token = await this.acquireTokenWithCertificate(authConfig, actualScope)
             break
           case AuthType.UserManagedIdentity:
-          case AuthType.SystemManagedIdentity:
             token = await this.acquireTokenWithUserAssignedIdentity(authConfig, actualScope)
+            break
+          case AuthType.SystemManagedIdentity:
+            token = await this.acquireTokenWithSystemAssignedIdentity(authConfig, actualScope)
             break
           default:
             throw ExceptionHelper.generateException(Error, Errors.UnsupportedAuthType, undefined, { authType: authConfig.authtype })
@@ -472,6 +474,22 @@ export class MsalTokenProvider implements AuthProvider {
       managedIdentityIdParams: {
         userAssignedClientId: authConfig.clientId || ''
       },
+      system: this.sysOptions
+    })
+    const token = await mia.acquireToken({
+      resource: scope
+    })
+    return token?.accessToken
+  }
+
+  /**
+   * Acquires a token using a system-assigned identity.
+   * @param authConfig The authentication configuration.
+   * @param scope The scope for the token.
+   * @returns A promise that resolves to the access token.
+   */
+  private async acquireTokenWithSystemAssignedIdentity (authConfig: AuthConfiguration, scope: string) {
+    const mia = new ManagedIdentityApplication({
       system: this.sysOptions
     })
     const token = await mia.acquireToken({

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -15,6 +15,8 @@ import jwt from 'jsonwebtoken'
 import fs from 'fs'
 import crypto from 'crypto'
 import { AuthenticationTraceDefinitions } from '../observability'
+import { ExceptionHelper } from '@microsoft/agents-activity'
+import { Errors } from '../errorHelper'
 
 const audience = 'api://AzureADTokenExchange'
 const logger = debug('agents:msal')
@@ -71,59 +73,65 @@ export class MsalTokenProvider implements AuthProvider {
 
       let token
       if (authConfig.authtype) {
+        record({ method: authConfig.authtype })
+        logger.debug(`getAccessToken via ${authConfig.authtype} clientId=${authConfig.clientId} scope=${actualScope}`)
         switch (authConfig.authtype) {
-          case AuthType.WorkloadIdentity:
-            record({ method: 'wid' })
-            logger.debug('getAccessToken via WID clientId=%s scope=%s', authConfig.clientId, actualScope)
+          case AuthType.WorkloadIdentity: {
+            const tokenFilePath = authConfig.federatedtokenfile ?? authConfig.WIDAssertionFile
+            if (!tokenFilePath) {
+              throw ExceptionHelper.generateException(Error, Errors.WorkloadIdentityTokenFileRequired)
+            }
             token = await this.acquireAccessTokenViaWID(authConfig, actualScope)
             break
+          }
           case AuthType.FederatedCredentials:
-            record({ method: 'fic' })
-            logger.debug('getAccessToken via FIC clientId=%s scope=%s', authConfig.clientId, actualScope)
+            if (!authConfig.FICClientId) {
+              throw ExceptionHelper.generateException(Error, Errors.FICClientIdRequired)
+            }
             token = await this.acquireAccessTokenViaFIC(authConfig, actualScope)
             break
           case AuthType.ClientSecret:
-            record({ method: 'secret' })
-            logger.debug('getAccessToken via secret clientId=%s scope=%s', authConfig.clientId, actualScope)
+            if (!authConfig.clientSecret) {
+              throw ExceptionHelper.generateException(Error, Errors.ClientSecretRequired)
+            }
             token = await this.acquireAccessTokenViaSecret(authConfig, actualScope)
             break
           case AuthType.Certificate:
           case AuthType.CertificateSubjectName:
-            record({ method: 'certificate' })
-            logger.debug('getAccessToken via certificate clientId=%s scope=%s', authConfig.clientId, actualScope)
+            if (!authConfig.certPemFile || !authConfig.certKeyFile) {
+              throw ExceptionHelper.generateException(Error, Errors.CertificateFilesRequired)
+            }
             token = await this.acquireTokenWithCertificate(authConfig, actualScope)
             break
           case AuthType.UserManagedIdentity:
           case AuthType.SystemManagedIdentity:
-            record({ method: 'managed_identity' })
-            logger.debug('getAccessToken via managed identity clientId=%s scope=%s', authConfig.clientId, actualScope)
             token = await this.acquireTokenWithUserAssignedIdentity(authConfig, actualScope)
             break
           default:
-            throw new Error(`Unsupported authtype: ${authConfig.authtype}`)
+            throw ExceptionHelper.generateException(Error, Errors.UnsupportedAuthType, undefined, { authType: authConfig.authtype })
         }
       } else if (authConfig.WIDAssertionFile !== undefined) {
-        record({ method: 'wid' })
-        logger.debug('getAccessToken via WID clientId=%s scope=%s', authConfig.clientId, actualScope)
+        record({ method: AuthType.WorkloadIdentity })
+        logger.debug('getAccessToken via method=%s clientId=%s scope=%s', AuthType.WorkloadIdentity, authConfig.clientId, actualScope)
         token = await this.acquireAccessTokenViaWID(authConfig, actualScope)
       } else if (authConfig.FICClientId !== undefined) {
-        record({ method: 'fic' })
-        logger.debug('getAccessToken via FIC clientId=%s scope=%s', authConfig.clientId, actualScope)
+        record({ method: AuthType.FederatedCredentials })
+        logger.debug('getAccessToken via method=%s clientId=%s scope=%s', AuthType.FederatedCredentials, authConfig.clientId, actualScope)
         token = await this.acquireAccessTokenViaFIC(authConfig, actualScope)
       } else if (authConfig.clientSecret !== undefined) {
-        record({ method: 'secret' })
-        logger.debug('getAccessToken via secret clientId=%s scope=%s', authConfig.clientId, actualScope)
+        record({ method: AuthType.ClientSecret })
+        logger.debug('getAccessToken via method=%s clientId=%s scope=%s', AuthType.ClientSecret, authConfig.clientId, actualScope)
         token = await this.acquireAccessTokenViaSecret(authConfig, actualScope)
       } else if (authConfig.certPemFile !== undefined &&
           authConfig.certKeyFile !== undefined) {
-        record({ method: 'certificate' })
-        logger.debug('getAccessToken via certificate clientId=%s scope=%s', authConfig.clientId, actualScope)
+        record({ method: AuthType.Certificate })
+        logger.debug('getAccessToken via method=%s clientId=%s scope=%s', AuthType.Certificate, authConfig.clientId, actualScope)
         token = await this.acquireTokenWithCertificate(authConfig, actualScope)
       } else if (authConfig.clientSecret === undefined &&
           authConfig.certPemFile === undefined &&
           authConfig.certKeyFile === undefined) {
-        record({ method: 'managed_identity' })
-        logger.debug('getAccessToken via managed identity clientId=%s scope=%s', authConfig.clientId, actualScope)
+        record({ method: AuthType.UserManagedIdentity })
+        logger.debug('getAccessToken via method=%s clientId=%s scope=%s', AuthType.UserManagedIdentity, authConfig.clientId, actualScope)
         token = await this.acquireTokenWithUserAssignedIdentity(authConfig, actualScope)
       } else {
         throw new Error('Invalid authConfig. ')
@@ -341,14 +349,23 @@ export class MsalTokenProvider implements AuthProvider {
       switch (this.connectionSettings.authtype) {
         case AuthType.WorkloadIdentity: {
           const tokenFilePath = this.connectionSettings.federatedtokenfile ?? this.connectionSettings.WIDAssertionFile
+          if (tokenFilePath === undefined) {
+            throw ExceptionHelper.generateException(Error, Errors.WorkloadIdentityTokenFileRequired)
+          }
           clientAssertion = fs.readFileSync(tokenFilePath as string, 'utf8')
           break
         }
         case AuthType.FederatedCredentials:
+          if (!this.connectionSettings.FICClientId) {
+            throw ExceptionHelper.generateException(Error, Errors.FICClientIdRequired)
+          }
           clientAssertion = await this.fetchExternalToken(this.connectionSettings.FICClientId as string)
           break
         case AuthType.Certificate:
         case AuthType.CertificateSubjectName:
+          if (!this.connectionSettings.certPemFile || !this.connectionSettings.certKeyFile) {
+            throw ExceptionHelper.generateException(Error, Errors.CertificateFilesRequired)
+          }
           clientAssertion = this.getAssertionFromCert(this.connectionSettings)
           break
       }

--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -516,6 +516,46 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
     description: "The current token for the '{connectionName}' AzureBot connection is not exchangeable for an on-behalf-of flow. Ensure the base token audience is for the bot/resource app, such as an App ID URI like 'api://...' or otherwise includes the app's client id."
   },
 
+  /**
+   * Error thrown when an unsupported authorization type is specified in authConfig.
+   */
+  UnsupportedAuthType: {
+    code: -120593,
+    description: 'Unsupported authorization type: {authType}'
+  },
+
+  /**
+     * Error thrown when WorkloadIdentity authentication requires `federatedtokenfile` or the deprecated `WIDAssertionFile` to be configured.
+     */
+  WorkloadIdentityTokenFileRequired: {
+    code: -120594,
+    description: 'WorkloadIdentity authentication requires `federatedtokenfile` or the deprecated `WIDAssertionFile` to be configured'
+  },
+
+  /**
+   * Error thrown when ClientSecret authentication is specified but `clientSecret` is not configured.
+   */
+  ClientSecretRequired: {
+    code: -120595,
+    description: 'ClientSecret authentication requires `clientSecret` to be configured'
+  },
+
+  /**
+   * Error thrown when Certificate authentication is specified but `certPemFile` or `certKeyFile` is not configured.
+   */
+  CertificateFilesRequired: {
+    code: -120596,
+    description: 'Certificate authentication requires both `certPemFile` and `certKeyFile` to be configured'
+  },
+
+  /**
+   * Error thrown when FederatedCredentials authentication is specified but `FICClientId` is not configured.
+   */
+  FICClientIdRequired: {
+    code: -120597,
+    description: 'FederatedCredentials authentication requires `FICClientId` to be configured'
+  },
+
   // ============================================================================
   // Agent and Client Errors (-120600 to -120630)
   // ============================================================================

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert'
 import { describe, it, beforeEach } from 'node:test'
 import sinon from 'sinon'
 import { ConfidentialClientApplication, ManagedIdentityApplication } from '@azure/msal-node'
-import { MsalTokenProvider, ConnectorClient, AuthConfiguration, CloudAdapter } from '../../src'
+import { MsalTokenProvider, ConnectorClient, AuthConfiguration, AuthType, CloudAdapter } from '../../src'
 import fs from 'fs'
 import crypto from 'crypto'
 import axios from 'axios'
@@ -82,6 +82,20 @@ describe('MsalTokenProvider', () => {
     authConfig.certPemFile = undefined
     authConfig.certKeyFile = undefined
     authConfig.WIDAssertionFile = '/etc/issue'
+    // @ts-ignore
+    const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
+    const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')
+    assert.strictEqual(token, 'test-token')
+    acquireTokenStub.restore()
+  })
+
+  it('should acquire token with WID using authtype and federatedtokenfile', async () => {
+    authConfig.clientSecret = undefined
+    authConfig.certPemFile = undefined
+    authConfig.certKeyFile = undefined
+    authConfig.WIDAssertionFile = undefined
+    authConfig.authtype = AuthType.WorkloadIdentity
+    authConfig.federatedtokenfile = '/etc/issue'
     // @ts-ignore
     const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
     const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -85,6 +85,7 @@ describe('MsalTokenProvider', () => {
     authConfig.WIDAssertionFile = '/var/run/secrets/azure/tokens/azure-identity-token'
     sinon.stub(fs, 'readFileSync').returns('fake-wid-assertion')
     // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
     const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')
     assert.strictEqual(token, 'test-token')
@@ -101,6 +102,7 @@ describe('MsalTokenProvider', () => {
     authConfig.federatedtokenfile = '/var/run/secrets/azure/tokens/azure-identity-token'
     sinon.stub(fs, 'readFileSync').returns('fake-wid-assertion')
     // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
     const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')
     assert.strictEqual(token, 'test-token')

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -78,29 +78,33 @@ describe('MsalTokenProvider', () => {
   })
 
   it('should acquire token with WID', async () => {
+    sinon.restore()
     authConfig.clientSecret = undefined
     authConfig.certPemFile = undefined
     authConfig.certKeyFile = undefined
-    authConfig.WIDAssertionFile = '/etc/issue'
+    authConfig.WIDAssertionFile = '/var/run/secrets/azure/tokens/azure-identity-token'
+    sinon.stub(fs, 'readFileSync').returns('fake-wid-assertion')
     // @ts-ignore
     const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
     const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')
     assert.strictEqual(token, 'test-token')
-    acquireTokenStub.restore()
+    sinon.restore()
   })
 
   it('should acquire token with WID using authtype and federatedtokenfile', async () => {
+    sinon.restore()
     authConfig.clientSecret = undefined
     authConfig.certPemFile = undefined
     authConfig.certKeyFile = undefined
     authConfig.WIDAssertionFile = undefined
     authConfig.authtype = AuthType.WorkloadIdentity
-    authConfig.federatedtokenfile = '/etc/issue'
+    authConfig.federatedtokenfile = '/var/run/secrets/azure/tokens/azure-identity-token'
+    sinon.stub(fs, 'readFileSync').returns('fake-wid-assertion')
     // @ts-ignore
     const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
     const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')
     assert.strictEqual(token, 'test-token')
-    acquireTokenStub.restore()
+    sinon.restore()
   })
 
   it('should throw error for invalid authConfig', async () => {


### PR DESCRIPTION
Fixes # 1044

## Description
This pull request enhances the authentication configuration system for agent connections by introducing a new `authtype` property and supporting federated token files for Workload Identity. It standardizes and expands the supported authentication types, updates the logic for acquiring tokens, and improves test coverage for the new configuration options.

### Detailed Change
**Authentication configuration and type support:**
- Added an `AuthType` enum to define supported authentication types (e.g., `Certificate`, `ClientSecret`, `WorkloadIdentity`, etc.), and extended the `AuthConfiguration` interface with new properties: `authtype` and `federatedtokenfile`. The `WIDAssertionFile` property is now marked as deprecated in favor of these new options. [[1]](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6R13-R25) [[2]](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6R104-R116)

**Configuration loading and environment variable support:**
- Updated the logic in `loadPrevAuthConfigFromEnv` and `buildLegacyAuthConfig` to read the new `authtype` and `federatedtokenfile` from environment variables, ensuring backward compatibility and easier configuration. [[1]](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6R223-R224) [[2]](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6L355-R383)

**Token acquisition logic:**
- Refactored `MsalTokenProvider` to use the new `authtype` property, supporting all defined authentication types through a switch statement. The logic now prioritizes `authtype` and falls back to legacy properties if not set. Federated token file support is integrated into Workload Identity flows. [[1]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L8-R8) [[2]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L73-R105) [[3]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L308-R357) [[4]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L520-R569)

**Connection management:**
- Updated `MsalConnectionManager` to use the new `authtype` property for determining the authentication method, improving clarity in connection logging and management.

**Testing:**
- Added a new test case to verify that tokens can be acquired using the `authtype` set to `WorkloadIdentity` and the new `federatedtokenfile` property, ensuring correct behavior for the updated configuration. [[1]](diffhunk://#diff-8d4f6a317db5468a07c4c51d2962b329c246af1849ab018f886a5fec85a501d7L5-R5) [[2]](diffhunk://#diff-8d4f6a317db5468a07c4c51d2962b329c246af1849ab018f886a5fec85a501d7R92-R105)

## Testing 
These images show a sample running and authenticating via WID successfully.
<img width="1702" height="1314" alt="image" src="https://github.com/user-attachments/assets/02ae8348-e3b6-43c5-be25-980ceb023ff3" />
