### PR TITLE
OTel: Add Span Links to proactive operations

### DIFF
--- a/packages/agents-hosting/src/app/proactive/proactive.ts
+++ b/packages/agents-hosting/src/app/proactive/proactive.ts
@@ -116,8 +116,11 @@ export class Proactive<TState extends TurnState> {
 
       conv.validate()
       const id = conv.reference.conversation.id
+      const storage = this.requireStorage()
+      const key = this._storageKey(id)
       record({ conversationId: id })
-      await actions.link(this.requireStorage(), this._storageKey(id), { reference: conv.reference, claims: conv.claims })
+      const linkedItem = await actions.link(storage, key)
+      await storage.write({ [key]: { ...linkedItem, reference: conv.reference, claims: conv.claims } })
       return id
     })
   }

--- a/packages/agents-hosting/src/app/proactive/proactive.ts
+++ b/packages/agents-hosting/src/app/proactive/proactive.ts
@@ -49,6 +49,10 @@ export class Proactive<TState extends TurnState> {
     this._storage = options.storage
   }
 
+  private _storageKey (conversationId: string): string {
+    return `${STORAGE_KEY_PREFIX}${conversationId}`
+  }
+
   private requireStorage (): Storage {
     if (!this._storage) {
       throw ExceptionHelper.generateException(Error, Errors.ProactiveStorageRequired)
@@ -104,7 +108,7 @@ export class Proactive<TState extends TurnState> {
    */
   storeConversation (conversation: Conversation): Promise<string>
   async storeConversation (contextOrConversation: TurnContext | Conversation): Promise<string> {
-    return trace(ProactiveTraceDefinitions.storeConversation, async ({ record }) => {
+    return trace(ProactiveTraceDefinitions.storeConversation, async ({ record, actions }) => {
       const conv =
         contextOrConversation instanceof Conversation
           ? contextOrConversation
@@ -113,7 +117,7 @@ export class Proactive<TState extends TurnState> {
       conv.validate()
       const id = conv.reference.conversation.id
       record({ conversationId: id })
-      await this.requireStorage().write({ [`${STORAGE_KEY_PREFIX}${id}`]: { reference: conv.reference, claims: conv.claims } })
+      await actions.link(this.requireStorage(), this._storageKey(id), { reference: conv.reference, claims: conv.claims })
       return id
     })
   }
@@ -134,8 +138,8 @@ export class Proactive<TState extends TurnState> {
   async getConversation (conversationId: string): Promise<Conversation | undefined> {
     return trace(ProactiveTraceDefinitions.getConversation, async ({ record }) => {
       record({ conversationId })
-      const result = await this.requireStorage().read([`${STORAGE_KEY_PREFIX}${conversationId}`])
-      const stored = result[`${STORAGE_KEY_PREFIX}${conversationId}`] as { reference: any; claims: any } | undefined
+      const storageKey = this._storageKey(conversationId)
+      const stored = (await this.requireStorage().read([storageKey]))?.[storageKey]
       if (!stored) {
         record({ found: false })
         return undefined
@@ -186,7 +190,7 @@ export class Proactive<TState extends TurnState> {
   async deleteConversation (conversationId: string): Promise<void> {
     return trace(ProactiveTraceDefinitions.deleteConversation, async ({ record }) => {
       record({ conversationId })
-      await this.requireStorage().delete([`${STORAGE_KEY_PREFIX}${conversationId}`])
+      await this.requireStorage().delete([this._storageKey(conversationId)])
     })
   }
 
@@ -231,22 +235,22 @@ export class Proactive<TState extends TurnState> {
     conversationOrId: Conversation | string,
     activity: Partial<Activity>
   ): Promise<ResourceResponse> {
-    return trace(ProactiveTraceDefinitions.sendActivity, async ({ record }) => {
-      const conv =
-        typeof conversationOrId === 'string'
-          ? await this.getConversationOrThrow(conversationOrId)
-          : conversationOrId
+    return trace(ProactiveTraceDefinitions.sendActivity, async ({ record, actions }) => {
+      const conv = typeof conversationOrId === 'string'
+        ? await this.getConversationOrThrow(conversationOrId)
+        : conversationOrId
 
+      const id = conv.reference.conversation.id
       const activityToSend: Partial<Activity> = { type: 'message', ...activity }
 
       record({
-        conversationId: conv.reference.conversation.id,
+        conversationId: id,
         channelId: conv.reference.channelId,
         activityType: activityToSend.type ?? 'message',
       })
 
       logger.info('sendActivity: conversation=%s channel=%s serviceUrl=%s',
-        conv.reference.conversation.id, conv.reference.channelId, conv.reference.serviceUrl)
+        id, conv.reference.channelId, conv.reference.serviceUrl)
 
       let response: ResourceResponse | undefined
       let caughtError: unknown
@@ -261,7 +265,7 @@ export class Proactive<TState extends TurnState> {
       })
 
       if (caughtError !== undefined) {
-        logger.warn('sendActivity: failed for conversation=%s: %s', conv.reference.conversation.id, caughtError)
+        logger.warn('sendActivity: failed for conversation=%s: %s', id, caughtError)
         throw caughtError
       }
       if (response === undefined) throw ExceptionHelper.generateException(Error, Errors.ProactiveSendActivityNoResponse)
@@ -345,20 +349,22 @@ export class Proactive<TState extends TurnState> {
     autoSignInHandlers?: string[],
     continuationActivity?: Partial<Activity>
   ): Promise<void> {
-    return trace(ProactiveTraceDefinitions.continueConversation, async ({ record }) => {
-      const conv =
-        typeof conversationOrId === 'string'
-          ? await this.getConversationOrThrow(conversationOrId)
-          : conversationOrId
+    return trace(ProactiveTraceDefinitions.continueConversation, async ({ record, actions }) => {
+      const conv = typeof conversationOrId === 'string'
+        ? await this.getConversationOrThrow(conversationOrId)
+        : conversationOrId
+
+      const id = conv.reference.conversation.id
 
       record({
-        conversationId: conv.reference.conversation.id,
+        conversationId: id,
         channelId: conv.reference.channelId,
         hasAutoSignIn: !!autoSignInHandlers?.length,
       })
+      await actions.link(this.requireStorage(), this._storageKey(id))
 
       logger.info('continueConversation: conversation=%s channel=%s serviceUrl=%s',
-        conv.reference.conversation.id, conv.reference.channelId, conv.reference.serviceUrl)
+        id, conv.reference.channelId, conv.reference.serviceUrl)
 
       let caughtError: unknown
 
@@ -384,7 +390,7 @@ export class Proactive<TState extends TurnState> {
             const allAcquired = results.every((r) => !!r.token)
             if (!allAcquired) {
               logger.warn('continueConversation: not all tokens acquired for conversation=%s handlers=%o',
-                conv.reference.conversation.id, autoSignInHandlers)
+                id, autoSignInHandlers)
               if (this._options.failOnUnsignedInConnections !== false) {
                 throw ExceptionHelper.generateException(Error, Errors.ProactiveNotAllTokensAcquired)
               }
@@ -403,10 +409,10 @@ export class Proactive<TState extends TurnState> {
       })
 
       if (caughtError !== undefined) {
-        logger.warn('continueConversation: failed for conversation=%s: %s', conv.reference.conversation.id, caughtError)
+        logger.warn('continueConversation: failed for conversation=%s: %s', id, caughtError)
         throw caughtError
       }
-      logger.debug('continueConversation: complete for conversation=%s', conv.reference.conversation.id)
+      logger.debug('continueConversation: complete for conversation=%s', id)
     })
   }
 

--- a/packages/agents-hosting/src/app/proactive/proactive.ts
+++ b/packages/agents-hosting/src/app/proactive/proactive.ts
@@ -248,6 +248,7 @@ export class Proactive<TState extends TurnState> {
         channelId: conv.reference.channelId,
         activityType: activityToSend.type ?? 'message',
       })
+      await actions.link(this.requireStorage(), this._storageKey(id))
 
       logger.info('sendActivity: conversation=%s channel=%s serviceUrl=%s',
         id, conv.reference.channelId, conv.reference.serviceUrl)

--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -5,6 +5,7 @@ import { SpanNames, trace } from '@microsoft/agents-telemetry'
 import { HostingMetrics } from './metrics'
 import { Activity, ConversationReference } from '@microsoft/agents-activity'
 import { HandlerStorage } from '../app/auth/handlerStorage'
+import type { Storage } from '../storage'
 
 export const AgentApplicationTraceDefinitions = {
   run: trace.define({
@@ -259,6 +260,12 @@ export const ProactiveTraceDefinitions = {
     record: {
       conversationId: '',
     },
+    actions: ({ span }) => ({
+      async link (storage: Storage, key: string, data: any) {
+        const item = (await storage.read([key]))?.[key] ?? {}
+        await storage.write({ [key]: { ...item, ...data, ...link(span) } })
+      }
+    }),
     end ({ span, record }) {
       span.setAttributes({
         'activity.conversation_id': record.conversationId ?? 'unknown',
@@ -335,6 +342,12 @@ export const ProactiveTraceDefinitions = {
       channelId: '',
       hasAutoSignIn: false,
     },
+    actions: ({ span }) => ({
+      async link (storage: Storage, key: string) {
+        const item = (await storage.read([key]))?.[key] ?? {}
+        link(span, item)
+      }
+    }),
     end ({ span, record, duration, error }) {
       const attributes = {
         'activity.channel_id': record.channelId ?? 'unknown',
@@ -783,12 +796,7 @@ export const AuthorizationTraceDefinitions = {
           return
         }
 
-        if (active.__link) {
-          span.addLink({ context: active.__link })
-        }
-
-        active.__link = span.spanContext()
-        await storage.write(active)
+        await storage.write(link(span, active))
       }
     }),
     end ({ span, record }) {
@@ -985,4 +993,21 @@ export const UserTokenClientTraceDefinitions = {
       HostingMetrics.userTokenClientRequestDuration.record(duration, attributes)
     }
   }),
+}
+
+/**
+ * Adds a link to the span in the item and returns the updated item with the new link context.
+ * @remarks
+ * - **Parent to child**: use the returned item to 'link' future child spans.
+ * - **Parent to children**: use the original item  to 'link' future child spans. Ignore the returned item.
+ */
+function link <T extends { __link?: unknown }> (span: any, item?: T) {
+  if (item?.__link) {
+    span.addLink({ context: item.__link })
+  }
+
+  return {
+    ...(item ?? {}),
+    __link: span.spanContext()
+  } as T
 }

--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -314,6 +314,12 @@ export const ProactiveTraceDefinitions = {
       channelId: '',
       activityType: '',
     },
+    actions: ({ span }) => ({
+      async link (storage: Storage, key: string) {
+        const item = (await storage.read([key]))?.[key] ?? {}
+        link(span, item)
+      }
+    }),
     end ({ span, record, duration, error }) {
       const attributes = {
         'activity.channel_id': record.channelId ?? 'unknown',

--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -261,9 +261,9 @@ export const ProactiveTraceDefinitions = {
       conversationId: '',
     },
     actions: ({ span }) => ({
-      async link (storage: Storage, key: string, data: any) {
+      async link (storage: Storage, key: string) {
         const item = (await storage.read([key]))?.[key] ?? {}
-        await storage.write({ [key]: { ...item, ...data, ...link(span) } })
+        return link(span, item)
       }
     }),
     end ({ span, record }) {


### PR DESCRIPTION
Fixes # 1113

This pull request refactors how conversation storage keys are generated and used in the `Proactive` class, and introduces improved span linking for observability and tracing. The main changes focus on encapsulating storage key computation, standardizing trace action handling, and enhancing span linking logic to support better distributed tracing across storage and activity operations.

Key improvements include:

**Storage Key Handling and Proactive API Refactoring**
- Introduced a private `_storageKey` method in the `Proactive` class to standardize and encapsulate the generation of storage keys for conversations, replacing repeated string interpolation throughout the code.
- Updated all `storeConversation`, `getConversation`, and `deleteConversation` methods in `Proactive` to use the new `_storageKey` method for consistent storage access. [[1]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L116-R120) [[2]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L137-R142) [[3]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L189-R193)
- Modified the tracing logic in `storeConversation`, `sendActivity`, and `continueConversation` to utilize new `actions` provided by the trace definitions, improving consistency and enabling enhanced span linking. [[1]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L107-R111) [[2]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L234-R253) [[3]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L348-R367)

**Observability and Tracing Enhancements**
- Added `actions.link` to `ProactiveTraceDefinitions` for both storing and continuing conversations, enabling automatic linking of storage and activity spans for better distributed traceability. [[1]](diffhunk://#diff-28bde2a2893f06680f902717f3b8850ffbeecc8996b22b66b97fbd4d6b091faeR263-R268) [[2]](diffhunk://#diff-28bde2a2893f06680f902717f3b8850ffbeecc8996b22b66b97fbd4d6b091faeR345-R350)
- Refactored the `link` utility function to add span links and store the span context in the storage item, supporting both parent-to-child and parent-to-children trace relationships. This function is now used in both proactive and authorization trace actions. [[1]](diffhunk://#diff-28bde2a2893f06680f902717f3b8850ffbeecc8996b22b66b97fbd4d6b091faeR997-R1013) [[2]](diffhunk://#diff-28bde2a2893f06680f902717f3b8850ffbeecc8996b22b66b97fbd4d6b091faeL786-R799)

**Type and Import Cleanups**
- Added an explicit type import for `Storage` in the observability traces module to clarify usage and improve type safety.

**Logging Consistency**
- Standardized logging statements in `sendActivity` and `continueConversation` to use the extracted conversation ID variable, improving readability and maintainability. [[1]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L234-R253) [[2]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L264-R268) [[3]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L387-R393) [[4]](diffhunk://#diff-a8a987df9e2d711b320aefd51679aa8584fccb81199752695630eda18338b3b6L406-R415)

**Testing**
The following image shows the proactive traces.
<img width="1929" height="737" alt="imagen" src="https://github.com/user-attachments/assets/2f00dd63-78a7-477a-bee5-8d30578be71c" />

