### PR TITLE
Address remaining TODOs in the repo

### DIFF
--- a/packages/agents-hosting-dialogs/src/choices/recognizeChoices.ts
+++ b/packages/agents-hosting-dialogs/src/choices/recognizeChoices.ts
@@ -66,9 +66,7 @@ export function recognizeChoices (
   // Normalize choices
   const list: Choice[] = (choices || [])
     .map((choice) => (typeof choice === 'string' ? { value: choice } : choice))
-    .filter(
-      (choice: Choice) => choice // TODO: does this do anything?
-    )
+    .filter((choice): choice is Choice => choice !== undefined && choice !== null)
 
   // Try finding choices by text search first
   // - We only want to use a single strategy for returning results to avoid issues where utterances

--- a/packages/agents-hosting-dialogs/test/choiceRecognizer.test.ts
+++ b/packages/agents-hosting-dialogs/test/choiceRecognizer.test.ts
@@ -143,7 +143,6 @@ describe('Choices Recognizers Tests', function () {
   })
 
   describe('recognizeChoices()', function () {
-    // TODO: add recognizer test with ordinal and number options
     it('should find a choice in an utterance by name.', function () {
       const found = recognizeChoices('the red one please.', colorChoices)
       assert(found.length === 1, `Invalid token count of '${found.length}' returned.`)
@@ -211,6 +210,12 @@ describe('Choices Recognizers Tests', function () {
         recognizeNumbers: false,
       })
       assert(found.length === 0, `Invalid token count of '${found.length}' returned.`)
+    })
+
+    it('should ignore nullish choices from JavaScript callers.', function () {
+      const found = recognizeChoices('the green one please.', ['red', null, 'green', undefined] as any)
+      assert(found.length === 1, `Invalid token count of '${found.length}' returned.`)
+      assertChoice(found[0], 'green', 1, 1, 'green')
     })
   })
 })

--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -721,75 +721,75 @@ export class AgentApplication<TState extends TurnState> {
    * Executes the turn processing logic for the given context, including routing and handler execution.
    */
   private async runTurn (context: TurnContext): Promise<boolean> {
-    return trace(AgentApplicationTraceDefinitions.run, async ({ record }) => {
-      record({ authorized: true, activity: context.activity })
+    const managed = trace(AgentApplicationTraceDefinitions.run)
+    managed.record({ authorized: true, activity: context.activity })
 
-      try {
-        if (this._options.startTypingTimer) {
-          this.startTypingTimer(context)
-        }
-
-        if (this._options.removeRecipientMention && context.activity.type === ActivityTypes.Message) {
-          context.activity.removeRecipientMention()
-        }
-
-        if (this._options.normalizeMentions && context.activity.type === ActivityTypes.Message) {
-          context.activity.normalizeMentions()
-        }
-
-        const { storage, turnStateFactory } = this._options
-        const state = turnStateFactory()
-        await state.load(context, storage)
-
-        const route = await this.getRoute(context)
-
-        record({ routeMatched: route !== undefined })
-
-        if (!route) {
-          logger.debug('No matching route found for activity:', context.activity)
-          return false
-        }
-
-        const fileDownloaders = this._options.fileDownloaders
-        if (Array.isArray(fileDownloaders) && fileDownloaders.length > 0) {
-          await trace(AgentApplicationTraceDefinitions.downloadFiles, async ({ record }) => {
-            record({ attachmentsCount: context.activity.attachments?.length })
-            for (let i = 0; i < fileDownloaders.length; i++) {
-              await fileDownloaders[i].downloadAndStoreFiles(context, state)
-            }
-          })
-        }
-
-        if (this._beforeTurn.length > 0) {
-          await trace(AgentApplicationTraceDefinitions.beforeTurn, async () => {
-            if (!(await this.callEventHandlers(context, state, this._beforeTurn))) {
-              await state.save(context, storage)
-              return false
-            }
-          })
-        }
-
-        await trace(AgentApplicationTraceDefinitions.routeHandler, async ({ record }) => {
-          record({ isInvoke: route.isInvokeRoute, isAgentic: route.isAgenticRoute })
-          await route.handler(context, state)
-        })
-
-        if (this._afterTurn.length > 0) {
-          await trace(AgentApplicationTraceDefinitions.afterTurn, async () => {
-            if (await this.callEventHandlers(context, state, this._afterTurn)) {
-              await state.save(context, storage)
-            }
-          })
-        }
-
-        return true
-      } catch (err: any) {
-        logger.error(err)
-        throw err
-      } finally {
-        this.stopTypingTimer(context)
+    try {
+      if (this._options.startTypingTimer) {
+        this.startTypingTimer(context)
       }
-    })
+
+      if (this._options.removeRecipientMention && context.activity.type === ActivityTypes.Message) {
+        context.activity.removeRecipientMention()
+      }
+
+      if (this._options.normalizeMentions && context.activity.type === ActivityTypes.Message) {
+        context.activity.normalizeMentions()
+      }
+
+      const { storage, turnStateFactory } = this._options
+      const state = turnStateFactory()
+      await state.load(context, storage)
+
+      const route = await this.getRoute(context)
+
+      managed.record({ routeMatched: route !== undefined })
+
+      if (!route) {
+        logger.debug('No matching route found for activity:', context.activity)
+        return false
+      }
+
+      const fileDownloaders = this._options.fileDownloaders
+      if (Array.isArray(fileDownloaders) && fileDownloaders.length > 0) {
+        await managed.child(AgentApplicationTraceDefinitions.downloadFiles, async ({ record }) => {
+          record({ attachmentsCount: context.activity.attachments?.length })
+          for (let i = 0; i < fileDownloaders.length; i++) {
+            await fileDownloaders[i].downloadAndStoreFiles(context, state)
+          }
+        })
+      }
+
+      if (this._beforeTurn.length > 0) {
+        await managed.child(AgentApplicationTraceDefinitions.beforeTurn, async () => {
+          if (!(await this.callEventHandlers(context, state, this._beforeTurn))) {
+            await state.save(context, storage)
+            return false
+          }
+        })
+      }
+
+      await managed.child(AgentApplicationTraceDefinitions.routeHandler, async ({ record }) => {
+        record({ isInvoke: route.isInvokeRoute, isAgentic: route.isAgenticRoute })
+        await route.handler(context, state)
+      })
+
+      if (this._afterTurn.length > 0) {
+        await managed.child(AgentApplicationTraceDefinitions.afterTurn, async () => {
+          if (await this.callEventHandlers(context, state, this._afterTurn)) {
+            await state.save(context, storage)
+          }
+        })
+      }
+
+      return true
+    } catch (err: any) {
+      logger.error(err)
+      throw managed.fail(err)
+    } finally {
+      this.stopTypingTimer(context)
+      managed.end()
+    }
   }
 
   /**

--- a/packages/agents-telemetry/README.md
+++ b/packages/agents-telemetry/README.md
@@ -183,7 +183,7 @@ For long-lived operations where you need manual control over the span lifecycle:
 ```ts
 import { SpanNames, trace } from '@microsoft/agents-telemetry'
 
-const { record, actions, end, fail } = trace({
+const { record, actions, child, end, fail } = trace({
   name: SpanNames.ADAPTER_PROCESS,
   record: { status: 'pending' },
   end: ({ span, record, duration }) => {
@@ -193,7 +193,20 @@ const { record, actions, end, fail } = trace({
 
 try {
   record({ status: 'processing' })
-  await doWork()
+  const keys = ['conversation']
+  await child(
+    {
+      name: SpanNames.STORAGE_READ,
+      record: { keys: 0 },
+      end: ({ span, record }) => {
+        span.setAttribute('storage.keys', record.keys)
+      },
+    },
+    async ({ record }) => {
+      record({ keys: 5 })
+      await storage.read(keys)
+    }
+  )
   record({ status: 'done' })
   end()
 } catch (error) {
@@ -230,6 +243,8 @@ trace(storageReadTrace, ({ record }) => {
 - Non-Error thrown values are recorded with their type name and string representation.
 - Unrecognized span names throw immediately.
 - Disabled span categories run the callback with a noop context — no telemetry is emitted.
+- Managed spans can start parented spans with `child(definition)` or `child(definition, callback)`.
+- Record updates recursively merge plain objects; arrays are copied and replaced.
 - The `end` hook receives `{ span, record, duration, error? }`.
 
 ### Using debug
@@ -268,6 +283,7 @@ When `@opentelemetry/api` is not available, the instruments are safe noops.
 - **Error recording**: Exceptions are recorded on the span with `ERROR` status
 - **Span name validation**: Unknown span names are rejected early
 - **Record tracking**: Accumulate structured data during a trace and access it in the `end` hook
+- **Managed child spans**: Start child spans from a managed trace context when a manual parent span stays open
 - **Custom actions**: Define span-scoped helper functions via the `actions` factory
 - **Category-based disabling**: Disable groups of spans via environment configuration
 - **Noop fallback**: All instrumentation calls are safe no-ops when OpenTelemetry APIs are not installed
@@ -278,13 +294,17 @@ When `@opentelemetry/api` is not available, the instruments are safe noops.
 
 ### `trace(definition)` — Managed mode
 
-Starts a span and returns a managed context with `record`, `actions`, `end`, and `fail` methods.
+Starts a span and returns a managed context with `record`, `actions`, `child`, `end`, and `fail` methods.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `definition` | `TraceDefinition` | Trace definition object (see below). |
 
-Returns: `{ record, actions, end, fail }`
+Returns: `{ record, actions, child, end, fail }`
+
+### `managed.child(definition[, callback])`
+
+Starts a span parented to an open managed span. Without a callback, it returns another managed context. With a callback, the child span follows callback-mode lifecycle behavior.
 
 ### `trace(definition, callback)` — Callback mode
 

--- a/packages/agents-telemetry/src/observability/trace.ts
+++ b/packages/agents-telemetry/src/observability/trace.ts
@@ -9,11 +9,14 @@ import type {
   TraceDefinition,
   TraceFunction,
   TraceRecord,
+  TraceChildFunction,
+  TraceCallback,
 } from '../types.js'
 import { attempt } from '../utils/attempt.js'
 import { isSpanDisabled } from './category.js'
 import { SpanNames } from './constants.js'
 import { noopContext } from '../utils/noop.js'
+import { cloneRecordValue, mergeRecordValues } from '../utils/record.js'
 
 /**
  * Creates the trace helper bound to the package tracer.
@@ -27,6 +30,14 @@ export function traceFactory (otel: OTel) {
   const tracer = otel.trace.getTracer('@microsoft/agents-telemetry')
 
   const trace = function trace (target, callback) {
+    return runTrace(target, callback)
+  } as TraceFunction
+
+  function runTrace (
+    target: TraceDefinition<any, any> | undefined,
+    callback?: TraceCallback<any, any, unknown>,
+    parentSpan?: Span
+  ) {
     if (!target) {
       throw new Error('Trace definition is required')
     }
@@ -36,33 +47,44 @@ export function traceFactory (otel: OTel) {
     }
 
     if (isSpanDisabled(target.name)) {
-      return noopContext(callback)
+      return callback ? noopContext(callback) : noopContext()
     }
 
-    const record = createRecord(target)
+    const execute = () => {
+      const record = createRecord(target)
 
-    if (!callback) {
-      // TODO: if parent/child span connections are needed, we could expose a 'child' function that internally connects them.
-      const span = tracer.startSpan(target.name)
-      const flow = start(otel, target, span, record)
+      if (!callback) {
+        const span = tracer.startSpan(target.name)
+        const flow = start(otel, target, span, record)
+        const child = ((definition, childCallback) =>
+          runTrace(definition, childCallback, span)) as TraceChildFunction
 
-      return {
-        record: flow.record,
-        actions: flow.actions,
-        fail: flow.fail,
-        end: flow.end
+        return {
+          record: flow.record,
+          actions: flow.actions,
+          child,
+          fail: flow.fail,
+          end: flow.end
+        }
       }
+
+      return tracer.startActiveSpan(target.name, span => {
+        const flow = start(otel, target, span, record)
+        return attempt({
+          try: () => callback({ record: flow.record, actions: flow.actions }),
+          catch: (error) => { throw flow.fail(error) },
+          finally: flow.end
+        })
+      })
     }
 
-    return tracer.startActiveSpan(target.name, span => {
-      const flow = start(otel, target, span, record)
-      return attempt({
-        try: () => callback({ record: flow.record, actions: flow.actions }),
-        catch: (error) => { throw flow.fail(error) },
-        finally: flow.end
-      })
-    })
-  } as TraceFunction
+    if (!parentSpan) {
+      return execute()
+    }
+
+    const parentContext = otel.trace.setSpan(otel.context.active(), parentSpan)
+    return otel.context.with(parentContext, execute)
+  }
 
   trace.define = definition => definition
 
@@ -73,15 +95,15 @@ export function traceFactory (otel: OTel) {
  * Creates the mutable record stored for a trace execution.
  *
  * @remarks
- * - Updates use `Object.assign`, so nested objects are replaced rather than deeply merged.
+ * - Plain objects are recursively merged.
+ * - Arrays are copied and replaced.
  */
 function createRecord<TRecord extends object, TActions extends object> (target: TraceDefinition<TRecord, TActions>): TraceRecord<TRecord> {
-  const state: Partial<TRecord> = target.record ? { ...target.record } : {}
+  const state: Partial<TRecord> = target.record ? cloneRecordValue(target.record) : {}
 
   return {
     set (values) {
-      // TODO: use deep-merge strategy for Object and Array
-      Object.assign(state, values)
+      mergeRecordValues(state as Record<string, unknown>, values as Record<string, unknown>)
     },
     get () {
       return state as Readonly<TRecord>

--- a/packages/agents-telemetry/src/types.ts
+++ b/packages/agents-telemetry/src/types.ts
@@ -38,7 +38,8 @@ export type SpanName = typeof SpanNames[keyof typeof SpanNames]
  * Mutable state container used while a trace is active.
  *
  * @remarks
- * - `set()` performs a shallow merge.
+ * - `set()` recursively merges plain objects.
+ * - Arrays are copied and replaced.
  * - `get()` returns the latest snapshot stored for the span.
  */
 export interface TraceRecord<TRecord extends object> {
@@ -50,6 +51,13 @@ export interface TraceRecord<TRecord extends object> {
  * Context passed to traced callbacks.
  */
 export interface TraceContext<TRecord extends object, TActions extends object> {
+  /**
+   * Updates the record values collected for the span.
+   *
+   * @remarks
+   * - Plain objects are recursively merged.
+   * - Arrays are copied and replaced.
+   */
   record(values: Partial<TRecord>): void
   actions: TActions
 }
@@ -78,9 +86,18 @@ export interface TraceEndContext<TRecord extends object> {
 }
 
 /**
+ * Starts a child span parented to an active managed span.
+ */
+export interface TraceChildFunction {
+  <TRecord extends object, TActions extends object>(definition: TraceDefinition<TRecord, TActions>): TraceManagedContext<TRecord, TActions>
+  <TRecord extends object, TActions extends object, TReturn>(definition: TraceDefinition<TRecord, TActions>, callback: TraceCallback<TRecord, TActions, TReturn>): TReturn
+}
+
+/**
  * Handle returned when a trace is created without a callback.
  */
 export interface TraceManagedContext<TRecord extends object, TActions extends object> extends TraceContext<TRecord, TActions> {
+  child: TraceChildFunction
   end(): void
   fail<T extends unknown>(error: T): T
 }

--- a/packages/agents-telemetry/src/utils/noop.ts
+++ b/packages/agents-telemetry/src/utils/noop.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { Metric, TraceCallback, TraceContext, TraceFunction, TraceManagedContext } from '../types.js'
+import type { Metric, TraceCallback, TraceChildFunction, TraceContext, TraceFunction, TraceManagedContext } from '../types.js'
 
 const noopFn = () => {}
 
@@ -45,6 +45,7 @@ export function noopContext<TRecord extends object, TActions extends object, TRe
   const managedContext: TraceManagedContext<TRecord, TActions> = {
     record: context.record,
     actions: context.actions,
+    child: ((_definition, callback) => noopContext(callback)) as TraceChildFunction,
     end: noopFn,
     fail<T extends unknown> (error: T): T {
       return error

--- a/packages/agents-telemetry/src/utils/record.ts
+++ b/packages/agents-telemetry/src/utils/record.ts
@@ -55,5 +55,10 @@ export function cloneRecordValue<T> (value: T): T {
  * Arrays and class instances are not considered plain objects.
  */
 function isPlainObject (value: unknown): value is Record<string, unknown> {
-  return Object.prototype.toString.call(value) === '[object Object]'
+  if (Object.prototype.toString.call(value) !== '[object Object]') {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }

--- a/packages/agents-telemetry/src/utils/record.ts
+++ b/packages/agents-telemetry/src/utils/record.ts
@@ -54,6 +54,6 @@ export function cloneRecordValue<T> (value: T): T {
  * @remarks
  * Arrays and class instances are not considered plain objects.
  */
-export function isPlainObject (value: unknown): value is Record<string, unknown> {
+function isPlainObject (value: unknown): value is Record<string, unknown> {
   return Object.prototype.toString.call(value) === '[object Object]'
 }

--- a/packages/agents-telemetry/src/utils/record.ts
+++ b/packages/agents-telemetry/src/utils/record.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Recursively merges record values into the target state.
+ *
+ * @remarks
+ * - Plain objects are recursively merged.
+ * - Arrays are copied and replaced.
+ */
+export function mergeRecordValues (target: Record<string, unknown>, values: Record<string, unknown>): void {
+  Object.entries(values).forEach(([key, value]) => {
+    const current = target[key]
+
+    if (isPlainObject(current) && isPlainObject(value)) {
+      const merged = { ...current }
+      mergeRecordValues(merged, value)
+      target[key] = merged
+      return
+    }
+
+    target[key] = cloneRecordValue(value)
+  })
+}
+
+/**
+ * Clones record values while preserving non-plain objects by reference.
+ *
+ * @remarks
+ * - Plain objects and arrays are cloned.
+ * - Non-plain objects are kept by reference.
+ */
+export function cloneRecordValue<T> (value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(item => cloneRecordValue(item)) as T
+  }
+
+  if (isPlainObject(value)) {
+    const result: Record<string, unknown> = {}
+    Object.entries(value).forEach(([key, child]) => {
+      result[key] = cloneRecordValue(child)
+    })
+    return result as T
+  }
+
+  return value
+}
+
+/**
+ * Checks whether a value is a plain object that can be recursively merged.
+ *
+ * @remarks
+ * Arrays and class instances are not considered plain objects.
+ */
+export function isPlainObject (value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}

--- a/packages/agents-telemetry/test/observability/trace.test.ts
+++ b/packages/agents-telemetry/test/observability/trace.test.ts
@@ -13,15 +13,42 @@ function createMockSpan () {
   }
 }
 
-function createMockOTel (span?: ReturnType<typeof createMockSpan>) {
-  const mockSpan = span ?? createMockSpan()
+function createMockOTel (spanOrSpans?: ReturnType<typeof createMockSpan> | ReturnType<typeof createMockSpan>[]) {
+  const spans = Array.isArray(spanOrSpans) ? [...spanOrSpans] : [spanOrSpans ?? createMockSpan()]
+  const mockSpan = spans[0]
+  const startedContexts: any[] = []
+  let activeContext: any = {}
+
+  function nextSpan () {
+    return spans.shift() ?? mockSpan
+  }
+
   return {
     otel: {
       trace: {
         getTracer: () => ({
-          startSpan: () => mockSpan,
-          startActiveSpan: (_name: string, fn: (span: any) => any) => fn(mockSpan),
+          startSpan: () => {
+            startedContexts.push(activeContext)
+            return nextSpan()
+          },
+          startActiveSpan: (_name: string, fn: (span: any) => any) => {
+            startedContexts.push(activeContext)
+            return fn(nextSpan())
+          },
         }),
+        setSpan: (_context: any, span: any) => ({ span }),
+      },
+      context: {
+        active: () => activeContext,
+        with: (context: any, fn: Function) => {
+          const previousContext = activeContext
+          activeContext = context
+          try {
+            return fn()
+          } finally {
+            activeContext = previousContext
+          }
+        },
       },
       SpanStatusCode: {
         OK: 1,
@@ -29,6 +56,7 @@ function createMockOTel (span?: ReturnType<typeof createMockSpan>) {
       },
     } as any,
     span: mockSpan,
+    startedContexts,
   }
 }
 
@@ -64,6 +92,34 @@ describe('traceFactory', () => {
     assert.strictEqual(typeof result.record, 'function')
     assert.strictEqual(typeof result.end, 'function')
     assert.strictEqual(typeof result.fail, 'function')
+    assert.strictEqual(typeof result.child, 'function')
+  })
+
+  it('managed context starts child spans with the parent span active', () => {
+    const parentSpan = createMockSpan()
+    const childSpan = createMockSpan()
+    const { otel, startedContexts } = createMockOTel([parentSpan, childSpan])
+    const trace = traceFactory(otel)
+
+    const parent = trace({
+      name: SpanNames.ADAPTER_PROCESS,
+      record: {},
+      end: () => {},
+    })
+
+    const child = parent.child({
+      name: SpanNames.STORAGE_READ,
+      record: {},
+      end: () => {},
+    })
+
+    child.end()
+    parent.end()
+
+    assert.strictEqual(startedContexts.length, 2)
+    assert.strictEqual(startedContexts[1].span, parentSpan)
+    assert.strictEqual(childSpan.end.mock.callCount(), 1)
+    assert.strictEqual(parentSpan.end.mock.callCount(), 1)
   })
 
   it('managed context sets OK status and calls end on the span', () => {
@@ -198,6 +254,36 @@ describe('traceFactory', () => {
     )
 
     assert.deepStrictEqual(captured, { count: 5 })
+  })
+
+  it('record recursively merges objects and replaces arrays', () => {
+    const { otel } = createMockOTel()
+    const trace = traceFactory(otel)
+    let captured: any
+
+    trace(
+      {
+        name: SpanNames.ADAPTER_PROCESS,
+        record: {
+          metadata: { attempt: 1, nested: { before: true, after: false } },
+          tags: ['initial'],
+          status: 'pending',
+        },
+        end: (ctx) => { captured = ctx.record },
+      },
+      (ctx) => {
+        ctx.record({
+          metadata: { nested: { after: true }, source: 'test' },
+          tags: ['updated'],
+        } as any)
+      }
+    )
+
+    assert.deepStrictEqual(captured, {
+      metadata: { attempt: 1, nested: { before: true, after: true }, source: 'test' },
+      tags: ['updated'],
+      status: 'pending',
+    })
   })
 
   it('record initializes with default values from definition', () => {

--- a/packages/agents-telemetry/test/observability/trace.test.ts
+++ b/packages/agents-telemetry/test/observability/trace.test.ts
@@ -286,6 +286,40 @@ describe('traceFactory', () => {
     })
   })
 
+  it('record preserves class instances by reference', () => {
+    class TraceValue {
+      constructor (public readonly value: string) {}
+
+      get displayValue () {
+        return `value:${this.value}`
+      }
+
+      isTraceValue () {
+        return true
+      }
+    }
+
+    const { otel } = createMockOTel()
+    const trace = traceFactory(otel)
+    const value = new TraceValue('test')
+    let captured: any
+
+    trace(
+      {
+        name: SpanNames.ADAPTER_PROCESS,
+        record: { value: new TraceValue('default') },
+        end: (ctx) => { captured = ctx.record },
+      },
+      (ctx) => {
+        ctx.record({ value })
+      }
+    )
+
+    assert.strictEqual(captured.value, value)
+    assert.strictEqual(captured.value.displayValue, 'value:test')
+    assert.strictEqual(captured.value.isTraceValue(), true)
+  })
+
   it('record initializes with default values from definition', () => {
     const { otel } = createMockOTel()
     const trace = traceFactory(otel)

--- a/packages/agents-telemetry/test/utils/noop.test.ts
+++ b/packages/agents-telemetry/test/utils/noop.test.ts
@@ -14,6 +14,28 @@ describe('noopTrace', () => {
     assert.strictEqual(typeof result.record, 'function')
     assert.strictEqual(typeof result.end, 'function')
     assert.strictEqual(typeof result.fail, 'function')
+    assert.strictEqual(typeof result.child, 'function')
+  })
+
+  it('managed child returns another noop managed context', () => {
+    const { result } = callNoopTrace({ name: 'agents.adapter.process', record: {}, end: () => {} })
+    const child = result.child({ name: 'agents.storage.read', record: {}, end: () => {} })
+
+    assert.strictEqual(typeof child.record, 'function')
+    assert.strictEqual(typeof child.end, 'function')
+  })
+
+  it('managed child invokes callback and returns its result', () => {
+    const { result } = callNoopTrace({ name: 'agents.adapter.process', record: {}, end: () => {} })
+    const childResult = result.child(
+      { name: 'agents.storage.read', record: {}, end: () => {} },
+      (ctx: any) => {
+        assert.strictEqual(typeof ctx.record, 'function')
+        return 'child-result'
+      }
+    )
+
+    assert.strictEqual(childResult, 'child-result')
   })
 
   it('end is callable and does nothing', () => {
@@ -82,6 +104,7 @@ describe('noopContext', () => {
     assert.strictEqual(typeof result.record, 'function')
     assert.strictEqual(typeof result.end, 'function')
     assert.strictEqual(typeof result.fail, 'function')
+    assert.strictEqual(typeof result.child, 'function')
     assert.ok(result.actions)
   })
 

--- a/samples/compat/cardFactoryHandler.ts
+++ b/samples/compat/cardFactoryHandler.ts
@@ -43,18 +43,15 @@ export class CardFactoryHandler extends ActivityHandler {
             await CardFactoryHandler.sendReceiptCard(context)
             break
           case '6':
-            await CardFactoryHandler.sendOauthCard(context)
-            break
-          case '7':
             await CardFactoryHandler.sendO365ConnectorCard(context)
             break
-          case '8':
+          case '7':
             await CardFactoryHandler.sendSigninCard(context)
             break
-          case '9':
+          case '8':
             await CardFactoryHandler.sendThumbnailCard(context)
             break
-          case '10':
+          case '9':
             await CardFactoryHandler.sendVideoCard(context)
             break
           default: {
@@ -86,11 +83,10 @@ export class CardFactoryHandler extends ActivityHandler {
       { type: ActionTypes.ImBack, title: '3. Audio Card', value: '3' },
       { type: ActionTypes.ImBack, title: '4. Hero Card', value: '4' },
       { type: ActionTypes.ImBack, title: '5. Receipt Card', value: '5' },
-      // { type: ActionTypes.ImBack, title: '6. oAuth Card [NotImplemented]', value: '6' }, // TODO still pending
-      { type: ActionTypes.ImBack, title: '7. o365Connector Card', value: '7' },
-      { type: ActionTypes.ImBack, title: '8. Signin Card', value: '8' },
-      { type: ActionTypes.ImBack, title: '9. Thumbnail Card', value: '9' },
-      { type: ActionTypes.ImBack, title: '10. Video Card', value: '10' },
+      { type: ActionTypes.ImBack, title: '6. o365Connector Card', value: '6' },
+      { type: ActionTypes.ImBack, title: '7. Signin Card', value: '7' },
+      { type: ActionTypes.ImBack, title: '8. Thumbnail Card', value: '8' },
+      { type: ActionTypes.ImBack, title: '9. Video Card', value: '9' },
     ]
 
     const card = CardFactory.heroCard('', undefined,
@@ -190,11 +186,6 @@ export class CardFactoryHandler extends ActivityHandler {
     })
 
     await CardFactoryHandler.sendCard(context, card)
-  }
-
-  static async sendOauthCard (context: TurnContext): Promise<void> {
-    // TODO still pending
-    throw new Error('NotImplemented')
   }
 
   static async sendO365ConnectorCard (context: TurnContext): Promise<void> {

--- a/test-agents/web-chat/src/cardFactoryHandler.ts
+++ b/test-agents/web-chat/src/cardFactoryHandler.ts
@@ -43,18 +43,15 @@ export class CardFactoryHandler extends ActivityHandler {
             await CardMessages.sendReceiptCard(context)
             break
           case '6':
-            await CardMessages.sendOauthCard(context)
-            break
-          case '7':
             await CardMessages.sendO365ConnectorCard(context)
             break
-          case '8':
+          case '7':
             await CardMessages.sendSigninCard(context)
             break
-          case '9':
+          case '8':
             await CardMessages.sendThumbnailCard(context)
             break
-          case '10':
+          case '9':
             await CardMessages.sendVideoCard(context)
             break
           default: {

--- a/test-agents/web-chat/src/cardMessages.ts
+++ b/test-agents/web-chat/src/cardMessages.ts
@@ -12,11 +12,10 @@ export class CardMessages {
       { type: ActionTypes.ImBack, title: '3. Audio Card', value: '3' },
       { type: ActionTypes.ImBack, title: '4. Hero Card', value: '4' },
       { type: ActionTypes.ImBack, title: '5. Receipt Card', value: '5' },
-      // { type: ActionTypes.ImBack, title: '6. oAuth Card [NotImplemented]', value: '6' }, // TODO still pending
-      { type: ActionTypes.ImBack, title: '7. o365Connector Card', value: '7' },
-      { type: ActionTypes.ImBack, title: '8. Signin Card', value: '8' },
-      { type: ActionTypes.ImBack, title: '9. Thumbnail Card', value: '9' },
-      { type: ActionTypes.ImBack, title: '10. Video Card', value: '10' },
+      { type: ActionTypes.ImBack, title: '6. o365Connector Card', value: '6' },
+      { type: ActionTypes.ImBack, title: '7. Signin Card', value: '7' },
+      { type: ActionTypes.ImBack, title: '8. Thumbnail Card', value: '8' },
+      { type: ActionTypes.ImBack, title: '9. Video Card', value: '9' },
     ]
 
     const card = CardFactory.heroCard('', undefined,
@@ -122,11 +121,6 @@ export class CardMessages {
     })
 
     await CardMessages.sendActivity(context, card)
-  }
-
-  static async sendOauthCard (context: TurnContext): Promise<void> {
-    // TODO still pending
-    throw new Error('NotImplemented')
   }
 
   static async sendO365ConnectorCard (context: TurnContext): Promise<void> {


### PR DESCRIPTION
Addresses # 1158

## Summary

This PR cleans up remaining non-Teams TODOs and improves telemetry tracing behavior.

- Removes the unfinished OAuth card path from card samples and renumbers the remaining card options so they are contiguous.
- Adds managed child span support to telemetry tracing and uses it in `AgentApplication.runTurn`.
- Updates trace record merging to recursively merge plain objects while replacing arrays.
- Moves record merge helpers into a dedicated telemetry utils module.
- Cleans up stale dialog choice recognizer TODOs and makes nullish choice handling explicit.
- Updates docs/JSDoc for the new trace API and record merge semantics.

## Testing

The following image shows the OTel sample continues working.
<img width="1593" height="971" alt="imagen" src="https://github.com/user-attachments/assets/dcff77ec-c5a6-4c46-8309-e38c2498a415" />
