### PR TITLE
[#1124] Replace axios with native fetch - samples and docs

### DIFF
--- a/compat/baseline/agents-hosting.api.md
+++ b/compat/baseline/agents-hosting.api.md
@@ -9,7 +9,6 @@ import { AdaptiveCardInvokeAction } from '@microsoft/agents-activity';
 import { AgentErrorDefinition } from '@microsoft/agents-activity';
 import { Application } from 'express';
 import { Attachment } from '@microsoft/agents-activity';
-import { AxiosInstance } from 'axios';
 import { CardAction } from '@microsoft/agents-activity';
 import { ChannelAccount } from '@microsoft/agents-activity';
 import { ClientCitation } from '@microsoft/agents-activity';
@@ -400,6 +399,7 @@ export interface AuthConfiguration {
     connectionName?: string;
     connections?: Map<string, AuthConfiguration>;
     connectionsMap?: ConnectionMapItem[];
+    federatedTokenFile?: string;
     FICClientId?: string;
     idpmResource?: string;
     issuers?: string[];
@@ -407,6 +407,7 @@ export interface AuthConfiguration {
     scope?: string;
     sendX5C?: boolean;
     tenantId?: string;
+    // @deprecated
     WIDAssertionFile?: string;
 }
 
@@ -580,11 +581,7 @@ export interface ConnectionMapItem {
 
 // @public
 export class ConnectorClient {
-    protected constructor(axInstance: AxiosInstance);
-    // (undocumented)
-    get axiosInstance(): AxiosInstance;
-    // (undocumented)
-    protected readonly _axiosInstance: AxiosInstance;
+    protected constructor(httpClient: HttpClient);
     static createClientWithAuth(baseURL: string, authConfig: AuthConfiguration, authProvider: AuthProvider, scope: string, headers?: HeaderPropagationCollection): Promise<ConnectorClient>;
     static createClientWithToken(baseURL: string, token: string, headers?: HeaderPropagationCollection): ConnectorClient;
     createConversation(body: ConversationParameters): Promise<ConversationResourceResponse>;
@@ -594,6 +591,10 @@ export class ConnectorClient {
     // (undocumented)
     getConversationMember(userId: string, conversationId: string): Promise<ChannelAccount>;
     getConversations(continuationToken?: string): Promise<ConversationsResult>;
+    // (undocumented)
+    get httpClient(): HttpClient;
+    // (undocumented)
+    protected readonly _httpClient: HttpClient;
     replyToActivity(conversationId: string, activityId: string, body: Activity): Promise<ResourceResponse>;
     sendToConversation(conversationId: string, body: Activity): Promise<ResourceResponse>;
     updateActivity(conversationId: string, activityId: string, body: Activity): Promise<ResourceResponse>;
@@ -829,6 +830,81 @@ export interface HeroCard {
 export const HostingErrors: {
     [key: string]: AgentErrorDefinition;
 };
+
+// @public
+export class HttpClient {
+    constructor(options?: HttpClientOptions);
+    // (undocumented)
+    get baseURL(): string;
+    // (undocumented)
+    get defaultHeaders(): Record<string, string>;
+    set defaultHeaders(headers: Record<string, string>);
+    // (undocumented)
+    delete<T = unknown>(url: string, options?: Partial<HttpRequestConfig>): Promise<HttpResponse<T>>;
+    // (undocumented)
+    get<T = unknown>(url: string, options?: Partial<HttpRequestConfig>): Promise<HttpResponse<T>>;
+    // (undocumented)
+    post<T = unknown>(url: string, data?: unknown, options?: Partial<HttpRequestConfig>): Promise<HttpResponse<T>>;
+    // (undocumented)
+    put<T = unknown>(url: string, data?: unknown, options?: Partial<HttpRequestConfig>): Promise<HttpResponse<T>>;
+    // (undocumented)
+    removeHeader(name: string): void;
+    // (undocumented)
+    request<T = unknown>(config: HttpRequestConfig): Promise<HttpResponse<T>>;
+    // (undocumented)
+    setHeader(name: string, value: string): void;
+}
+
+// @public
+export interface HttpClientOptions {
+    // (undocumented)
+    baseURL?: string;
+    // (undocumented)
+    headers?: Record<string, string>;
+}
+
+// @public
+export class HttpError extends Error {
+    constructor(message: string, response: HttpResponse, config: HttpRequestConfig);
+    // (undocumented)
+    readonly config: HttpRequestConfig;
+    // (undocumented)
+    readonly response: HttpResponse;
+    // (undocumented)
+    readonly status: number;
+    // (undocumented)
+    toJSON(): Record<string, unknown>;
+}
+
+// @public
+export interface HttpRequestConfig {
+    // (undocumented)
+    data?: unknown;
+    // (undocumented)
+    headers?: Record<string, string>;
+    // (undocumented)
+    method: string;
+    // (undocumented)
+    params?: Record<string, string | undefined>;
+    // (undocumented)
+    responseType?: 'json' | 'arraybuffer' | 'stream';
+    // (undocumented)
+    url: string;
+}
+
+// @public
+export interface HttpResponse<T = unknown> {
+    // (undocumented)
+    config: HttpRequestConfig;
+    // (undocumented)
+    data: T;
+    // (undocumented)
+    headers: Headers;
+    // (undocumented)
+    status: number;
+    // (undocumented)
+    statusText: string;
+}
 
 // @public
 export interface InputFile {
@@ -1427,9 +1503,9 @@ export class UserState extends AgentState {
 // @public
 export class UserTokenClient {
     constructor(msAppId: string);
-    constructor(axiosInstance: AxiosInstance);
+    constructor(httpClient: HttpClient);
     // (undocumented)
-    client: AxiosInstance;
+    client: HttpClient;
     static createClientWithScope(baseURL: string, authProvider: AuthProvider, scope: string, headers?: HeaderPropagationCollection): Promise<UserTokenClient>;
     exchangeTokenAsync(userId: string, connectionName: string, channelIdComposite: string, tokenExchangeRequest: TokenExchangeRequest): Promise<TokenResponse>;
     getAadTokens(userId: string, connectionName: string, channelIdComposite: string, resourceUrls: AadResourceUrls): Promise<Record<string, TokenResponse>>;

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -24,8 +24,6 @@
     ".": {
       "project": ["*.{js,mjs,ts}"],
       "ignoreDependencies": [
-        // Samples are built from the root tsconfig, but knip does not model them as a root package.
-        "axios",
         "@microsoft/microsoft-graph-client",
         "@microsoft/microsoft-graph-types"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/express": "5.0.6",
         "@types/node": "25.6.0",
         "@types/sinon": "21.0.0",
-        "axios": "1.17.0",
         "esbuild": "0.27.3",
         "eslint": "9.39.2",
         "knip": "5.86.0",
@@ -2517,12 +2516,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "dev": true,
@@ -2535,43 +2528,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -2757,18 +2713,6 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2959,15 +2903,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -3193,6 +3128,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3948,26 +3884,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "dev": true,
@@ -3980,43 +3896,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/formatly": {
@@ -4293,6 +4172,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6160,15 +6040,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -7827,7 +7698,6 @@
       "dependencies": {
         "@microsoft/agents-activity": "file:../../packages/agents-activity",
         "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
-        "axios": "1.17.0",
         "express": "5.2.1",
         "express-rate-limit": "8.5.2"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@types/express": "5.0.6",
     "@types/node": "25.6.0",
     "@types/sinon": "21.0.0",
-    "axios": "1.17.0",
     "esbuild": "0.27.3",
     "eslint": "9.39.2",
     "knip": "5.86.0",

--- a/packages/agents-hosting-directline-namedpipes/src/createLocalAdapter.ts
+++ b/packages/agents-hosting-directline-namedpipes/src/createLocalAdapter.ts
@@ -235,7 +235,7 @@ class LocalPipeAdapter extends CloudAdapter {
    * which uses ConnectorClient over HTTP.
    *
    * Without this override the base implementation would try to use the
-   * ConnectorClient (axios) against a `urn:botframework:namedpipe:` baseURL
+   * ConnectorClient against a `urn:botframework:namedpipe:` baseURL
    * and fail with a confusing "Invalid URL" / `ECONNREFUSED`.
    */
   override async updateActivity (context: TurnContext, activity: Activity): Promise<ResourceResponse | void> {

--- a/samples/basic/typeAheadSearch.ts
+++ b/samples/basic/typeAheadSearch.ts
@@ -1,13 +1,5 @@
-import axios from 'axios'
 import { startServer } from '@microsoft/agents-hosting-express'
 import { AdaptiveCardSearchResult, AgentApplication, CardFactory, MemoryStorage, MessageFactory, TurnContext, TurnState } from '@microsoft/agents-hosting'
-
-interface packageResult {
-  package: {
-    name: string
-    description: string
-  }
-}
 
 const app = new AgentApplication<TurnState>({ storage: new MemoryStorage() })
 app.onConversationUpdate('membersAdded', async (context: TurnContext) => {
@@ -26,14 +18,15 @@ app.adaptiveCards.search('', async (context: TurnContext, state: TurnState) => {
     if (searchQuery.lengh < 4) {
       return []
     }
-    const params = { text: searchQuery, size: 8 }
-    const response = await axios.get('http://registry.npmjs.com/-/v1/search?', { params })
+    const params = new URLSearchParams({ text: searchQuery, size: '8' })
+    const response = await fetch(`http://registry.npmjs.com/-/v1/search?${params.toString()}`)
 
-    const npmPackages: AdaptiveCardSearchResult[] = response.data.objects.map((obj: packageResult) => ({
-      title: obj.package.name,
-      value: `${obj.package.name} - ${obj.package.description}`
-    }))
     if (response.status === 200) {
+      const data = await response.json() as any
+      const npmPackages = data.objects.map((obj: any) => ({
+        title: obj.package.name,
+        value: `${obj.package.name} - ${obj.package.description}`
+      }))
       return Promise.resolve(npmPackages)
     } else if (response.status === 204) {
       return Promise.resolve([{ title: 'No results found', value: 'No results found' }])

--- a/samples/compat/multiFeatureHandler.ts
+++ b/samples/compat/multiFeatureHandler.ts
@@ -6,7 +6,6 @@ import { ActivityHandler, CardFactory, MessageFactory, TurnContext } from '@micr
 import { ActionTypes, Activity, ActivityTypes, Attachment, EndOfConversationCodes } from '@microsoft/agents-activity'
 import path from 'path'
 import fs from 'fs'
-import axios from 'axios'
 
 export class MultiFeatureHandler extends ActivityHandler {
   // conversationReferences: { [key: string]: ConversationReference }
@@ -201,18 +200,26 @@ export class MultiFeatureHandler extends ActivityHandler {
     }
 
     // Local file path for the agent to save the attachment.
-    const localFileName = path.join(__dirname, attachment.name)
+    const localFileName = path.join(import.meta.dirname, attachment.name)
 
     try {
-      // arraybuffer is necessary for images
-      const response = await axios.get(attachment.contentUrl!, { responseType: 'arraybuffer' })
+      const response = await fetch(attachment.contentUrl!)
+      let data: any
       // If user uploads JSON file, this prevents it from being written as "{"type":"Buffer","data":[123,13,10,32,32,34,108..."
-      if (response.headers['content-type'] === 'application/json') {
-        response.data = JSON.parse(response.data, (key, value) => {
-          return value !== undefined && value.type === 'Buffer' ? Buffer.from(value.data) : value
+      if (response.headers.get('content-type') === 'application/json') {
+        const json = await response.json()
+        data = JSON.parse(JSON.stringify(json), (key, value) => {
+          return value !== undefined && value.type === 'Buffer'
+            ? Buffer.from(value.data)
+            : value
         })
+      } else {
+        // arraybuffer is necessary for images
+        const arrayBuffer = await response.arrayBuffer()
+        data = Buffer.from(arrayBuffer)
       }
-      fs.writeFile(localFileName, response.data, (fsError) => {
+
+      fs.writeFile(localFileName, data, (fsError) => {
         if (fsError != null) {
           throw fsError
         }
@@ -274,7 +281,7 @@ export class MultiFeatureHandler extends ActivityHandler {
   }
 
   getInlineAttachment (): Attachment {
-    const imageData = fs.readFileSync(path.join(__dirname, './../_resources/multi-agents.jpg'))
+    const imageData = fs.readFileSync(path.join(import.meta.dirname, './../_resources/multi-agents.jpg'))
     const base64Image = Buffer.from(imageData).toString('base64')
 
     return {

--- a/samples/compat/typeAhead.cjs
+++ b/samples/compat/typeAhead.cjs
@@ -1,8 +1,7 @@
 const { CardFactory, MessageFactory } = require('@microsoft/agents-hosting')
 const { TeamsActivityHandler } = require('@microsoft/agents-hosting-extensions-teams')
-const axios = require('axios')
-const querystring = require('querystring')
 const { startServer } = require('@microsoft/agents-hosting-express')
+
 class TeamsBot extends TeamsActivityHandler {
   constructor () {
     super()
@@ -11,10 +10,10 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Handles members added to the conversation.
-     * @param {TurnContext} context - The context object for the turn.
-     * @param {Function} next - The next middleware or handler to run.
-     */
+   * Handles members added to the conversation.
+   * @param {TurnContext} context - The context object for the turn.
+   * @param {Function} next - The next middleware or handler to run.
+   */
   async handleMembersAdded (context, next) {
     const membersAdded = context.activity.membersAdded
     for (const member of membersAdded) {
@@ -26,10 +25,10 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Handles incoming messages.
-     * @param {TurnContext} context - The context object for the turn.
-     * @param {Function} next - The next middleware or handler to run.
-     */
+   * Handles incoming messages.
+   * @param {TurnContext} context - The context object for the turn.
+   * @param {Function} next - The next middleware or handler to run.
+   */
   async handleMessage (context, next) {
     const text = context.activity.text?.toLowerCase().trim()
     const value = context.activity.value
@@ -56,10 +55,10 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Handles invoke activities.
-     * @param {TurnContext} context - The context object for the turn.
-     * @returns {Promise<Object>} The response object.
-     */
+   * Handles invoke activities.
+   * @param {TurnContext} context - The context object for the turn.
+   * @returns {Promise<Object>} The response object.
+   */
   async onInvokeActivity (context) {
     if (context._activity.name === 'application/search') {
       const dropdownCard = context._activity.value.data.choiceselect
@@ -70,12 +69,14 @@ class TeamsBot extends TeamsActivityHandler {
         if (searchQuery.length < 4) {
           return
         }
-        const response = await axios.get(`http://registry.npmjs.com/-/v1/search?${querystring.stringify({ text: searchQuery, size: 8 })}`)
-        const npmPackages = response.data.objects.map(obj => ({
-          title: obj.package.name,
-          value: `${obj.package.name} - ${obj.package.description}`
-        }))
+        const params = new URLSearchParams({ text: searchQuery, size: '8' })
+        const response = await fetch(`http://registry.npmjs.com/-/v1/search?${params.toString()}`)
         if (response.status === 200) {
+          const data = await response.json()
+          const npmPackages = data.objects.map(obj => ({
+            title: obj.package.name,
+            value: `${obj.package.name} - ${obj.package.description}`
+          }))
           return this.getSuccessResult(npmPackages)
         } else if (response.status === 400) {
           return this.getNoResultFound()
@@ -88,9 +89,9 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the adaptive card for static search.
-     * @returns {Object} The adaptive card JSON.
-     */
+   * Returns the adaptive card for static search.
+   * @returns {Object} The adaptive card JSON.
+   */
   getStaticSearchCard () {
     return {
       $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
@@ -160,9 +161,9 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the adaptive card for dynamic search.
-     * @returns {Object} The adaptive card JSON.
-     */
+   * Returns the adaptive card for dynamic search.
+   * @returns {Object} The adaptive card JSON.
+   */
   getDynamicSearchCard () {
     return {
       $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
@@ -229,9 +230,9 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the adaptive card for dependant search.
-     * @returns {Object} The adaptive card JSON.
-     */
+   * Returns the adaptive card for dependant search.
+   * @returns {Object} The adaptive card JSON.
+   */
   getDependantSearchCard () {
     return {
       type: 'AdaptiveCard',
@@ -286,10 +287,10 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the success result for npm package search.
-     * @param {Array} npmPackages - The list of npm packages.
-     * @returns {Object} The success result object.
-     */
+   * Returns the success result for npm package search.
+   * @param {Array} npmPackages - The list of npm packages.
+   * @returns {Object} The success result object.
+   */
   getSuccessResult (npmPackages) {
     return {
       status: 200,
@@ -303,10 +304,10 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the country-specific results.
-     * @param {string} country - The selected country.
-     * @returns {Object} The country-specific results object.
-     */
+   * Returns the country-specific results.
+   * @param {string} country - The selected country.
+   * @returns {Object} The country-specific results object.
+   */
   getCountrySpecificResults (country) {
     const results = {
       usa: [
@@ -338,9 +339,9 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the no result found response.
-     * @returns {Object} The no result found response object.
-     */
+   * Returns the no result found response.
+   * @returns {Object} The no result found response object.
+   */
   getNoResultFound () {
     return {
       status: 204,
@@ -351,9 +352,9 @@ class TeamsBot extends TeamsActivityHandler {
   }
 
   /**
-     * Returns the error result response.
-     * @returns {Object} The error result response object.
-     */
+   * Returns the error result response.
+   * @returns {Object} The error result response object.
+   */
   getErrorResult () {
     return {
       status: 500,

--- a/test-agents/web-chat/package.json
+++ b/test-agents/web-chat/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@microsoft/agents-activity": "file:../../packages/agents-activity",
     "@microsoft/agents-hosting": "file:../../packages/agents-hosting",
-    "axios": "1.17.0",
     "express": "5.2.1",
     "express-rate-limit": "8.5.2"
   }

--- a/test-agents/web-chat/src/multiFeature.ts
+++ b/test-agents/web-chat/src/multiFeature.ts
@@ -4,7 +4,6 @@
 import { ActivityHandler, CardFactory, MessageFactory, TurnContext } from '@microsoft/agents-hosting'
 import path from 'path'
 import fs from 'fs'
-import axios from 'axios'
 import { ActionTypes, Activity, ActivityTypes, Attachment, ConversationReference, EndOfConversationCodes } from '@microsoft/agents-activity'
 
 export class MultiFeatureHandler extends ActivityHandler {
@@ -206,15 +205,20 @@ export class MultiFeatureHandler extends ActivityHandler {
     const localFileName = path.join(__dirname, attachment.name)
 
     try {
-      // arraybuffer is necessary for images
-      const response = await axios.get(url, { responseType: 'arraybuffer' })
+      const response = await fetch(url)
+      let data: any
       // If user uploads JSON file, this prevents it from being written as "{"type":"Buffer","data":[123,13,10,32,32,34,108..."
-      if (response.headers['content-type'] === 'application/json') {
-        response.data = JSON.parse(response.data, (key, value) => {
+      if (response.headers.get('content-type') === 'application/json') {
+        const json = await response.json()
+        data = JSON.parse(JSON.stringify(json), (key, value) => {
           return value !== undefined && value.type === 'Buffer' ? Buffer.from(value.data) : value
         })
+      } else {
+        // arraybuffer is necessary for images
+        const arrayBuffer = await response.arrayBuffer()
+        data = Buffer.from(arrayBuffer)
       }
-      fs.writeFile(localFileName, response.data, (fsError) => {
+      fs.writeFile(localFileName, data, (fsError) => {
         if (fsError != null) {
           throw fsError
         }


### PR DESCRIPTION
Fixes # 1124

> NOTE: This PR depends on # 1139 to be merged.

## Descriptions
This PR replaces the use of axios with Nodejs native fetch across samples and test agents. It also updates the agents-hosting.md and removes the axios package from the dependencies.

### Detailed Changes
- Replaced axios in the following samples
  - basic/typeAhead
  - compat/typeAhead
  -  compat/multiFeatureHandler
  - test-agents/web-chat
- Updated compat/baseline/agents-hosting.api.md to reflect the changes made in agents-hosting.
- Removed axios from package.json and knip.jsonc
- Updated package-lock.json

## Testing
These images show the samples working after the changes.
<img width="1412" height="1465" alt="image" src="https://github.com/user-attachments/assets/4864fb5b-e2b1-4591-b99b-451456151201" />
