### PR TITLE
Add headers to Identity agents created with Agents SDK to M365.

### DIFF
--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -144,6 +144,8 @@ export class AgentApplication<TState extends TurnState> {
       this._adapter = new CloudAdapter()
     }
 
+    this._adapter.setAgentName(this._options.agentName)
+
     // Create Proactive whenever proactive options are explicitly configured or a storage
     // backend is available — no explicit `proactive` option is required.
     if (this._options.proactive !== undefined || this._options.storage !== undefined) {

--- a/packages/agents-hosting/src/app/agentApplicationOptions.ts
+++ b/packages/agents-hosting/src/app/agentApplicationOptions.ts
@@ -179,6 +179,17 @@ export interface AgentApplicationOptions<TState extends TurnState> {
   headerPropagation?: HeaderPropagationDefinition
 
   /**
+   * Optional. Human-friendly agent name sent in the `AgentName` header for
+   * SDK-managed outbound requests created during inbound turn processing.
+   *
+   * @remarks
+   * When omitted, the SDK uses the default value `Agent-SDK-JS`.
+   * The resolved value is trimmed and validated by the SDK. Only letters,
+   * numbers, spaces, hyphen, and underscore are allowed.
+   */
+  agentName?: string
+
+  /**
    * Optional. Configuration for managing multiple authentication connections within the agent.
    * This allows the agent to handle authentication across different services or
    * identity providers.

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -30,6 +30,7 @@ import { getTokenServiceEndpoint } from './oauth/customUserTokenAPI'
 import { Connections } from './auth/connections'
 import { trace } from '@microsoft/agents-telemetry'
 import { AdapterTraceDefinitions } from './observability'
+import { applyAgentHeaders } from './getProductInfo'
 const logger = debug('agents:cloud-adapter')
 
 /**
@@ -42,6 +43,9 @@ const logger = debug('agents:cloud-adapter')
  * and conversation continuations.
  */
 export class CloudAdapter extends BaseAdapter {
+  protected readonly authConfig: AuthConfiguration
+  protected _agentName?: string
+
   /**
    * Client for connecting to the Azure Bot Service
    */
@@ -55,7 +59,7 @@ export class CloudAdapter extends BaseAdapter {
    */
   constructor (authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient) {
     super()
-    authConfig = getAuthConfigWithDefaults(authConfig)
+    this.authConfig = authConfig = getAuthConfigWithDefaults(authConfig)
     this.connectionManager = new MsalConnectionManager(undefined, undefined, authConfig)
   }
 
@@ -199,6 +203,14 @@ export class CloudAdapter extends BaseAdapter {
     return {
       aud: appId
     } as JwtPayload
+  }
+
+  /**
+   * Sets the agent name for M365 agent header propagation.
+   * @param agentName The human-friendly agent name to set for header propagation.
+   */
+  public setAgentName (agentName?: string): void {
+    this._agentName = agentName
   }
 
   /**
@@ -355,7 +367,7 @@ export class CloudAdapter extends BaseAdapter {
       const headers = new HeaderPropagation(request.headers)
       if (headerPropagation && typeof headerPropagation === 'function') {
         headerPropagation(headers)
-        logger.debug('Headers to propagate: ', headers)
+        logger.debug('Headers to propagate: ', headers.outgoing)
       }
 
       const end = (status: StatusCodes, body?: unknown, isInvokeResponseOrExpectReplies: boolean = false) => {
@@ -383,8 +395,6 @@ export class CloudAdapter extends BaseAdapter {
       const activity = Activity.fromObject(incoming)
       logger.info(`--> Processing incoming activity, type:${activity.type} channel:${activity.channelId}`)
 
-      const isAgentic = activity.isAgenticRequest()
-
       record({ activity })
 
       if (!this.isValidChannelActivity(activity)) {
@@ -393,6 +403,9 @@ export class CloudAdapter extends BaseAdapter {
 
       logger.debug('Received activity: ', activity)
 
+      applyAgentHeaders(headers, activity, this._agentName, this.authConfig.clientId)
+      logger.debug('Applied Agent SDK headers for outgoing request: ', { incoming: headers.incoming, outgoing: headers.outgoing })
+
       const context = new TurnContext(this, activity, request.user!)
       // if Delivery Mode == ExpectReplies, we don't need a connector client.
       if (this.resolveIfConnectorClientIsNeeded(activity)) {
@@ -400,7 +413,7 @@ export class CloudAdapter extends BaseAdapter {
         this.setConnectorClient(context, connectorClient)
       }
 
-      if (!isAgentic) {
+      if (!activity.isAgenticRequest()) {
         const userTokenClient = await this.createUserTokenClient(request.user!, undefined, undefined, undefined, headers)
         this.setUserTokenClient(context, userTokenClient)
       }

--- a/packages/agents-hosting/src/connector-client/connectorClient.ts
+++ b/packages/agents-hosting/src/connector-client/connectorClient.ts
@@ -11,7 +11,7 @@ import { ResourceResponse } from './resourceResponse'
 import { AttachmentInfo } from './attachmentInfo'
 import { AttachmentData } from './attachmentData'
 import { normalizeOutgoingActivity } from '../activityWireCompat'
-import { getProductInfo } from '../getProductInfo'
+import { applyUserAgentHeader, getProductInfo } from '../getProductInfo'
 import { HeaderPropagation, HeaderPropagationCollection } from '../headerPropagation'
 import { trace } from '@microsoft/agents-telemetry'
 import { ConnectorClientTraceDefinitions } from '../observability'
@@ -112,13 +112,7 @@ export class ConnectorClient {
     headers?: HeaderPropagationCollection
   ): ConnectorClient {
     const headerPropagation = headers ?? new HeaderPropagation({})
-    const userAgent = headerPropagation.outgoing['user-agent']
-    const productInfo = getProductInfo()
-    if (!userAgent) {
-      headerPropagation.add({ 'User-Agent': productInfo })
-    } else if (!userAgent.includes(productInfo)) {
-      headerPropagation.concat({ 'User-Agent': productInfo })
-    }
+    applyUserAgentHeader(headerPropagation)
     headerPropagation.override({
       Accept: 'application/json',
       'Content-Type': 'application/json', // Required by transformRequest

--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -537,6 +537,14 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   /**
+   * Error thrown when agent name contains invalid characters.
+   */
+  AgentNameInvalid: {
+    code: -120650,
+    description: 'Agent name contains invalid characters: {agentName}'
+  },
+
+  /**
      * Error thrown when failed to post activity to agent.
      */
   FailedToPostActivityToAgent: {

--- a/packages/agents-hosting/src/getProductInfo.ts
+++ b/packages/agents-hosting/src/getProductInfo.ts
@@ -1,5 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { version } from '../package.json'
 import os from 'os'
+import { Activity, ExceptionHelper } from '@microsoft/agents-activity'
+import { Errors } from './errorHelper'
+import { HeaderPropagationCollection } from './headerPropagation'
+
+const AGENT_NAME_PATTERN = /^[A-Za-z0-9 _-]+$/
+const AGENT_REGISTRAR = 'A365'
+const DEFAULT_AGENT_NAME = 'Agent-SDK-JS'
 
 /**
  * Generates a string containing information about the SDK version and runtime environment.
@@ -8,3 +18,64 @@ import os from 'os'
  * @returns A formatted string containing the SDK version, Node.js version, and OS details
  */
 export const getProductInfo = () : string => `agents-sdk-js/${version} nodejs/${process.version} ${os.platform()}-${os.arch()}/${os.release()}`
+
+/**
+ * Applies the SDK product information to the User-Agent header of outgoing requests.
+ * @param headers The HeaderPropagationCollection to which the User-Agent header will be added or updated
+ */
+export function applyUserAgentHeader (headers: HeaderPropagationCollection): void {
+  const userAgentKey = headers.key('User-Agent')
+  const userAgent = headers.outgoing[userAgentKey]
+  const productInfo = getProductInfo()
+  if (!userAgent) {
+    headers.add({ [userAgentKey]: productInfo })
+  } else if (!userAgent.includes(productInfo)) {
+    headers.concat({ [userAgentKey]: productInfo })
+  }
+}
+
+/**
+ * Applies standardized agent-related headers to the outgoing request based on the incoming activity and identity.
+ *
+ * @param headers The HeaderPropagationCollection to which the agent headers will be applied.
+ * @param activity The incoming Activity that may contain agentic request information.
+ * @param agentName An optional human-friendly name for the agent, which will be validated and included in the headers.
+ * @param identity An optional JwtPayload containing identity claims, used to resolve the AgentID if not present in the activity.
+ * @param clientId An optional default AgentID to use if it cannot be resolved from the activity or identity.
+ *
+ * @remarks
+ * The function sets the following headers:
+ * - `AgentRegistrar`: A fixed value indicating the registrar of the agent (e.g., "A365").
+ * - `AgentName`: A human-friendly name for the agent, validated against a pattern to ensure it only contains allowed characters.
+ * - `AgentID`: A unique identifier for the agent instance, resolved from the activity's agentic instance ID, identity claims, or a provided default.
+ * - `Agent-Referrer`: The channel ID from the incoming activity, indicating the source of the request.
+ * - `User-Agent`: Includes the SDK product information for telemetry and identification purposes.
+ * The function ensures that the agent headers are consistently applied to outgoing requests for proper identification and tracing.
+ */
+export function applyAgentHeaders (
+  headers: HeaderPropagationCollection,
+  activity: Activity,
+  agentName?: string,
+  clientId?: string
+): void {
+  applyUserAgentHeader(headers)
+  headers.override({
+    AgentRegistrar: AGENT_REGISTRAR,
+    AgentName: normalizeAgentName(agentName),
+    AgentID: activity.getAgenticInstanceId() ?? activity.getAgenticUser() ?? clientId ?? '',
+    'Agent-Referrer': activity.channelId ?? '',
+  })
+}
+
+function normalizeAgentName (agentName?: string): string {
+  const normalizedAgentName = agentName?.trim()
+  if (!normalizedAgentName) {
+    return DEFAULT_AGENT_NAME
+  }
+
+  if (!AGENT_NAME_PATTERN.test(normalizedAgentName)) {
+    throw ExceptionHelper.generateException(Error, Errors.AgentNameInvalid, undefined, { agentName: normalizedAgentName })
+  }
+
+  return normalizedAgentName
+}

--- a/packages/agents-hosting/src/headerPropagation.ts
+++ b/packages/agents-hosting/src/headerPropagation.ts
@@ -8,6 +8,7 @@
  * It filters the incoming request headers based on the definition provided and loads them into the outgoing headers collection.
  */
 export class HeaderPropagation implements HeaderPropagationCollection {
+  private _keys = new Set<string>()
   private _incomingRequests: Record<string, string>
   private _outgoingHeaders: Record<string, string> = {}
 
@@ -32,49 +33,57 @@ export class HeaderPropagation implements HeaderPropagationCollection {
 
   propagate (headers: string[]) {
     for (const key of headers ?? []) {
-      const lowerKey = key.toLowerCase()
-      if (this._incomingRequests[lowerKey] && !this._outgoingHeaders[lowerKey]) {
-        this._outgoingHeaders[lowerKey] = this._incomingRequests[lowerKey]
+      const realKey = this.key(key)
+      if (this._incomingRequests[realKey] && !this._outgoingHeaders[realKey]) {
+        this._outgoingHeaders[realKey] = this._incomingRequests[realKey]
+        this._keys.add(realKey)
       }
     }
   }
 
   add (headers: Record<string, string>) {
     for (const [key, value] of Object.entries(headers ?? {})) {
-      const lowerKey = key.toLowerCase()
-      if (!this._incomingRequests[lowerKey] && !this._outgoingHeaders[lowerKey]) {
-        this._outgoingHeaders[lowerKey] = value
+      const realKey = this.key(key)
+      if (!this._incomingRequests[realKey] && !this._outgoingHeaders[realKey]) {
+        this._outgoingHeaders[realKey] = value
+        this._keys.add(realKey)
       }
     }
   }
 
   concat (headers: Record<string, string>) {
     for (const [key, value] of Object.entries(headers ?? {})) {
-      const lowerKey = key.toLowerCase()
-      if (this._incomingRequests[lowerKey] && !this._headersToPropagate.includes(lowerKey)) {
-        this._outgoingHeaders[lowerKey] = `${this._outgoingHeaders[lowerKey] ?? this._incomingRequests[lowerKey]} ${value}`.trim()
+      const realKey = this.key(key)
+      if (this._incomingRequests[realKey] && !this._headersToPropagate.includes(realKey.toLowerCase())) {
+        this._outgoingHeaders[realKey] = `${this._outgoingHeaders[realKey] ?? this._incomingRequests[realKey]} ${value}`.trim()
+        this._keys.add(realKey)
       }
     }
   }
 
   override (headers: Record<string, string>) {
     for (const [key, value] of Object.entries(headers ?? {})) {
-      const lowerKey = key.toLowerCase()
-      if (!this._headersToPropagate.includes(lowerKey)) {
-        this._outgoingHeaders[lowerKey] = value
+      const realKey = this.key(key)
+      if (!this._headersToPropagate.includes(realKey.toLowerCase())) {
+        this._outgoingHeaders[realKey] = value
+        this._keys.add(realKey)
       }
     }
   }
 
+  key (key: string) {
+    return Array.from(this._keys).find(k => k.toLowerCase() === key.toLowerCase()) ?? key
+  }
+
   /**
-   * Normalizes the headers by lowercasing the keys and ensuring the values are strings.
+   * Normalizes the headers by ensuring the values are strings.
    * @param headers The headers to normalize.
    * @returns A new object with normalized headers.
    */
   private normalizeHeaders (headers: Record<string, string | string[] | undefined>) {
     return Object.entries(headers).reduce((acc, [key, value]) => {
       if (value) {
-        acc[key.toLowerCase()] = Array.isArray(value) ? value.join(' ') : value
+        acc[key] = Array.isArray(value) ? value.join(' ') : value
       }
       return acc
     }, {} as Record<string, string>)
@@ -138,4 +147,13 @@ export interface HeaderPropagationCollection {
    * If the header does not exist in the incoming headers, it will be added to the outgoing collection.
    */
   override(headers: Record<string, string>): void
+  /**
+   * Finds the real key in the incoming headers based on a case-insensitive search.
+   * If the key is not found, it returns the provided key.
+   * This is necessary because HTTP headers are case-insensitive, but the incoming headers may have different casing.
+   * The outgoing headers should maintain the same casing as the incoming headers for consistency.
+   * @param key The header key to find.
+   * @returns The real key from the incoming headers or the provided key if not found.
+   */
+  key(key: string): string
 }

--- a/packages/agents-hosting/src/oauth/userTokenClient.ts
+++ b/packages/agents-hosting/src/oauth/userTokenClient.ts
@@ -6,7 +6,7 @@ import { Activity, ConversationReference } from '@microsoft/agents-activity'
 import { debug } from '@microsoft/agents-telemetry'
 import { normalizeTokenExchangeState } from '../activityWireCompat'
 import { AadResourceUrls, SignInResource, TokenExchangeRequest, TokenOrSinginResourceResponse, TokenResponse, TokenStatus } from './userTokenClient.types'
-import { getProductInfo } from '../getProductInfo'
+import { applyUserAgentHeader, getProductInfo } from '../getProductInfo'
 import { AuthProvider } from '../auth'
 import { HeaderPropagation, HeaderPropagationCollection } from '../headerPropagation'
 import { getTokenServiceEndpoint } from './customUserTokenAPI'
@@ -112,13 +112,7 @@ export class UserTokenClient {
     headers?: HeaderPropagationCollection
   ): Promise<UserTokenClient> {
     const headerPropagation = headers ?? new HeaderPropagation({})
-    const userAgent = headerPropagation.outgoing['user-agent']
-    const productInfo = getProductInfo()
-    if (!userAgent) {
-      headerPropagation.add({ 'User-Agent': productInfo })
-    } else if (!userAgent.includes(productInfo)) {
-      headerPropagation.concat({ 'User-Agent': productInfo })
-    }
+    applyUserAgentHeader(headerPropagation)
     headerPropagation.override({
       Accept: 'application/json',
       'Content-Type': 'application/json', // Required by transformRequest

--- a/packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts
@@ -15,6 +15,7 @@ describe('CloudAdapter', function () {
   let req: Request
   let res: Partial<Response>
   let createConnectorClientWithIdentitySpy: sinon.SinonStub
+  let createUserTokenClientSpy: sinon.SinonStub
 
   const authentication: AuthConfiguration = {
     tenantId: 'tenantId',
@@ -32,7 +33,7 @@ describe('CloudAdapter', function () {
     (cloudAdapter as any).connectionManager = mockConnectionManager
 
     sinon.stub(cloudAdapter as any, 'createConnectorClient').returns(mockConnectorClient)
-    sinon.stub(cloudAdapter as any, 'createUserTokenClient').returns(mockUserTokenClient)
+    createUserTokenClientSpy = sinon.stub(cloudAdapter as any, 'createUserTokenClient').returns(mockUserTokenClient)
     createConnectorClientWithIdentitySpy = sinon.stub(cloudAdapter as any, 'createConnectorClientWithIdentity').returns(mockConnectorClient)
 
     req = {
@@ -190,6 +191,99 @@ describe('CloudAdapter', function () {
       sinon.assert.notCalled((res as any).send)
       sinon.assert.notCalled((res as any).end)
       sinon.assert.notCalled(createConnectorClientWithIdentitySpy)
+
+      stubfromObject.restore()
+    })
+
+    it('Should apply M365 agent headers for normal requests', async function () {
+      const activity = createActivity(ActivityTypes.Message)
+      const stubfromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      cloudAdapter.setAgentName('Valid Agent_1')
+
+      await cloudAdapter.process(req as Request, res as Response, async () => {})
+
+      const connectorHeaders = createConnectorClientWithIdentitySpy.firstCall.args[2]
+      const userTokenHeaders = createUserTokenClientSpy.firstCall.args[4]
+
+      assert.strictEqual(connectorHeaders.outgoing.AgentRegistrar, 'A365')
+      assert.strictEqual(connectorHeaders.outgoing.AgentID, 'clientId')
+      assert.strictEqual(connectorHeaders.outgoing.AgentName, 'Valid Agent_1')
+      assert.strictEqual(connectorHeaders.outgoing['Agent-Referrer'], 'test-channel')
+
+      assert.strictEqual(userTokenHeaders.outgoing.AgentRegistrar, 'A365')
+      assert.strictEqual(userTokenHeaders.outgoing.AgentID, 'clientId')
+      assert.strictEqual(userTokenHeaders.outgoing.AgentName, 'Valid Agent_1')
+      assert.strictEqual(userTokenHeaders.outgoing['Agent-Referrer'], 'test-channel')
+
+      stubfromObject.restore()
+    })
+
+    it('Should prefer agenticAppId when applying M365 agent headers for agentic requests', async function () {
+      const activity = createActivity(ActivityTypes.Message)
+      activity.recipient = {
+        id: 'test-bot-id',
+        name: 'test-bot-name',
+        role: 'agenticUser',
+        agenticAppId: 'agentic-app-id'
+      }
+      const stubfromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      cloudAdapter.setAgentName('Valid Agent_1')
+
+      await cloudAdapter.process(req as Request, res as Response, async () => {})
+
+      const connectorHeaders = createConnectorClientWithIdentitySpy.firstCall.args[2]
+
+      assert.strictEqual(connectorHeaders.outgoing.AgentID, 'agentic-app-id')
+      assert.strictEqual(connectorHeaders.outgoing.AgentName, 'Valid Agent_1')
+      assert.strictEqual(connectorHeaders.outgoing.AgentRegistrar, 'A365')
+      assert.strictEqual(connectorHeaders.outgoing['Agent-Referrer'], 'test-channel')
+      sinon.assert.notCalled(createUserTokenClientSpy)
+
+      stubfromObject.restore()
+    })
+
+    it('Should trim agent name when applying agent headers', async function () {
+      const activity = createActivity(ActivityTypes.Message)
+      const stubfromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      cloudAdapter.setAgentName('  Valid Agent_1  ')
+
+      await cloudAdapter.process(req as Request, res as Response, async () => {})
+
+      const connectorHeaders = createConnectorClientWithIdentitySpy.firstCall.args[2]
+
+      assert.strictEqual(connectorHeaders.outgoing.AgentID, 'clientId')
+      assert.strictEqual(connectorHeaders.outgoing.AgentName, 'Valid Agent_1')
+      assert.strictEqual(connectorHeaders.outgoing.AgentRegistrar, 'A365')
+      assert.strictEqual(connectorHeaders.outgoing['Agent-Referrer'], 'test-channel')
+
+      stubfromObject.restore()
+    })
+
+    it('Should use default agent name when adapter is configured without one', async function () {
+      const activity = createActivity(ActivityTypes.Message)
+      const stubfromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      cloudAdapter.setAgentName(undefined)
+
+      await cloudAdapter.process(req as Request, res as Response, async () => {})
+
+      const connectorHeaders = createConnectorClientWithIdentitySpy.firstCall.args[2]
+
+      assert.strictEqual(connectorHeaders.outgoing.AgentID, 'clientId')
+      assert.strictEqual(connectorHeaders.outgoing.AgentName, 'Agent-SDK-JS')
+      assert.strictEqual(connectorHeaders.outgoing.AgentRegistrar, 'A365')
+      assert.strictEqual(connectorHeaders.outgoing['Agent-Referrer'], 'test-channel')
+
+      stubfromObject.restore()
+    })
+
+    it('Should reject invalid agent name when processing a request', async function () {
+      const activity = createActivity(ActivityTypes.Message)
+      const stubfromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      cloudAdapter.setAgentName('Bad!Name')
+
+      await assert.rejects(async () => {
+        await cloudAdapter.process(req as Request, res as Response, async () => {})
+      })
 
       stubfromObject.restore()
     })

--- a/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
+++ b/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
@@ -59,6 +59,33 @@ describe('Application', () => {
     assert.equal(app.options.transcriptLogger, undefined)
   })
 
+  it('should preserve configured agent name on options', () => {
+    const localApp = new AgentApplication({
+      agentName: 'Valid Agent_1'
+    })
+
+    assert.equal(localApp.options.agentName, 'Valid Agent_1')
+  })
+
+  it('should leave agent name undefined when not provided', () => {
+    const localApp = new AgentApplication()
+
+    assert.equal(localApp.options.agentName, undefined)
+  })
+
+  it('should forward agent name config to the adapter', () => {
+    const adapter = createStubInstance(CloudAdapter)
+
+    const app = new AgentApplication({
+      adapter: adapter as unknown as CloudAdapter,
+      agentAppId: 'app-level-agent-id',
+      agentName: 'Valid Agent_1'
+    })
+
+    assert.ok(app)
+    sinon.assert.calledOnceWithExactly(adapter.setAgentName, 'Valid Agent_1')
+  })
+
   it('should route to an activity handler', async () => {
     let called = false
 
@@ -453,6 +480,9 @@ describe('Application', () => {
     class TrackingAdapter extends TestAdapter {
       continueConversationCalled = false
       continueConversationCallback: ((ctx: TurnContext) => Promise<void>) | undefined
+
+      setAgentName (_agentName?: string): void {
+      }
 
       override continueConversation (_identity: any, _reference: any, logic: (ctx: TurnContext) => Promise<void>): Promise<void> {
         this.continueConversationCalled = true

--- a/packages/agents-hosting/test/hosting/headerPropagation.test.ts
+++ b/packages/agents-hosting/test/hosting/headerPropagation.test.ts
@@ -14,24 +14,24 @@ describe('HeaderPropagation', () => {
     assert.throws(() => new HeaderPropagation(undefined as any))
   })
 
-  it('should normalize headers', async () => {
+  it('should normalize header values without changing header names', async () => {
     const headers = new HeaderPropagation({
       'X-HEADER': 'headerValue',
       'x-Header-List': ['One', 'Two'],
     })
 
     headers.add({ 'x-header-ADD': 'headerValue' })
-    headers.propagate(['x-Header', 'x-header-list'])
+    headers.propagate(['X-HEADER', 'x-Header-List'])
 
     assert.deepStrictEqual(headers.incoming, {
-      'x-header': 'headerValue',
-      'x-header-list': 'One Two',
+      'X-HEADER': 'headerValue',
+      'x-Header-List': 'One Two',
     })
 
     assert.deepStrictEqual(headers.outgoing, {
-      'x-header': 'headerValue',
-      'x-header-list': 'One Two',
-      'x-header-add': 'headerValue',
+      'X-HEADER': 'headerValue',
+      'x-Header-List': 'One Two',
+      'x-header-ADD': 'headerValue',
     })
   })
 


### PR DESCRIPTION
Fixes # 1106

This pull request introduces a new feature that enables the propagation of a human-friendly agent name in outbound SDK-managed requests, along with refactoring and improvements to header handling and agent identification. The changes ensure that standardized agent headers are consistently applied for better observability, traceability, and compliance with header casing. Several utility functions and error handling mechanisms are also introduced or improved.

Key changes include:

**Agent Name Propagation and Validation**
* Added an optional `agentName` field to `AgentApplicationOptions`, allowing developers to specify a human-friendly agent name for outbound requests. The agent name is validated for allowed characters and defaults to `Agent-SDK-JS` if omitted. (`packages/agents-hosting/src/app/agentApplicationOptions.ts`, `packages/agents-hosting/src/app/agentApplication.ts`, `packages/agents-hosting/src/cloudAdapter.ts`, `packages/agents-hosting/src/getProductInfo.ts`) [[1]](diffhunk://#diff-01be4facccbf879b56f6604d274a58ee33d50e80327a9b67f2a01c4dbcd20330R181-R191) [[2]](diffhunk://#diff-eb62ee565800a96a056213566c64b9dba3ab20f387cef5c8dc2facf8845507d2R147-R148) [[3]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R46-R48) [[4]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R208-R215) [[5]](diffhunk://#diff-879b29cc47b46fec582d2035a18bfad3fc207e4ba342f2210c84789fa663af03R1-R12)
* Introduced agent name validation logic and a new error code for invalid agent names. (`packages/agents-hosting/src/getProductInfo.ts`, `packages/agents-hosting/src/errorHelper.ts`) [[1]](diffhunk://#diff-879b29cc47b46fec582d2035a18bfad3fc207e4ba342f2210c84789fa663af03R1-R12) [[2]](diffhunk://#diff-a99d0b88336dd114b0573b8c64cca81a0e18eef6206caead4f18258cff0b7d94R539-R546)

**Standardized Agent Header Application**
* Implemented `applyAgentHeaders` and `applyUserAgentHeader` utility functions to consistently apply agent-related headers, including `AgentRegistrar`, `AgentName`, `AgentID`, `Agent-Referrer`, and `User-Agent`, to outgoing requests. (`packages/agents-hosting/src/getProductInfo.ts`, `packages/agents-hosting/src/cloudAdapter.ts`, `packages/agents-hosting/src/connector-client/connectorClient.ts`, `packages/agents-hosting/src/oauth/userTokenClient.ts`) [[1]](diffhunk://#diff-879b29cc47b46fec582d2035a18bfad3fc207e4ba342f2210c84789fa663af03R1-R12) [[2]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R406-R416) [[3]](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74L14-R14) [[4]](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74L115-R115) [[5]](diffhunk://#diff-394ddc5894236f1228ead6d2141128a24f9d83477dd2e2908f56149e63c3f787L9-R9) [[6]](diffhunk://#diff-394ddc5894236f1228ead6d2141128a24f9d83477dd2e2908f56149e63c3f787L115-R115)
* Updated `CloudAdapter` to call `applyAgentHeaders` before sending outbound requests, ensuring all relevant headers are set. (`packages/agents-hosting/src/cloudAdapter.ts`)

**HeaderPropagation Improvements**
* Enhanced the `HeaderPropagation` class and interface to provide a `key()` method for case-insensitive header key lookups, preserving original casing for outgoing headers and improving header management consistency. (`packages/agents-hosting/src/headerPropagation.ts`) [[1]](diffhunk://#diff-89fd268074db55c2d5e17829d08f10139ed304e0e4984687e99e9c1718a61b7bR11) [[2]](diffhunk://#diff-89fd268074db55c2d5e17829d08f10139ed304e0e4984687e99e9c1718a61b7bL35-R86) [[3]](diffhunk://#diff-89fd268074db55c2d5e17829d08f10139ed304e0e4984687e99e9c1718a61b7bR150-R158)
* Adjusted all header propagation methods to use the new key handling logic, ensuring proper casing and deduplication. (`packages/agents-hosting/src/headerPropagation.ts`)

**Refactoring and Logging**
* Refactored code to use new utility functions for header application, reducing duplication and improving maintainability. (`packages/agents-hosting/src/connector-client/connectorClient.ts`, `packages/agents-hosting/src/oauth/userTokenClient.ts`) [[1]](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74L14-R14) [[2]](diffhunk://#diff-2e8863008604a8febac825f545e49f081bf7d5d5a67046e25164b4fc7da0fa74L115-R115) [[3]](diffhunk://#diff-394ddc5894236f1228ead6d2141128a24f9d83477dd2e2908f56149e63c3f787L9-R9) [[4]](diffhunk://#diff-394ddc5894236f1228ead6d2141128a24f9d83477dd2e2908f56149e63c3f787L115-R115)
* Improved debug logging to capture outgoing header state after propagation and agent header application. (`packages/agents-hosting/src/cloudAdapter.ts`) [[1]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420L358-R370) [[2]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R406-R416)

**Testing**
* Updated tests to use spies for `createUserTokenClient` to support new header propagation logic. (`packages/agents-hosting/test/hosting/adapter/cloudAdapter.test.ts`) [[1]](diffhunk://#diff-f9e2de25f77c1749277c91494944b68d9ded5369f17bad0862c902754bbd7efbR18) [[2]](diffhunk://#diff-f9e2de25f77c1749277c91494944b68d9ded5369f17bad0862c902754bbd7efbL35-R36)

The following image shows the agents identifiers headers are set correctly.
<img width="659" height="456" alt="image" src="https://github.com/user-attachments/assets/603ac17c-5355-49be-822a-e93e27171026" />
