### PR TITLE
Improve error handling in long running calls

### DIFF
--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -1086,20 +1086,73 @@ export class AgentApplication<TState extends TurnState> {
     handler: (context: TurnContext) => Promise<any>
   ) {
     const activity = Activity.fromObject(context.activity)
-    this.continueConversationAsync(context.identity, activity.getConversationReference(), async (ctx) => {
-      try {
-        Object.assign(ctx.activity, activity)
-        await handler(ctx)
-      } catch (err) {
-        if (this.adapter.onTurnError && err instanceof Error) {
-          await this.adapter.onTurnError(ctx, err)
-        } else {
-          throw err
+    const createErrorContext = () => new TurnContext(context.adapter, Activity.fromObject(activity), context.identity)
+
+    try {
+      const reference = activity.getConversationReference()
+      this.continueConversationAsync(context.identity, reference, async (ctx) => {
+        try {
+          Object.assign(ctx.activity, activity)
+          await handler(ctx)
+        } catch (err) {
+          await this.handleLongRunningCallError(ctx, activity, err)
         }
-      }
-    }).catch(err => {
-      logger.error(`Unhandled error in long-running call for activity '${activity.type}' (id: ${activity.id}):`, err)
+      }).catch(async err => {
+        await this.handleLongRunningCallError(createErrorContext(), activity, err)
+      })
+    } catch (err) {
+      this.handleLongRunningCallError(createErrorContext(), activity, err).catch(handlerErr => {
+        logger.error(`Unhandled error in long-running error handler for activity '${activity.type}' (id: ${activity.id}):`, this.normalizeLongRunningCallError(handlerErr))
+      })
+    }
+  }
+
+  private async handleLongRunningCallError (
+    context: TurnContext,
+    activity: Activity,
+    err: unknown
+  ): Promise<void> {
+    const error = this.normalizeLongRunningCallError(err)
+
+    try {
+      await context.adapter.onTurnError(context, error)
+    } catch (handlerErr) {
+      logger.error(`Unhandled error in long-running error handler for activity '${activity.type}' (id: ${activity.id}):`, this.normalizeLongRunningCallError(handlerErr))
+    }
+  }
+
+  private normalizeLongRunningCallError (err: unknown): Error {
+    if (err instanceof Error) {
+      return err
+    }
+
+    return ExceptionHelper.generateException(Error, Errors.UnknownErrorType, undefined, {
+      errorMessage: this.stringifyThrownValue(err)
     })
+  }
+
+  private stringifyThrownValue (value: unknown): string {
+    if (typeof value === 'string') {
+      return value
+    }
+
+    if (value === undefined) {
+      return 'undefined'
+    }
+
+    if (value === null) {
+      return 'null'
+    }
+
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value) ?? Object.prototype.toString.call(value)
+      } catch {
+        return Object.prototype.toString.call(value)
+      }
+    }
+
+    return String(value)
   }
 
   /**

--- a/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
+++ b/packages/agents-hosting/test/hosting/app/agentApplication.test.ts
@@ -480,6 +480,9 @@ describe('Application', () => {
     class TrackingAdapter extends TestAdapter {
       continueConversationCalled = false
       continueConversationCallback: ((ctx: TurnContext) => Promise<void>) | undefined
+      continueConversationError: unknown
+      runContinuationAsync = false
+      continuationPromise: Promise<void> | undefined
 
       setAgentName (_agentName?: string): void {
       }
@@ -487,7 +490,36 @@ describe('Application', () => {
       override continueConversation (_identity: any, _reference: any, logic: (ctx: TurnContext) => Promise<void>): Promise<void> {
         this.continueConversationCalled = true
         this.continueConversationCallback = logic
+        if (this.continueConversationError !== undefined) {
+          return Promise.reject(this.continueConversationError)
+        }
+
+        if (this.runContinuationAsync) {
+          this.continuationPromise = Promise.resolve().then(() => logic(this.createContinuationContext()))
+          return this.continuationPromise
+        }
+
         return Promise.resolve()
+      }
+
+      createContinuationContext (): TurnContext {
+        return new TurnContext(this, Activity.fromObject({
+          type: ActivityTypes.Message,
+          text: 'placeholder',
+          from: { id: 'user', name: 'user' },
+          conversation: { id: 'conv' },
+          channelId: 'test',
+          recipient: { id: 'bot' },
+          serviceUrl: 'https://test.example'
+        }))
+      }
+    }
+
+    class NonErrorThrownValue {
+      message: string
+
+      constructor (message: string) {
+        this.message = message
       }
     }
 
@@ -501,6 +533,28 @@ describe('Application', () => {
       serviceUrl: 'https://test.example',
       value: { token: 'mytoken', id: 'exchangeId' }
     })
+
+    const flushDetachedCall = async () => {
+      await new Promise(resolve => setImmediate(resolve))
+      await new Promise(resolve => setImmediate(resolve))
+    }
+
+    const assertNoUnhandledRejection = async (action: () => Promise<void>) => {
+      const unhandledRejections: unknown[] = []
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason)
+      }
+
+      process.on('unhandledRejection', onUnhandledRejection)
+      try {
+        await action()
+        await flushDetachedCall()
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection)
+      }
+
+      assert.deepEqual(unhandledRejections, [])
+    }
 
     it('should detach signin/tokenExchange and return true immediately', async () => {
       const trackingAdapter = new TrackingAdapter()
@@ -541,15 +595,7 @@ describe('Application', () => {
       // Execute the continuation synchronously to verify the handler is eventually called
       if (trackingAdapter.continueConversationCallback) {
         // The continuation context activity will be overwritten by the original tokenExchange activity
-        const continuationCtx = new TurnContext(trackingAdapter, Activity.fromObject({
-          type: ActivityTypes.Message,
-          text: 'placeholder',
-          from: { id: 'user', name: 'user' },
-          conversation: { id: 'conv' },
-          channelId: 'test',
-          recipient: { id: 'bot' },
-          serviceUrl: 'https://test.example'
-        }))
+        const continuationCtx = trackingAdapter.createContinuationContext()
         await trackingAdapter.continueConversationCallback(continuationCtx)
       }
       assert.equal(handlerCalled, true, 'invoke handler should be called in the continuation')
@@ -582,6 +628,89 @@ describe('Application', () => {
 
       assert.equal(handled, true)
       assert.equal(trackingAdapter.continueConversationCalled, true, 'continueConversation should be called for longRunningMessages')
+    })
+
+    it('should not emit unhandledRejection when detached handler throws', async () => {
+      const trackingAdapter = new TrackingAdapter()
+      trackingAdapter.runContinuationAsync = true
+      const localApp = new AgentApplication({ adapter: trackingAdapter as any })
+      const expectedError = new Error('handler failed')
+
+      localApp.onActivity(ActivityTypes.Invoke, async () => {
+        throw expectedError
+      })
+
+      await assertNoUnhandledRejection(async () => {
+        const context = new TurnContext(trackingAdapter, createTokenExchangeActivity())
+        const handled = await localApp.runInternal(context)
+
+        assert.equal(handled, true)
+      })
+    })
+
+    it('should not emit unhandledRejection when continueConversation rejects', async () => {
+      const trackingAdapter = new TrackingAdapter()
+      trackingAdapter.continueConversationError = new Error('continue failed')
+      const localApp = new AgentApplication({ adapter: trackingAdapter as any })
+
+      await assertNoUnhandledRejection(async () => {
+        const context = new TurnContext(trackingAdapter, createTokenExchangeActivity())
+        const handled = await localApp.runInternal(context)
+
+        assert.equal(handled, true)
+      })
+    })
+
+    it('should forward continueConversation rejections to onError', async () => {
+      const trackingAdapter = new TrackingAdapter()
+      const expectedError = new Error('continue failed')
+      trackingAdapter.continueConversationError = expectedError
+      const localApp = new AgentApplication({ adapter: trackingAdapter as any })
+      let actualError: Error | undefined
+      let actualActivityType: string | undefined
+      let actualActivityId: string | undefined
+
+      localApp.onError(async (context, error) => {
+        actualError = error
+        actualActivityType = context.activity.type
+        actualActivityId = context.activity.id
+      })
+
+      const activity = createTokenExchangeActivity()
+      activity.id = 'activity-1'
+      const context = new TurnContext(trackingAdapter, activity)
+      const handled = await localApp.runInternal(context)
+      await flushDetachedCall()
+
+      assert.equal(handled, true)
+      assert.equal(actualError, expectedError)
+      assert.equal(actualActivityType, ActivityTypes.Invoke)
+      assert.equal(actualActivityId, 'activity-1')
+    })
+
+    it('should normalize non-Error detached handler rejections before forwarding to onError', async () => {
+      const trackingAdapter = new TrackingAdapter()
+      trackingAdapter.runContinuationAsync = true
+      const localApp = new AgentApplication({ adapter: trackingAdapter as any })
+      let actualError: Error | undefined
+
+      localApp.onError(async (_context, error) => {
+        actualError = error
+      })
+
+      localApp.onActivity(ActivityTypes.Invoke, async () => {
+        throw new NonErrorThrownValue('handler failed')
+      })
+
+      await assertNoUnhandledRejection(async () => {
+        const context = new TurnContext(trackingAdapter, createTokenExchangeActivity())
+        const handled = await localApp.runInternal(context)
+
+        assert.equal(handled, true)
+      })
+
+      assert.ok(actualError instanceof Error)
+      assert.match(actualError.message, /handler failed/)
     })
   })
 })


### PR DESCRIPTION
Fixes # 1171

## Summary

Fixes long-running turn error handling so detached failures from `startLongRunningCall` are captured consistently and routed through the configured `onError` / `onTurnError` path.

## Changes

- Routes `continueConversationAsync` rejections through the long-running error handler.
- Preserves fire-and-forget behavior for long-running turns.
- Normalizes non-`Error` thrown values before forwarding to error handling.
- Adds regression coverage for detached handler failures, `continueConversation` rejections, and unhandled rejection prevention.

## Testing
The following image shows the captured errors correctly working.
<img width="2094" height="633" alt="image" src="https://github.com/user-attachments/assets/0b103c26-4119-461e-98b4-e0e5400fa7da" />
