### PR TITLE
[#1105] Add support for ContainerIMDS Auth type

### DIFF
--- a/compat/baseline/agents-hosting.api.md
+++ b/compat/baseline/agents-hosting.api.md
@@ -6,12 +6,14 @@
 
 import { Activity } from '@microsoft/agents-activity';
 import { AdaptiveCardInvokeAction } from '@microsoft/agents-activity';
+import { AgentErrorDefinition } from '@microsoft/agents-activity';
 import { Application } from 'express';
 import { Attachment } from '@microsoft/agents-activity';
 import { AxiosInstance } from 'axios';
 import { CardAction } from '@microsoft/agents-activity';
 import { ChannelAccount } from '@microsoft/agents-activity';
 import { ClientCitation } from '@microsoft/agents-activity';
+import type { ConversationAccount } from '@microsoft/agents-activity';
 import { ConversationParameters } from '@microsoft/agents-activity';
 import { ConversationReference } from '@microsoft/agents-activity';
 import { GetTokenOptions } from '@azure/core-auth';
@@ -156,39 +158,43 @@ export const adaptiveCardsSearchParamsZodSchema: z.ZodObject<{
 // @public
 export class AgentApplication<TState extends TurnState> {
     constructor(options?: Partial<AgentApplicationOptions<TState>>);
-    get adapter(): BaseAdapter;
+    get adapter(): CloudAdapter;
     get adaptiveCards(): AdaptiveCardsActions<TState>;
-    addRoute(selector: RouteSelector, handler: RouteHandler<TState>, isInvokeRoute?: boolean, rank?: number, authHandlers?: string[]): this;
+    addRoute(selector: RouteSelector, handler: RouteHandler<TState>, isInvokeRoute?: boolean, rank?: number, authHandlers?: string[], isAgenticRoute?: boolean): this;
     // (undocumented)
     protected readonly _afterTurn: ApplicationEventHandler<TState>[];
     get authorization(): Authorization;
     // (undocumented)
     protected readonly _beforeTurn: ApplicationEventHandler<TState>[];
     protected callEventHandlers(context: TurnContext, state: TState, handlers: ApplicationEventHandler<TState>[]): Promise<boolean>;
-    protected continueConversationAsync(conversationReferenceOrContext: ConversationReference | TurnContext, logic: (context: TurnContext) => Promise<void>): Promise<void>;
+    protected continueConversationAsync(botAppIdOrIdentity: string | JwtPayload, conversationReferenceOrContext: ConversationReference | TurnContext, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     // (undocumented)
     protected readonly _extensions: AgentExtension<TState>[];
-    onActivity(type: string | RegExp | RouteSelector | (string | RegExp | RouteSelector)[], handler: (context: TurnContext, state: TState) => Promise<void>, authHandlers?: string[], rank?: RouteRank): this;
-    onConversationUpdate(event: ConversationUpdateEvents, handler: (context: TurnContext, state: TState) => Promise<void>, authHandlers?: string[], rank?: RouteRank): this;
+    get hasUserAuthorization(): boolean;
+    onActivity(type: string | RegExp | RouteSelector | (string | RegExp | RouteSelector)[], handler: (context: TurnContext, state: TState) => Promise<void>, authHandlers?: string[], rank?: RouteRank, isAgenticRoute?: boolean): this;
+    onConversationUpdate(event: ConversationUpdateEvents, handler: (context: TurnContext, state: TState) => Promise<void>, authHandlers?: string[], rank?: RouteRank, isAgenticRoute?: boolean): this;
     onError(handler: (context: TurnContext, error: Error) => Promise<void>): this;
-    onMessage(keyword: string | RegExp | RouteSelector | (string | RegExp | RouteSelector)[], handler: (context: TurnContext, state: TState) => Promise<void>, authHandlers?: string[], rank?: RouteRank): this;
-    onMessageReactionAdded(handler: (context: TurnContext, state: TState) => Promise<void>, rank?: RouteRank): this;
-    onMessageReactionRemoved(handler: (context: TurnContext, state: TState) => Promise<void>, rank?: RouteRank): this;
+    onMessage(keyword: string | RegExp | RouteSelector | (string | RegExp | RouteSelector)[], handler: (context: TurnContext, state: TState) => Promise<void>, authHandlers?: string[], rank?: RouteRank, isAgenticRoute?: boolean): this;
+    onMessageReactionAdded(handler: (context: TurnContext, state: TState) => Promise<void>, rank?: RouteRank, isAgenticRoute?: boolean): this;
+    onMessageReactionRemoved(handler: (context: TurnContext, state: TState) => Promise<void>, rank?: RouteRank, isAgenticRoute?: boolean): this;
     onSignInFailure(handler: (context: TurnContext, state: TurnState, id?: string) => Promise<void>): this;
     onSignInSuccess(handler: (context: TurnContext, state: TurnState, id?: string) => Promise<void>): this;
     onTurn(event: TurnEvents | TurnEvents[], handler: (context: TurnContext, state: TState) => Promise<boolean>): this;
     get options(): AgentApplicationOptions<TState>;
     // (undocumented)
     protected readonly _options: AgentApplicationOptions<TState>;
+    get proactive(): Proactive<TState>;
     registerExtension<T extends AgentExtension<TState>>(extension: T, regcb: (ext: T) => void): void;
     // (undocumented)
     protected readonly _routes: RouteList<TState>;
     run(turnContext: TurnContext): Promise<void>;
     runInternal(turnContext: TurnContext): Promise<boolean>;
-    sendProactiveActivity(context: TurnContext | ConversationReference, activityOrText: string | Activity, speak?: string, inputHint?: string): Promise<ResourceResponse | undefined>;
-    protected startLongRunningCall(context: TurnContext, handler: (context: TurnContext) => Promise<boolean>): Promise<boolean>;
+    sendProactiveActivity(botAppIdOrIdentity: string | JwtPayload, context: TurnContext | ConversationReference, activityOrText: string | Activity, speak?: string, inputHint?: string): Promise<ResourceResponse | undefined>;
+    protected startLongRunningCall(context: TurnContext, handler: (context: TurnContext) => Promise<any>): void;
     startTypingTimer(context: TurnContext): void;
+    // @deprecated
     stopTypingTimer(): void;
+    stopTypingTimer(context: TurnContext): void;
 }
 
 // @public
@@ -197,9 +203,12 @@ export class AgentApplicationBuilder<TState extends TurnState = TurnState> {
     protected get options(): Partial<AgentApplicationOptions<TState>>;
     // (undocumented)
     protected _options: Partial<AgentApplicationOptions<TState>>;
+    setStartTypingTimer(startTypingTimer: boolean): this;
     withAuthorization(authHandlers: AuthorizationOptions): this;
+    withProactive(options: ProactiveOptions): this;
     withStorage(storage: Storage_2): this;
     withTurnStateFactory(turnStateFactory: () => TState): this;
+    withTyping(typing: TypingOptions): this;
 }
 
 // @public
@@ -208,15 +217,18 @@ export interface AgentApplicationOptions<TState extends TurnState> {
     adaptiveCardsOptions?: AdaptiveCardsOptions;
     agentAppId?: string;
     authorization?: AuthorizationOptions;
+    connections?: Connections;
     fileDownloaders?: InputFileDownloader<TState>[];
     headerPropagation?: HeaderPropagationDefinition;
     longRunningMessages: boolean;
     normalizeMentions?: boolean;
+    proactive?: ProactiveOptions;
     removeRecipientMention?: boolean;
     startTypingTimer: boolean;
     storage?: Storage_2;
     transcriptLogger?: TranscriptLogger;
     turnStateFactory: () => TState;
+    typing?: TypingOptions;
 }
 
 // @public
@@ -304,10 +316,32 @@ export interface AppMemory {
 export interface AppRoute<TState extends TurnState> {
     authHandlers?: string[];
     handler: RouteHandler<TState>;
+    isAgenticRoute?: boolean;
     isInvokeRoute?: boolean;
     rank?: number;
     selector: RouteSelector;
 }
+
+// @public (undocumented)
+export const ApxDevScope = "0d94caae-b412-4943-8a68-83135ad6d35f/.default";
+
+// @public (undocumented)
+export const ApxDoDScope = "0a069c81-8c7c-4712-886b-9c542d673ffb/.default";
+
+// @public (undocumented)
+export const ApxGallatinScope = "bd004c8e-5acf-4c48-8570-4e7d46b2f63b/.default";
+
+// @public (undocumented)
+export const ApxGCCHScope = "6f669b9e-7701-4e2b-b624-82c9207fde26/.default";
+
+// @public (undocumented)
+export const ApxGCCScope = "c9475445-9789-4fef-9ec5-cde4a9bcd446/.default";
+
+// @public
+export const ApxLocalScope = "c16e153d-5d2b-4c21-b7f4-b05ee5d516f1/.default";
+
+// @public (undocumented)
+export const ApxProductionScope = "5a807f24-c9de-44ee-a3a7-329e88a00ffc/.default";
 
 // @public
 export interface AttachmentData {
@@ -355,15 +389,41 @@ export interface AudioCard {
 
 // @public
 export interface AuthConfiguration {
+    altBlueprintConnectionName?: string;
     authority?: string;
+    authType?: AuthType | string;
+    azureRegion?: string;
     certKeyFile?: string;
     certPemFile?: string;
-    clientId: string;
+    clientId?: string;
     clientSecret?: string;
     connectionName?: string;
+    connections?: Map<string, AuthConfiguration>;
+    connectionsMap?: ConnectionMapItem[];
     FICClientId?: string;
-    issuers: string[];
+    idpmResource?: string;
+    issuers?: string[];
+    // (undocumented)
+    scope?: string;
+    sendX5C?: boolean;
     tenantId?: string;
+    WIDAssertionFile?: string;
+}
+
+// @public (undocumented)
+export interface Authorization {
+    // (undocumented)
+    exchangeToken(context: TurnContext, scopes: string[], authHandlerId: string): Promise<TokenResponse>;
+    // (undocumented)
+    exchangeToken(context: TurnContext, authHandlerId: string, options?: AuthorizationHandlerTokenOptions): Promise<TokenResponse>;
+    // (undocumented)
+    getToken(context: TurnContext, authHandlerId: string): Promise<TokenResponse>;
+    // (undocumented)
+    onSignInFailure(handler: (context: TurnContext, state: TurnState, authHandlerId?: string, errorMessage?: string) => Promise<void>): void;
+    // (undocumented)
+    onSignInSuccess(handler: (context: TurnContext, state: TurnState, authHandlerId?: string) => Promise<void>): void;
+    // (undocumented)
+    signOut(context: TurnContext, state: TurnState, authHandlerId?: string): Promise<void>;
 }
 
 // @public
@@ -371,30 +431,69 @@ export const authorizeJWT: (authConfig: AuthConfiguration) => (req: Request_2, r
 
 // @public
 export interface AuthProvider {
-    getAccessToken: (authConfig: AuthConfiguration, scope: string) => Promise<string>;
+    // (undocumented)
+    acquireTokenOnBehalfOf(scopes: string[], oboAssertion: string): Promise<string>;
+    // (undocumented)
+    acquireTokenOnBehalfOf(authConfig: AuthConfiguration, scopes: string[], oboAssertion: string): Promise<string>;
+    // (undocumented)
+    acquireTokenOnBehalfOf(authConfigOrScopes: AuthConfiguration | string[], scopesOrOboAssertion?: string[] | string, oboAssertion?: string): Promise<string>;
+    connectionSettings?: AuthConfiguration;
+    getAccessToken(authConfig: AuthConfiguration, scope: string): Promise<string>;
+    // (undocumented)
+    getAccessToken(scope: string): Promise<string>;
+    // (undocumented)
+    getAccessToken(authConfigOrScope: AuthConfiguration | string, scope?: string): Promise<string>;
+    getAgenticApplicationToken: (tenantId: string, agentAppInstanceId: string) => Promise<string>;
+    getAgenticInstanceToken: (tenantId: string, agentAppInstanceId: string) => Promise<string>;
+    getAgenticUserToken: (tenantId: string, agentAppInstanceId: string, upn: string, scopes: string[]) => Promise<string>;
 }
 
 // @public
+export enum AuthType {
+    // (undocumented)
+    Certificate = "Certificate",
+    // (undocumented)
+    CertificateSubjectName = "CertificateSubjectName",
+    // (undocumented)
+    ClientSecret = "ClientSecret",
+    // (undocumented)
+    FederatedCredentials = "FederatedCredentials",
+    // (undocumented)
+    IdentityProxyManager = "IdentityProxyManager",
+    // (undocumented)
+    SystemManagedIdentity = "SystemManagedIdentity",
+    // (undocumented)
+    UserManagedIdentity = "UserManagedIdentity",
+    // (undocumented)
+    WorkloadIdentity = "WorkloadIdentity"
+}
+
+// @public
+export const AzureBotScope = "https://api.botframework.com";
+
+// @public
 export abstract class BaseAdapter {
-    readonly AgentIdentityKey: symbol;
-    abstract authConfig: AuthConfiguration;
-    authProvider: AuthProvider;
     readonly ConnectorClientKey: symbol;
-    abstract continueConversation(reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void>;
+    abstract continueConversation(botAppIdOrIdentity: string | JwtPayload, reference: Partial<ConversationReference>, logic: (revocableContext: TurnContext) => Promise<void>): Promise<void>;
     abstract deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void>;
-    abstract getAttachment(attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
-    abstract getAttachmentInfo(attachmentId: string): Promise<AttachmentInfo>;
+    // @deprecated (undocumented)
+    abstract getAttachment(context: TurnContext, attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
+    // @deprecated (undocumented)
+    abstract getAttachmentInfo(context: TurnContext, attachmentId: string): Promise<AttachmentInfo>;
     protected middleware: MiddlewareSet;
-    readonly OAuthScopeKey: symbol;
     get onTurnError(): (context: TurnContext, error: Error) => Promise<void>;
     set onTurnError(value: (context: TurnContext, error: Error) => Promise<void>);
     protected runMiddleware(context: TurnContext, next: (revocableContext: TurnContext) => Promise<void>): Promise<void>;
     abstract sendActivities(context: TurnContext, activities: Activity[]): Promise<ResourceResponse[]>;
     abstract updateActivity(context: TurnContext, activity: Activity): Promise<ResourceResponse | void>;
-    abstract uploadAttachment(conversationId: string, attachmentData: AttachmentData): Promise<ResourceResponse>;
+    // @deprecated (undocumented)
+    abstract uploadAttachment(context: TurnContext, conversationId: string, attachmentData: AttachmentData): Promise<ResourceResponse>;
     use(...middlewares: Array<MiddlewareHandler | Middleware>): this;
-    userTokenClient: UserTokenClient | null;
+    readonly UserTokenClientKey: symbol;
 }
+
+// @public
+export function buildJwksUri(iss: string, authConfig: AuthConfiguration): string;
 
 // @public
 export interface CachedAgentState {
@@ -415,7 +514,7 @@ export class CardFactory {
     static images(images: (CardImage | string)[] | undefined): CardImage[];
     static media(links: (MediaUrl | string)[] | undefined): MediaUrl[];
     static o365ConnectorCard(card: O365ConnectorCard): Attachment;
-    static oauthCard(connectionName: string, title: string, text: string, signingResource: SignInResource): Attachment;
+    static oauthCard(connectionName: string, title: string, text: string, signingResource: SignInResource, enableSso?: boolean): Attachment;
     static receiptCard(card: ReceiptCard): Attachment;
     static signinCard(title: string, url: string, text?: string): Attachment;
     static thumbnailCard(title: string, text?: any, images?: any, buttons?: any, other?: Partial<ThumbnailCard>): Attachment;
@@ -438,50 +537,46 @@ export interface Citation {
 }
 
 // @public
-export interface Claim {
-    // (undocumented)
-    readonly type: string;
-    // (undocumented)
-    readonly value: string;
-}
-
-// @public
-export class ClaimsIdentity {
-    constructor(claims: Claim[], authenticationType?: string | boolean | undefined);
-    // (undocumented)
-    readonly claims: Claim[];
-    getClaimValue(claimType: string): string | null;
-    get isAuthenticated(): boolean;
-}
-
-// @public
 export class CloudAdapter extends BaseAdapter {
     constructor(authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient);
-    // (undocumented)
-    authConfig: AuthConfiguration;
-    connectorClient: ConnectorClient;
-    continueConversation(reference: ConversationReference, logic: (revocableContext: TurnContext) => Promise<void>, isResponse?: Boolean): Promise<void>;
-    protected createConnectorClient(serviceUrl: string, scope: string, headers?: HeaderPropagationCollection): Promise<ConnectorClient>;
+    connectionManager: Connections;
+    continueConversation(botAppIdOrIdentity: string | JwtPayload, reference: ConversationReference, logic: (revocableContext: TurnContext) => Promise<void>, isResponse?: Boolean): Promise<void>;
+    protected createConnectorClient(serviceUrl: string, scope: string, identity: JwtPayload, headers?: HeaderPropagationCollection): Promise<ConnectorClient>;
+    protected createConnectorClientWithIdentity(identity: JwtPayload, activity: Activity, headers?: HeaderPropagationCollection): Promise<ConnectorClient>;
     createConversationAsync(agentAppId: string, channelId: string, serviceUrl: string, audience: string, conversationParameters: ConversationParameters, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     protected createCreateActivity(createdConversationId: string | undefined, channelId: string, serviceUrl: string, conversationParameters: ConversationParameters): Activity;
-    createTurnContext(activity: Activity, logic: AgentHandler): TurnContext;
-    // (undocumented)
-    createTurnContextWithScope(activity: Activity, logic: AgentHandler, scope: string): Promise<TurnContext>;
+    static createIdentity(appId: string): JwtPayload;
+    // @deprecated (undocumented)
+    createTurnContext(activity: Activity, logic: AgentHandler, identity?: JwtPayload): TurnContext;
+    protected createUserTokenClient(identity: JwtPayload, tokenServiceEndpoint?: string, scope?: string, audience?: string, headers?: HeaderPropagationCollection): Promise<UserTokenClient>;
     deleteActivity(context: TurnContext, reference: Partial<ConversationReference>): Promise<void>;
-    getAttachment(attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
-    getAttachmentInfo(attachmentId: string): Promise<AttachmentInfo>;
+    // @deprecated (undocumented)
+    getAttachment(context: TurnContext, attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
+    // @deprecated (undocumented)
+    getAttachmentInfo(context: TurnContext, attachmentId: string): Promise<AttachmentInfo>;
     process(request: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>, headerPropagation?: HeaderPropagationDefinition): Promise<void>;
     protected processTurnResults(context: TurnContext): InvokeResponse | undefined;
-    replyToActivity(activity: Activity): Promise<ResourceResponse>;
     protected resolveIfConnectorClientIsNeeded(activity: Activity): boolean;
     sendActivities(context: TurnContext, activities: Activity[]): Promise<ResourceResponse[]>;
-    protected setConnectorClient(context: TurnContext): void;
+    protected setConnectorClient(context: TurnContext, connectorClient?: ConnectorClient): void;
+    protected setUserTokenClient(context: TurnContext, userTokenClient?: UserTokenClient): void;
     updateActivity(context: TurnContext, activity: Activity): Promise<ResourceResponse | void>;
-    uploadAttachment(conversationId: string, attachmentData: AttachmentData): Promise<ResourceResponse>;
+    // @deprecated (undocumented)
+    uploadAttachment(context: TurnContext, conversationId: string, attachmentData: AttachmentData): Promise<ResourceResponse>;
 }
 
 // @public
 export const configureResponseController: (app: Application, adapter: CloudAdapter, agent: ActivityHandler, conversationState: ConversationState) => void;
+
+// @public (undocumented)
+export interface ConnectionMapItem {
+    // (undocumented)
+    audience?: string;
+    // (undocumented)
+    connection: string;
+    // (undocumented)
+    serviceUrl: string;
+}
 
 // @public
 export class ConnectorClient {
@@ -491,8 +586,9 @@ export class ConnectorClient {
     // (undocumented)
     protected readonly _axiosInstance: AxiosInstance;
     static createClientWithAuth(baseURL: string, authConfig: AuthConfiguration, authProvider: AuthProvider, scope: string, headers?: HeaderPropagationCollection): Promise<ConnectorClient>;
+    static createClientWithToken(baseURL: string, token: string, headers?: HeaderPropagationCollection): ConnectorClient;
     createConversation(body: ConversationParameters): Promise<ConversationResourceResponse>;
-    deleteActivity(conversationId: string, activityId: string): Promise<void>;
+    deleteActivity(conversationId: string, activityId: string, isTargetedActivity?: boolean): Promise<void>;
     getAttachment(attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
     getAttachmentInfo(attachmentId: string): Promise<AttachmentInfo>;
     // (undocumented)
@@ -510,6 +606,45 @@ export class ConsoleTranscriptLogger implements TranscriptLogger {
 }
 
 // @public
+export class Conversation {
+    constructor(context: TurnContext);
+    constructor(claims: ConversationClaims, reference: ConversationReference);
+    // (undocumented)
+    claims: ConversationClaims;
+    get identity(): JwtPayload;
+    // (undocumented)
+    reference: ConversationReference;
+    toJson(): string;
+    validate(): void;
+}
+
+// @public
+export class ConversationBuilder {
+    build(): Conversation;
+    static create(agentClientId: string, channelId: string, serviceUrl?: string, requestorId?: string): ConversationBuilder;
+    static fromContext(context: TurnContext): ConversationBuilder;
+    withActivityId(activityId: string): this;
+    withConversation(account: ConversationAccount): this;
+    withConversationId(id: string): this;
+    withReference(ref: Partial<ConversationReference>): this;
+    withUser(userId: string, userName?: string): this;
+}
+
+// @public
+export interface ConversationClaims {
+    // (undocumented)
+    [key: string]: string | undefined;
+    // (undocumented)
+    appid?: string;
+    // (undocumented)
+    aud: string;
+    // (undocumented)
+    azp?: string;
+    // (undocumented)
+    tid?: string;
+}
+
+// @public
 export interface ConversationData {
     conversationReference: ConversationReference;
     nameRequested: boolean;
@@ -519,6 +654,21 @@ export interface ConversationData {
 export interface ConversationMembers {
     id: string;
     members: ChannelAccount[];
+}
+
+// @public
+export class ConversationReferenceBuilder {
+    build(): ConversationReference;
+    static create(agentClientId: string, channelId: string, serviceUrl?: string): ConversationReferenceBuilder;
+    static serviceUrlForChannel(channelId: string): string;
+    withActivityId(activityId: string): this;
+    withAgent(agentClientId: string, agentName?: string): this;
+    withAgent(account: ChannelAccount): this;
+    withConversationId(id: string): this;
+    withLocale(locale: string): this;
+    withServiceUrl(serviceUrl: string): this;
+    withUser(userId: string, userName?: string): this;
+    withUser(account: ChannelAccount): this;
 }
 
 // @public
@@ -543,6 +693,34 @@ export class ConversationState extends AgentState {
 export type ConversationUpdateEvents = 'membersAdded' | 'membersRemoved';
 
 // @public
+export interface CreateConversationOptions {
+    channelId: string;
+    identity: ConversationClaims;
+    parameters: Partial<ConversationParameters>;
+    scope: string;
+    serviceUrl: string;
+    storeConversation?: boolean;
+}
+
+// @public
+export class CreateConversationOptionsBuilder {
+    build(): CreateConversationOptions;
+    static create(agentClientId: string, channelId: string, serviceUrl?: string, parameters?: Partial<ConversationParameters>): CreateConversationOptionsBuilder;
+    static create(claims: ConversationClaims, channelId: string, serviceUrl?: string, parameters?: Partial<ConversationParameters>): CreateConversationOptionsBuilder;
+    isGroup(value: boolean): this;
+    storeConversation(value: boolean): this;
+    withActivity(activity: Partial<Activity>): this;
+    withChannelData(data: object): this;
+    withScope(scope: string): this;
+    withTeamsChannelId(teamsChannelId: string): this;
+    withTenantId(tenantId: string): this;
+    withTopicName(name: string): this;
+    withUser(userId: string, userName?: string): this;
+    // (undocumented)
+    withUser(account: ChannelAccount): this;
+}
+
+// @public
 export interface CustomKey {
     channelId: string;
     conversationId: string;
@@ -560,6 +738,31 @@ export interface DefaultUserState {
 export type DeleteActivityHandler = (context: TurnContext, reference: ConversationReference, next: () => Promise<void>) => Promise<void>;
 
 // @public
+export function envParser<K extends string>(settings: ParserSettings<K> & ThisType<ParserSettings<K>>): {
+    parse(key: K, value: string): {
+        key?: undefined;
+        value?: undefined;
+    } | {
+        key: string;
+        value: any;
+    };
+};
+
+// @public
+export const envParserUtils: {
+    bypass: (value: string) => {
+        value: string;
+    };
+    redirect: <Parser extends ReturnType<typeof envParser>>(parser: Parser, key: Parameters<Parser["parse"]>[0]) => (value: string) => {
+        key?: undefined;
+        value?: undefined;
+    } | {
+        key: string;
+        value: any;
+    };
+};
+
+// @public
 export interface Fact {
     key: string;
     value: string;
@@ -572,6 +775,9 @@ export class FileStorage implements Storage_2 {
     read(keys: string[]): Promise<StoreItem>;
     write(changes: StoreItem): Promise<void>;
 }
+
+// @public
+export function getAuthConfigWithDefaults(config?: AuthConfiguration): AuthConfiguration;
 
 // @public
 export const getProductInfo: () => string;
@@ -619,6 +825,11 @@ export interface HeroCard {
     title: string;
 }
 
+// @public (undocumented)
+export const HostingErrors: {
+    [key: string]: AgentErrorDefinition;
+};
+
 // @public
 export interface InputFile {
     content: Buffer;
@@ -652,6 +863,13 @@ export const loadAuthConfigFromEnv: (cnxName?: string) => AuthConfiguration;
 
 // @public
 export const loadPrevAuthConfigFromEnv: () => AuthConfiguration;
+
+// @public
+export class M365AttachmentDownloader<TState extends TurnState = TurnState> implements InputFileDownloader<TState> {
+    constructor(stateKey?: string);
+    downloadAndStoreFiles(context: TurnContext, state: TState): Promise<void>;
+    downloadFiles(context: TurnContext): Promise<InputFile[]>;
+}
 
 // @public
 export interface MediaUrl {
@@ -697,6 +915,16 @@ export class MiddlewareSet implements Middleware {
     use(...middlewares: Array<MiddlewareHandler | Middleware>): this;
 }
 
+// @public (undocumented)
+export class MsalConnectionManager implements Connections {
+    constructor(connectionsConfigurations?: Map<string, AuthConfiguration>, connectionsMap?: ConnectionMapItem[], configuration?: AuthConfiguration);
+    getConnection(connectionName: string): MsalTokenProvider;
+    getDefaultConnection(): MsalTokenProvider;
+    getDefaultConnectionConfiguration(): AuthConfiguration;
+    getTokenProvider(identity: JwtPayload, serviceUrl: string): MsalTokenProvider;
+    getTokenProviderFromActivity(identity: JwtPayload, activity: Activity): MsalTokenProvider;
+}
+
 // @public
 export class MsalTokenCredential implements TokenCredential {
     constructor(authConfig: AuthConfiguration);
@@ -708,9 +936,21 @@ export class MsalTokenCredential implements TokenCredential {
 
 // @public
 export class MsalTokenProvider implements AuthProvider {
+    constructor(connectionSettings?: AuthConfiguration);
+    // (undocumented)
+    acquireTokenOnBehalfOf(scopes: string[], oboAssertion: string): Promise<string>;
     // (undocumented)
     acquireTokenOnBehalfOf(authConfig: AuthConfiguration, scopes: string[], oboAssertion: string): Promise<string>;
+    // (undocumented)
+    readonly connectionSettings?: AuthConfiguration;
+    getAccessToken(scope: string): Promise<string>;
     getAccessToken(authConfig: AuthConfiguration, scope: string): Promise<string>;
+    // (undocumented)
+    getAgenticApplicationToken(tenantId: string, agentAppInstanceId: string): Promise<string>;
+    // (undocumented)
+    getAgenticInstanceToken(tenantId: string, agentAppInstanceId: string): Promise<string>;
+    // (undocumented)
+    getAgenticUserToken(tenantId: string, agentAppInstanceId: string, agenticUserId: string, scopes: string[]): Promise<string>;
 }
 
 // @public
@@ -776,6 +1016,28 @@ export interface PagedResult<T> {
 }
 
 // @public
+export class Proactive<TState extends TurnState> {
+    constructor(app: AgentApplication<TState>, options: ProactiveOptions);
+    continueConversation(adapter: BaseAdapter, conversationId: string, handler: RouteHandler<TState>, autoSignInHandlers?: string[], continuationActivity?: Partial<Activity>): Promise<void>;
+    continueConversation(adapter: BaseAdapter, conversation: Conversation, handler: RouteHandler<TState>, autoSignInHandlers?: string[], continuationActivity?: Partial<Activity>): Promise<void>;
+    static readonly ContinueConversationValueType = "application/vnd.microsoft.activity.continueconversation+json";
+    createConversation(adapter: BaseAdapter, createOptions: CreateConversationOptions, handler?: RouteHandler<TState>): Promise<Conversation>;
+    deleteConversation(conversationId: string): Promise<void>;
+    getConversation(conversationId: string): Promise<Conversation | undefined>;
+    getConversationOrThrow(conversationId: string): Promise<Conversation>;
+    sendActivity(adapter: BaseAdapter, conversationId: string, activity: Partial<Activity>): Promise<ResourceResponse>;
+    sendActivity(adapter: BaseAdapter, conversation: Conversation, activity: Partial<Activity>): Promise<ResourceResponse>;
+    storeConversation(context: TurnContext): Promise<string>;
+    storeConversation(conversation: Conversation): Promise<string>;
+}
+
+// @public
+export interface ProactiveOptions {
+    failOnUnsignedInConnections?: boolean;
+    storage?: Storage_2;
+}
+
+// @public
 export interface Query<TParams extends Record<string, any>> {
     count: number;
     parameters: TParams;
@@ -815,6 +1077,9 @@ interface Request_2<Body extends Record<string, unknown> = Record<string, unknow
 export { Request_2 as Request }
 
 // @public
+export function resolveAuthority(authority?: string, tenantId?: string): string;
+
+// @public
 export interface ResourceResponse {
     id: string;
 }
@@ -827,7 +1092,7 @@ export class RouteList<TState extends TurnState> {
     // (undocumented)
     [Symbol.iterator](): Iterator<AppRoute<TState>>;
     // (undocumented)
-    addRoute(selector: RouteSelector, handler: RouteHandler<TState>, isInvokeRoute?: boolean, rank?: number, authHandlers?: string[]): this;
+    addRoute(selector: RouteSelector, handler: RouteHandler<TState>, isInvokeRoute?: boolean, rank?: number, authHandlers?: string[], isAgenticRoute?: boolean): this;
 }
 
 // @public
@@ -923,19 +1188,30 @@ export class StreamingResponse {
     constructor(context: TurnContext);
     get citations(): ClientCitation[] | undefined;
     get delayInMs(): number;
-    endStream(): Promise<void>;
+    endStream(): Promise<StreamingResponseResult>;
     getMessage(): string;
+    get isStreamingChannel(): boolean;
     queueInformativeUpdate(text: string): void;
     queueTextChunk(text: string, citations?: Citation[]): void;
+    reset(): Promise<void>;
     setAttachments(attachments: Attachment[]): void;
     setCitations(citations: Citation[]): void;
     setDelayInMs(delayInMs: number): void;
     setFeedbackLoop(enableFeedbackLoop: boolean): void;
     setFeedbackLoopType(feedbackLoopType: 'default' | 'custom'): void;
+    setFinalMessage(activity: Activity): void;
     setGeneratedByAILabel(enableGeneratedByAILabel: boolean): void;
     setSensitivityLabel(sensitivityLabel: SensitivityUsageInfo): void;
     get streamId(): string | undefined;
     get updatesSent(): number;
+}
+
+// @public
+export enum StreamingResponseResult {
+    AlreadyEnded = "alreadyEnded",
+    Error = "error",
+    Success = "success",
+    UserCanceled = "userCanceled"
 }
 
 // @public
@@ -950,6 +1226,18 @@ export class TaskModuleAction implements CardAction {
     type: string;
     value: unknown;
 }
+
+// @public @deprecated (undocumented)
+export class TeamsAttachmentDownloader extends M365AttachmentDownloader {
+}
+
+// @public
+export const TeamsServiceEndpoints: {
+    readonly publicGlobal: "https://smba.trafficmanager.net/teams/";
+    readonly gcc: "https://smba.infra.gcc.teams.microsoft.com/teams";
+    readonly gccHigh: "https://smba.infra.gov.teams.microsoft.us/teams";
+    readonly dod: "https://smba.infra.dod.teams.microsoft.us/teams";
+};
 
 // @public
 export interface ThumbnailCard {
@@ -975,9 +1263,14 @@ export interface TokenExchangeInvokeRequest {
 }
 
 // @public
-export interface TokenExchangeRequest {
-    connectionName?: string;
+export interface TokenExchangeInvokeResponse {
+    connectionName: string;
+    failureDetail?: string;
     id?: string;
+}
+
+// @public
+export interface TokenExchangeRequest {
     token?: string;
     uri?: string;
 }
@@ -1040,15 +1333,19 @@ export interface TranscriptStore extends TranscriptLogger {
 
 // @public
 export class TurnContext {
-    constructor(adapterOrContext: BaseAdapter, request: Activity);
+    constructor(adapterOrContext: BaseAdapter, request: Activity, identity?: JwtPayload);
     constructor(adapterOrContext: TurnContext);
     get activity(): Activity;
     get adapter(): BaseAdapter;
     readonly bufferedReplyActivities: Activity[];
     protected copyTo(context: TurnContext): void;
     deleteActivity(idOrReference: string | ConversationReference): Promise<void>;
+    // @deprecated (undocumented)
     getAttachment(attachmentId: string, viewId: string): Promise<NodeJS.ReadableStream>;
+    // @deprecated (undocumented)
     getAttachmentInfo(attachmentId: string): Promise<AttachmentInfo>;
+    // (undocumented)
+    get identity(): JwtPayload;
     get locale(): string | undefined;
     set locale(value: string | undefined);
     onDeleteActivity(handler: DeleteActivityHandler): this;
@@ -1063,6 +1360,7 @@ export class TurnContext {
     get streamingResponse(): StreamingResponse;
     get turnState(): TurnContextStateCollection;
     updateActivity(activity: Activity): Promise<void>;
+    // @deprecated (undocumented)
     uploadAttachment(conversationId: string, attachmentData: AttachmentData): Promise<ResourceResponse>;
 }
 
@@ -1108,6 +1406,17 @@ export class TurnStateEntry {
 }
 
 // @public
+export interface TypingOptions extends TypingTimingOptions {
+    channelStrategies?: Record<string, TypingTimingOptions>;
+}
+
+// @public
+export interface TypingTimingOptions {
+    initialDelayMs?: number;
+    intervalMs?: number;
+}
+
+// @public
 export type UpdateActivityHandler = (context: TurnContext, activity: Activity, next: () => Promise<void>) => Promise<void>;
 
 // @public
@@ -1118,15 +1427,17 @@ export class UserState extends AgentState {
 // @public
 export class UserTokenClient {
     constructor(msAppId: string);
+    constructor(axiosInstance: AxiosInstance);
     // (undocumented)
     client: AxiosInstance;
-    exchangeTokenAsync(userId: string, connectionName: string, channelId: string, tokenExchangeRequest: TokenExchangeRequest): Promise<TokenResponse>;
-    getAadTokens(userId: string, connectionName: string, channelId: string, resourceUrls: AadResourceUrls): Promise<Record<string, TokenResponse>>;
+    static createClientWithScope(baseURL: string, authProvider: AuthProvider, scope: string, headers?: HeaderPropagationCollection): Promise<UserTokenClient>;
+    exchangeTokenAsync(userId: string, connectionName: string, channelIdComposite: string, tokenExchangeRequest: TokenExchangeRequest): Promise<TokenResponse>;
+    getAadTokens(userId: string, connectionName: string, channelIdComposite: string, resourceUrls: AadResourceUrls): Promise<Record<string, TokenResponse>>;
     getSignInResource(msAppId: string, connectionName: string, conversation: ConversationReference, relatesTo?: ConversationReference): Promise<SignInResource>;
-    getTokenOrSignInResource(userId: string, connectionName: string, channelId: string, conversation: ConversationReference, relatesTo: ConversationReference, code: string, finalRedirect?: string, fwdUrl?: string): Promise<TokenOrSinginResourceResponse>;
-    getTokenStatus(userId: string, channelId: string, include?: string): Promise<TokenStatus[]>;
-    getUserToken(connectionName: string, channelId: string, userId: string, code?: string): Promise<TokenResponse>;
-    signOut(userId: string, connectionName: string, channelId: string): Promise<void>;
+    getTokenOrSignInResource(userId: string, connectionName: string, channelIdComposite: string, conversation: ConversationReference, relatesTo: ConversationReference, code: string, finalRedirect?: string, fwdUrl?: string): Promise<TokenOrSinginResourceResponse>;
+    getTokenStatus(userId: string, channelIdComposite: string, include?: string): Promise<TokenStatus[]>;
+    getUserToken(connectionName: string, channelIdComposite: string, userId: string, code?: string): Promise<TokenResponse>;
+    signOut(userId: string, connectionName: string, channelIdComposite: string): Promise<void>;
     // (undocumented)
     updateAuthToken(token: string): void;
 }

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -11,6 +11,20 @@ const logger = debug('agents:authConfiguration')
 const DEFAULT_CONNECTION = 'serviceConnection'
 
 /**
+ * Supported authentication types for agent connections.
+ */
+export enum AuthType {
+  Certificate = 'Certificate',
+  CertificateSubjectName = 'CertificateSubjectName',
+  ClientSecret = 'ClientSecret',
+  UserManagedIdentity = 'UserManagedIdentity',
+  SystemManagedIdentity = 'SystemManagedIdentity',
+  FederatedCredentials = 'FederatedCredentials',
+  WorkloadIdentity = 'WorkloadIdentity',
+  IdentityProxyManager = 'IdentityProxyManager'
+}
+
+/**
  * Represents the authentication configuration.
  */
 export interface AuthConfiguration {
@@ -91,6 +105,21 @@ export interface AuthConfiguration {
    */
   WIDAssertionFile?: string
 
+  /**
+   * The authentication type for the connection.
+   */
+  authType?: AuthType | string
+
+  /**
+   * Sets the resource URL for Identity Proxy Manager (IDPM).
+   *
+   * @remarks
+   * Set this to the appropriate resource identifier when the application is running in an environment,
+   * such as a Foundry container, that exposes Managed Identity through a container-specific IMDS endpoint.
+   * This setting is only meaningful when using Identity Proxy Manager (AuthType.IdentityProxyManager) for authentication.
+   */
+
+  idpmResource?: string
   /**
    * The Azure region for ESTS-R regional token acquisition (e.g. 'westus', 'eastus').
    * When set, MSAL routes token requests to the specified regional endpoint.
@@ -203,6 +232,8 @@ export const loadPrevAuthConfigFromEnv: () => AuthConfiguration = () => {
       issuers: getDefaultIssuers(process.env.MicrosoftAppTenantId ?? '', authority),
       altBlueprintConnectionName: process.env.altBlueprintConnectionName,
       WIDAssertionFile: process.env.WIDAssertionFile,
+      authType: process.env.authType,
+      idpmResource: process.env.idpmResource,
       azureRegion: process.env.azureRegion,
     }
     envConnections.connections.set(DEFAULT_CONNECTION, authConfig)
@@ -361,6 +392,8 @@ function buildLegacyAuthConfig (envPrefix: string = '', customConfig?: AuthConfi
     issuers: customConfig?.issuers ?? getDefaultIssuers(tenantId as string, authority),
     altBlueprintConnectionName: customConfig?.altBlueprintConnectionName ?? process.env[`${prefix}altBlueprintConnectionName`],
     WIDAssertionFile: customConfig?.WIDAssertionFile ?? process.env[`${prefix}WIDAssertionFile`],
+    authType: customConfig?.authType ?? process.env[`${prefix}authType`],
+    idpmResource: customConfig?.idpmResource ?? process.env[`${prefix}idpmResource`],
     azureRegion: customConfig?.azureRegion ?? process.env[`${prefix}azureRegion`]
   }
 }

--- a/packages/agents-hosting/src/auth/authConfiguration.ts
+++ b/packages/agents-hosting/src/auth/authConfiguration.ts
@@ -118,8 +118,8 @@ export interface AuthConfiguration {
    * such as a Foundry container, that exposes Managed Identity through a container-specific IMDS endpoint.
    * This setting is only meaningful when using Identity Proxy Manager (AuthType.IdentityProxyManager) for authentication.
    */
-
   idpmResource?: string
+
   /**
    * The Azure region for ESTS-R regional token acquisition (e.g. 'westus', 'eastus').
    * When set, MSAL routes token requests to the specified regional endpoint.

--- a/packages/agents-hosting/src/auth/msalConnectionManager.ts
+++ b/packages/agents-hosting/src/auth/msalConnectionManager.ts
@@ -5,7 +5,7 @@
 
 import { Activity, RoleTypes } from '@microsoft/agents-activity'
 import { debug } from '@microsoft/agents-telemetry'
-import { AuthConfiguration, resolveAuthority } from './authConfiguration'
+import { AuthConfiguration, AuthType, resolveAuthority } from './authConfiguration'
 import { Connections } from './connections'
 import { MsalTokenProvider } from './msalTokenProvider'
 import { JwtPayload } from 'jsonwebtoken'
@@ -50,7 +50,9 @@ export class MsalConnectionManager implements Connections {
           ? 'clientSecret'
           : cfg?.WIDAssertionFile || cfg?.FICClientId
             ? 'workloadIdentity'
-            : 'none'
+            : cfg?.authType === AuthType.IdentityProxyManager
+              ? 'IdentityProxyManager'
+              : 'none'
       logger.debug('connection "%s" clientId=%s tenantId=%s authType=%s', name, cfg?.clientId ?? '<none>', cfg?.tenantId ?? '<none>', authType)
     }
 

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -5,7 +5,7 @@
 
 import { ConfidentialClientApplication, LogLevel, ManagedIdentityApplication, NodeSystemOptions } from '@azure/msal-node'
 import axios from 'axios'
-import { AuthConfiguration, resolveAuthority as resolveAuthorityUtil } from './authConfiguration'
+import { AuthConfiguration, AuthType, resolveAuthority as resolveAuthorityUtil } from './authConfiguration'
 import { AuthProvider } from './authProvider'
 import { debug, trace } from '@microsoft/agents-telemetry'
 import { randomUUID } from 'crypto'
@@ -302,6 +302,31 @@ export class MsalTokenProvider implements AuthProvider {
       throw new Error('Connection settings must be provided when calling getAgenticApplicationToken')
     }
     logger.debug('getAgenticApplicationToken clientId=%s tenantId=%s agentAppInstanceId=%s', this.connectionSettings.clientId, tenantId, agentAppInstanceId)
+
+    if (this.connectionSettings.authType === AuthType.IdentityProxyManager) {
+      let resource
+      if (!this.connectionSettings.idpmResource) {
+        resource = 'api://AzureAdTokenExchange/.default'
+      } else {
+        try {
+          resource = new URL(this.connectionSettings.idpmResource).toString()
+        } catch {
+          throw new Error('IdpmResource must be a valid absolute URI')
+        }
+      }
+      const msiApp = new ManagedIdentityApplication({
+        managedIdentityIdParams: {
+          userAssignedClientId: this.connectionSettings.clientId
+        },
+        system: this.sysOptions
+      })
+      const tokenResult = await msiApp.acquireToken({ resource })
+      if (!tokenResult?.accessToken) {
+        throw new Error(`Failed to acquire token via IdentityProxyManager for agent instance: ${agentAppInstanceId}`)
+      }
+      logger.debug('getAgenticApplicationToken via IdentityProxyManager clientId=%s resource=%s', this.connectionSettings.clientId, resource)
+      return tokenResult.accessToken
+    }
 
     let clientAssertion
 

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -304,15 +304,13 @@ export class MsalTokenProvider implements AuthProvider {
     logger.debug('getAgenticApplicationToken clientId=%s tenantId=%s agentAppInstanceId=%s', this.connectionSettings.clientId, tenantId, agentAppInstanceId)
 
     if (this.connectionSettings.authType === AuthType.IdentityProxyManager) {
-      let resource
+      let resource: string
       if (!this.connectionSettings.idpmResource) {
         resource = 'api://AzureAdTokenExchange/.default'
+      } else if (!URL.canParse(this.connectionSettings.idpmResource)) {
+        throw new Error('idpmResource must be a valid absolute URI')
       } else {
-        try {
-          resource = new URL(this.connectionSettings.idpmResource).toString()
-        } catch {
-          throw new Error('IdpmResource must be a valid absolute URI')
-        }
+        resource = this.connectionSettings.idpmResource
       }
       const msiApp = new ManagedIdentityApplication({
         managedIdentityIdParams: {

--- a/packages/agents-hosting/test/hosting/authConfiguration.test.ts
+++ b/packages/agents-hosting/test/hosting/authConfiguration.test.ts
@@ -18,6 +18,7 @@ describe('AuthConfiguration', () => {
     process.env.connectionName = 'test-connection'
     process.env.FICClientId = 'test-fic-client-id'
     process.env.authorityEndpoint = 'https://login.microsoftonline.com'
+    process.env.idpmResource = 'https://test.uri.com'
     process.env.NODE_ENV = 'development'
   })
 
@@ -42,6 +43,7 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/test-tenant-id/v2.0'
       ])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, 'https://test.uri.com')
     })
 
     it('should throw an error if clientId is not provided in production', () => {
@@ -65,6 +67,7 @@ describe('AuthConfiguration', () => {
       delete process.env.connectionName
       delete process.env.FICClientId
       delete process.env.authorityEndpoint
+      delete process.env.idpmResource
 
       const config = loadAuthConfigFromEnv()
       assert.strictEqual(config.tenantId, undefined)
@@ -79,6 +82,7 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/botframework.com/v2.0'
       ])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, undefined)
     })
   })
 
@@ -92,6 +96,7 @@ describe('AuthConfiguration', () => {
       process.env.myconn_certKeyFile = 'conn-cert.key'
       process.env.myconn_connectionName = 'conn-connection-name'
       process.env.myconn_authorityEndpoint = 'https://login.microsoftonline.com'
+      process.env.myconn_idpmResource = 'https://test.uri.com'
     })
 
     it('should load configuration from connection-specific environment variables', () => {
@@ -109,6 +114,7 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/conn-tenant-id/v2.0'
       ])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, 'https://test.uri.com')
     })
 
     it('should throw an error if connection-specific clientId is not found', () => {
@@ -132,6 +138,7 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/botframework.com/v2.0'
       ])
       assert.deepStrictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, undefined)
     })
   })
 
@@ -142,6 +149,7 @@ describe('AuthConfiguration', () => {
       process.env.MicrosoftAppPassword = 'microsoft-app-password'
       process.env.MicrosoftAppTenantId = 'microsoft-tenant-id'
       process.env.MicrosoftAppClientId = 'microsoft-app-client-id'
+      process.env.idpmResource = 'https://test.uri.com'
     })
 
     it('should load configuration from Microsoft App environment variables', () => {
@@ -159,6 +167,7 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/microsoft-tenant-id/v2.0'
       ])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, 'https://test.uri.com')
     })
 
     it('should throw an error if MicrosoftAppId is not provided in production', () => {
@@ -182,6 +191,7 @@ describe('AuthConfiguration', () => {
       delete process.env.certKeyFile
       delete process.env.connectionName
       delete process.env.authorityEndpoint
+      delete process.env.idpmResource
 
       const config = loadPrevAuthConfigFromEnv()
       assert.strictEqual(config.tenantId, undefined)
@@ -196,12 +206,14 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/botframework.com/v2.0'
       ])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, undefined)
     })
   })
 
   describe('getAuthConfigWithDefaults', () => {
     it('should load configuration with defaults', () => {
       delete process.env.authorityEndpoint
+      delete process.env.idpmResource
 
       const customConfig: AuthConfiguration = {
         clientId: 'custom-test-client',
@@ -221,12 +233,14 @@ describe('AuthConfiguration', () => {
       assert.deepStrictEqual(config.issuers, ['https://example.com'])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
       assert.strictEqual(config.altBlueprintConnectionName, 'blue-connection')
+      assert.strictEqual(config.idpmResource, undefined)
       assert.strictEqual(config.connections?.size, 1)
       assert.strictEqual(config.connectionsMap?.length, 1)
     })
 
     it('should load configuration with connections', () => {
       delete process.env.authorityEndpoint
+      delete process.env.idpmResource
 
       const connections = new Map<string, AuthConfiguration>()
       connections.set('test-conn', { clientId: 'custom-test-client', clientSecret: 'custom-test-secret', tenantId: 'custom-test-tenant' })
@@ -245,6 +259,7 @@ describe('AuthConfiguration', () => {
       assert.strictEqual(config.FICClientId, 'test-fic-client-id')
       assert.deepStrictEqual(config.issuers?.length, 3)
       assert.strictEqual(config.authority, 'https://login.microsoftonline.com')
+      assert.strictEqual(config.idpmResource, undefined)
       assert.strictEqual(config.altBlueprintConnectionName, undefined)
       assert.strictEqual(config.connections?.size, 1)
       assert.strictEqual(config.connectionsMap?.length, 1)
@@ -253,6 +268,7 @@ describe('AuthConfiguration', () => {
 
     it('should load from env with defaults', () => {
       delete process.env.authorityEndpoint
+      delete process.env.idpmResource
 
       const config: AuthConfiguration = getAuthConfigWithDefaults()
       assert.strictEqual(config.tenantId, 'test-tenant-id')
@@ -269,6 +285,7 @@ describe('AuthConfiguration', () => {
         'https://login.microsoftonline.com/test-tenant-id/v2.0'
       ])
       assert.strictEqual(config.altBlueprintConnectionName, undefined)
+      assert.strictEqual(config.idpmResource, undefined)
       assert.strictEqual(config.connections?.size, 1)
       assert.strictEqual(config.connectionsMap?.length, 1)
     })
@@ -357,7 +374,8 @@ describe('AuthConfiguration', () => {
         connectionName: 'test-connection',
         FICClientId: 'fic-client',
         issuers: ['https://example.com'],
-        authority: 'https://login.microsoftonline.us'
+        authority: 'https://login.microsoftonline.us',
+        idpmResource: 'https://test.uri.com'
       }
 
       assert.strictEqual(config.tenantId, 'test-tenant')
@@ -369,6 +387,7 @@ describe('AuthConfiguration', () => {
       assert.strictEqual(config.FICClientId, 'fic-client')
       assert.deepStrictEqual(config.issuers, ['https://example.com'])
       assert.strictEqual(config.authority, 'https://login.microsoftonline.us')
+      assert.strictEqual(config.idpmResource, 'https://test.uri.com')
     })
 
     it('should allow creating minimal AuthConfiguration with only required fields', () => {

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -733,7 +733,7 @@ describe('MsalTokenProvider', () => {
     try {
       await assert.rejects(
         tokenProvider.getAgenticApplicationToken('agentic-tenant-id', 'agent-app-instance-id'),
-        /IdpmResource must be a valid absolute URI/
+        /idpmResource must be a valid absolute URI/
       )
     } finally {
       sinon.restore()

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from 'assert'
 import { describe, it, beforeEach } from 'node:test'
 import sinon from 'sinon'
-import { ConfidentialClientApplication, ManagedIdentityApplication } from '@azure/msal-node'
-import { MsalTokenProvider, ConnectorClient, AuthConfiguration, CloudAdapter } from '../../src'
+import { AuthenticationResult, ConfidentialClientApplication, ManagedIdentityApplication } from '@azure/msal-node'
+import { MsalTokenProvider, ConnectorClient, AuthConfiguration, CloudAdapter, AuthType } from '../../src'
 import fs from 'fs'
 import crypto from 'crypto'
 import axios from 'axios'
@@ -656,6 +656,86 @@ describe('MsalTokenProvider', () => {
     } finally {
       // @ts-ignore
       tokenProvider._agenticTokenCache.destroy()
+      sinon.restore()
+    }
+  })
+
+  it('should acquire agentic application token via IdentityProxyManager with custom resource', async () => {
+    sinon.restore()
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      authType: AuthType.IdentityProxyManager,
+      idpmResource: 'https://custom-resource/.default',
+    })
+
+    const acquireTokenStub = sinon.stub(ManagedIdentityApplication.prototype, 'acquireToken').resolves({ accessToken: 'idpm-custom-token' } as AuthenticationResult)
+
+    try {
+      const token = await tokenProvider.getAgenticApplicationToken('agentic-tenant-id', 'agent-app-instance-id')
+
+      assert.strictEqual(token, 'idpm-custom-token')
+      assert.strictEqual(acquireTokenStub.called, true)
+      const requestArg = acquireTokenStub.getCall(0).args[0] as any
+      assert.strictEqual(requestArg.resource, 'https://custom-resource/.default', 'should use custom idpmResource')
+    } finally {
+      sinon.restore()
+    }
+  })
+
+  it('should acquire agentic application token via IdentityProxyManager with default resource', async () => {
+    sinon.restore()
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      authType: AuthType.IdentityProxyManager,
+    })
+
+    const acquireTokenStub = sinon.stub(ManagedIdentityApplication.prototype, 'acquireToken').resolves({ accessToken: 'idpm-custom-token' } as AuthenticationResult)
+
+    try {
+      const token = await tokenProvider.getAgenticApplicationToken('agentic-tenant-id', 'agent-app-instance-id')
+
+      assert.strictEqual(token, 'idpm-custom-token')
+      assert.strictEqual(acquireTokenStub.called, true)
+      const requestArg = acquireTokenStub.getCall(0).args[0] as any
+      assert.strictEqual(requestArg.resource, 'api://AzureAdTokenExchange/.default', 'should use default idpmResource')
+    } finally {
+      sinon.restore()
+    }
+  })
+
+  it('should throw when IdentityProxyManager fails to acquire token', async () => {
+    sinon.restore()
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      authType: AuthType.IdentityProxyManager,
+      idpmResource: 'api://AzureAdTokenExchange/.default',
+    })
+
+    sinon.stub(ManagedIdentityApplication.prototype, 'acquireToken').resolves(undefined)
+
+    try {
+      await assert.rejects(
+        tokenProvider.getAgenticApplicationToken('agentic-tenant-id', 'agent-app-instance-id'),
+        /Failed to acquire token via IdentityProxyManager/
+      )
+    } finally {
+      sinon.restore()
+    }
+  })
+  it('should throw when idpmResource is not a valid absolute URI', async () => {
+    sinon.restore()
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      authType: AuthType.IdentityProxyManager,
+      idpmResource: 'not-a-valid-uri',
+    })
+
+    try {
+      await assert.rejects(
+        tokenProvider.getAgenticApplicationToken('agentic-tenant-id', 'agent-app-instance-id'),
+        /IdpmResource must be a valid absolute URI/
+      )
+    } finally {
       sinon.restore()
     }
   })


### PR DESCRIPTION
Fixes # 1105

## Description
This pull request adds support for a new authentication type, Identity Proxy Manager, to the agent hosting authentication system. 
It also introduces the `AuthType` enum, but updates the code to use only the new type, as the extended use of this enum is ready in PR # 1079.

**Authentication system enhancements:**

* Added the `AuthType` enum to represent supported authentication types, including the new `IdentityProxyManager` value. (`authConfiguration.ts`)
* Extended the `AuthConfiguration` interface to include the `authType` and `idpmResource` fields, allowing configuration of the Identity Proxy Manager authentication flow. (`authConfiguration.ts`)
* Updated configuration loading functions to read `authType` and `idpmResource` from environment variables and custom config objects. (`authConfiguration.ts`) [[1]](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6R235-R236) [[2]](diffhunk://#diff-5a028c0bf62fd6c9efc8d4189377cfe0f67ad3cec6156b6734cd51c8b94246c6R395-R396)

**Authentication flow updates:**

* Modified `MsalConnectionManager` and `MsalTokenProvider` to recognize and handle the `IdentityProxyManager` authentication type, including acquiring tokens using the specified resource URI. (`msalConnectionManager.ts`, `msalTokenProvider.ts`) [[1]](diffhunk://#diff-ca160782efd37355d71da0a190b2f006de2298a5d0c81fad33b74b1c3218578dL8-R8) [[2]](diffhunk://#diff-ca160782efd37355d71da0a190b2f006de2298a5d0c81fad33b74b1c3218578dR53-R54) [[3]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L8-R8) [[4]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4R306-R330)

**Testing improvements:**

* Updated and expanded tests to verify correct handling of the new `idpmResource` and `authType` fields in various configuration scenarios, ensuring proper loading, overriding, and cleanup of environment variables. (`authConfiguration.test.ts`, `msalTokenProvider.test.ts`) [[1]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R21) [[2]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R46) [[3]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R70) [[4]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R85) [[5]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R99) [[6]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R117) [[7]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R141) [[8]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R152) [[9]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R170) [[10]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R194) [[11]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R209-R216) [[12]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R236-R243) [[13]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R262) [[14]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R271) [[15]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R288) [[16]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894L360-R378) [[17]](diffhunk://#diff-690f3a8e8aeccf94d3d427bd572541cdf7f02e5b25c4afd695677534ec491894R390) [[18]](diffhunk://#diff-8d4f6a317db5468a07c4c51d2962b329c246af1849ab018f886a5fec85a501d7L4-R5)

## Testing
These images show the token successfully retrieve for the _IdentityProxyManager_ auth type.
<img width="1613" height="1362" alt="image" src="https://github.com/user-attachments/assets/991b529a-2f86-4d97-b738-d622860c2134" />
