### PR TITLE
Bump axios version to 1.15.1

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -22,7 +22,11 @@
   "workspaces": {
     // Root
     ".": {
-      "project": ["*.{js,mjs,ts}"]
+      "project": ["*.{js,mjs,ts}"],
+      "ignoreDependencies": [
+        // Samples are built from the root tsconfig, but knip does not model them as a root package.
+        "axios"
+      ]
     },
 
     // Packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -2710,15 +2710,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -7746,7 +7737,7 @@
         "@azure/msal-node": "5.0.6",
         "@microsoft/agents-activity": "file:../agents-activity",
         "@microsoft/agents-telemetry": "file:../agents-telemetry",
-        "axios": "1.15.0",
+        "axios": "1.15.1",
         "jsonwebtoken": "9.0.3",
         "jwks-rsa": "4.0.1",
         "object-path": "0.11.8",
@@ -7799,11 +7790,22 @@
       "dependencies": {
         "@microsoft/agents-activity": "file:../agents-activity",
         "@microsoft/agents-hosting": "file:../agents-hosting",
-        "axios": "1.15.0",
+        "axios": "1.15.1",
         "zod": "3.25.75"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/agents-hosting-extensions-teams/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "packages/agents-hosting-storage-blob": {
@@ -7834,6 +7836,17 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/agents-hosting/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "packages/agents-telemetry": {
@@ -7996,8 +8009,19 @@
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
         "@microsoft/microsoft-graph-client": "3.0.7",
         "adaptivecards-templating": "2.3.1",
-        "axios": "1.15.0",
+        "axios": "1.15.1",
         "express": "5.2.1"
+      }
+    },
+    "test-agents/web-chat/node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "25.6.0",
         "@types/sinon": "21.0.0",
         "@types/uuid": "10.0.0",
+        "axios": "1.15.1",
         "esbuild": "0.27.3",
         "eslint": "9.39.2",
         "knip": "5.86.0",
@@ -2708,6 +2709,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -7797,17 +7809,6 @@
         "node": ">=20.0.0"
       }
     },
-    "packages/agents-hosting-extensions-teams/node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "packages/agents-hosting-storage-blob": {
       "name": "@microsoft/agents-hosting-storage-blob",
       "version": "0.1.0",
@@ -7836,17 +7837,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "packages/agents-hosting/node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "packages/agents-telemetry": {
@@ -8011,17 +8001,6 @@
         "adaptivecards-templating": "2.3.1",
         "axios": "1.15.1",
         "express": "5.2.1"
-      }
-    },
-    "test-agents/web-chat/node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "25.6.0",
     "@types/sinon": "21.0.0",
     "@types/uuid": "10.0.0",
+    "axios": "1.15.1",
     "esbuild": "0.27.3",
     "eslint": "9.39.2",
     "knip": "5.86.0",

--- a/packages/agents-hosting-extensions-teams/package.json
+++ b/packages/agents-hosting-extensions-teams/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@microsoft/agents-hosting": "file:../agents-hosting",
     "@microsoft/agents-activity": "file:../agents-activity",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "zod": "3.25.75"
   },
   "license": "MIT",

--- a/packages/agents-hosting/package.json
+++ b/packages/agents-hosting/package.json
@@ -23,7 +23,7 @@
     "@azure/msal-node": "5.0.6",
     "@microsoft/agents-activity": "file:../agents-activity",
     "@microsoft/agents-telemetry": "file:../agents-telemetry",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "jsonwebtoken": "9.0.3",
     "jwks-rsa": "4.0.1",
     "object-path": "0.11.8",

--- a/packages/agents-hosting/src/app/teamsAttachmentDownloader.ts
+++ b/packages/agents-hosting/src/app/teamsAttachmentDownloader.ts
@@ -72,7 +72,12 @@ export class M365AttachmentDownloader<TState extends TurnState = TurnState> impl
         const response = await this._httpClient.get(downloadUrl, { responseType: 'arraybuffer' })
 
         const content = Buffer.from(response.data, 'binary')
-        const contentType = response.headers['content-type'] || 'application/octet-stream'
+        const contentTypeHeader = typeof response.headers.get === 'function'
+          ? response.headers.get('content-type')
+          : response.headers['content-type']
+        const contentType = Array.isArray(contentTypeHeader)
+          ? (contentTypeHeader[0] ?? 'application/octet-stream')
+          : (typeof contentTypeHeader === 'string' ? contentTypeHeader : 'application/octet-stream')
         inputFile = { content, contentType, contentUrl: attachment.contentUrl }
       } catch (error) {
         logger.error(`Failed to download Teams attachment: ${error}`)

--- a/test-agents/web-chat/package.json
+++ b/test-agents/web-chat/package.json
@@ -19,7 +19,7 @@
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/microsoft-graph-client": "3.0.7",
     "adaptivecards-templating": "2.3.1",
-    "axios": "1.15.0",
+    "axios": "1.15.1",
     "express": "5.2.1"
   }
 }


### PR DESCRIPTION
## Description
This PR updates the axios dependency to address security vulnerabilities.

### Detailed Changes
* Upgraded `axios` from `1.15.0` to `1.15.1` in `packages/agents-hosting/package.json`, `packages/agents-hosting-extensions-teams/package.json`, and `test-agents/web-chat/package.json` to address security and bug fixes. [[1]](diffhunk://#diff-f5c6b51b6c423a144c6d85766dba1e080ee00a18ed060be6fc8925205dec71fbL26-R26) [[2]](diffhunk://#diff-9cbd83fba18b04750e17f3f698bb7de3ce59eec89987b1f5bee1d9c8a253d181L24-R24) [[3]](diffhunk://#diff-6dccdb0db0849f2e8c9b749caa0b68ee85f9f164e4b9eee4933aa3a9b3b14cd4L22-R22)
* Updated the header handling in `teamsAttachmentDownloader`.

## Testing
This image shows the TeamsAttachmentDownloader feature working after the change (axios).
<img width="1595" height="707" alt="image" src="https://github.com/user-attachments/assets/ab05b4b4-3f92-4740-97d7-7420e79a0701" />
