### PR TITLE
[#1164] Fresh token fetches on every activity causing latency

### DIFF
--- a/packages/agents-hosting/src/auth/MemoryCache.ts
+++ b/packages/agents-hosting/src/auth/MemoryCache.ts
@@ -22,11 +22,16 @@ export class MemoryCache<T> {
     }
   }
 
+  clear (): void {
+    this.cache.clear()
+  }
+
   set (key: string, value: T, ttlSeconds: number): void {
     const validUntil = Date.now() + (ttlSeconds * 1000)
     this.cache.set(key, { value, validUntil })
     if (!this.purgeInterval) {
       this.purgeInterval = setInterval(() => this.purge(), CACHE_PURGE_INTERVAL)
+      this.purgeInterval.unref?.()
     }
   }
 

--- a/packages/agents-hosting/src/auth/MemoryCache.ts
+++ b/packages/agents-hosting/src/auth/MemoryCache.ts
@@ -24,6 +24,7 @@ export class MemoryCache<T> {
 
   clear (): void {
     this.cache.clear()
+    this.destroy()
   }
 
   set (key: string, value: T, ttlSeconds: number): void {

--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -29,14 +29,7 @@ function getJwksClient (jwksUri: string): JwksClient {
   // Check if a client for this JWKS URI already exists in the cache.
   let client = jwksClients.get(jwksUri)
   if (!client) {
-    client = jwksRsa({
-      jwksUri,
-      cache: true,
-      cacheMaxEntries: 10,
-      cacheMaxAge: 600000,
-      rateLimit: true,
-      jwksRequestsPerMinute: 10
-    })
+    client = jwksRsa({ jwksUri })
     jwksClients.set(jwksUri, client)
   }
   return client

--- a/packages/agents-hosting/src/auth/jwt-middleware.ts
+++ b/packages/agents-hosting/src/auth/jwt-middleware.ts
@@ -11,6 +11,7 @@ import jwt, { JwtHeader, JwtPayload, SignCallback, GetPublicKeyOrSecret } from '
 import { debug } from '@microsoft/agents-telemetry'
 
 const logger = debug('agents:jwt-middleware')
+const jwksClients = new Map<string, JwksClient>()
 
 /**
  * Builds the JWKS URI for the given token issuer and auth configuration.
@@ -22,6 +23,23 @@ export function buildJwksUri (iss: string, authConfig: AuthConfiguration): strin
   return iss === 'https://api.botframework.com'
     ? 'https://login.botframework.com/v1/.well-known/keys'
     : `${resolveAuthority(authConfig.authorityEndpoint ?? authConfig.authority, authConfig.tenantId)}/discovery/v2.0/keys`
+}
+
+function getJwksClient (jwksUri: string): JwksClient {
+  // Check if a client for this JWKS URI already exists in the cache.
+  let client = jwksClients.get(jwksUri)
+  if (!client) {
+    client = jwksRsa({
+      jwksUri,
+      cache: true,
+      cacheMaxEntries: 10,
+      cacheMaxAge: 600000,
+      rateLimit: true,
+      jwksRequestsPerMinute: 10
+    })
+    jwksClients.set(jwksUri, client)
+  }
+  return client
 }
 
 /**
@@ -55,9 +73,10 @@ const verifyToken = async (raw: string, config: AuthConfiguration): Promise<JwtP
   const jwksUri = buildJwksUri(payload.iss as string, authConfig)
 
   logger.debug(`fetching keys from ${jwksUri}`)
-  const jwksClient: JwksClient = jwksRsa({ jwksUri })
+  const jwksClient = getJwksClient(jwksUri)
 
   const getKey: GetPublicKeyOrSecret = (header: JwtHeader, callback: SignCallback) => {
+    // Retrieve the public, issuer-wide signing key from the JWKS endpoint using the kid from the token header.
     jwksClient.getSigningKey(header.kid, (err: Error | null, key: SigningKey | undefined): void => {
       if (err) {
         logger.error('jwksClient.getSigningKey ', JSON.stringify(err))

--- a/packages/agents-hosting/src/auth/msalTokenProvider.ts
+++ b/packages/agents-hosting/src/auth/msalTokenProvider.ts
@@ -3,13 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import { ConfidentialClientApplication, LogLevel, ManagedIdentityApplication, NodeSystemOptions } from '@azure/msal-node'
+import { AuthenticationResult, ConfidentialClientApplication, LogLevel, ManagedIdentityApplication, NodeSystemOptions } from '@azure/msal-node'
 import { AuthConfiguration, AuthType, resolveAuthority as resolveAuthorityUtil } from './authConfiguration'
 import { AuthProvider } from './authProvider'
 import { debug, trace } from '@microsoft/agents-telemetry'
 import { randomUUID } from 'crypto'
 import { MemoryCache } from './MemoryCache'
-import jwt from 'jsonwebtoken'
+import jwt, { JwtPayload } from 'jsonwebtoken'
 
 import fs from 'fs'
 import crypto from 'crypto'
@@ -33,12 +33,251 @@ function createTokenRequestTimeoutError (timeoutMs: number): Error {
  * Provides tokens using MSAL.
  */
 export class MsalTokenProvider implements AuthProvider {
-  private readonly _agenticTokenCache: MemoryCache<string>
+  private static readonly _accessTokenCache = new MemoryCache<string>()
+  private static readonly _agenticTokenCache = new MemoryCache<string>()
+  private static readonly _confidentialClients = new Map<string, ConfidentialClientApplication>()
   public readonly connectionSettings?: AuthConfiguration
 
   constructor (connectionSettings?: AuthConfiguration) {
-    this._agenticTokenCache = new MemoryCache<string>()
     this.connectionSettings = connectionSettings
+  }
+
+  /**
+   * Clears process-wide auth caches.
+   */
+  public static clearSharedCaches (): void {
+    MsalTokenProvider._accessTokenCache.clear()
+    MsalTokenProvider._agenticTokenCache.clear()
+    MsalTokenProvider._confidentialClients.clear()
+  }
+
+  private static cacheKey (...parts: Array<string | number | boolean | undefined | null>): string {
+    return JSON.stringify(parts.map(part => part ?? ''))
+  }
+
+  private static digest (value: string | Buffer | undefined): string {
+    return value ? crypto.createHash('sha256').update(value).digest('base64url') : ''
+  }
+
+  private getOrCreateConfidentialClient (
+    cacheKey: string,
+    createClient: () => ConfidentialClientApplication
+  ): ConfidentialClientApplication {
+    const existing = MsalTokenProvider._confidentialClients.get(cacheKey)
+    if (existing) {
+      return existing
+    }
+
+    const created = createClient()
+    MsalTokenProvider._confidentialClients.set(cacheKey, created)
+    return created
+  }
+
+  private resolveConfiguredAuthority (authConfig: AuthConfiguration): string {
+    return `${authConfig.authorityEndpoint ?? authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`
+  }
+
+  private getResolvedAuthType (authConfig: AuthConfiguration): AuthType | string {
+    if (authConfig.authType) {
+      return authConfig.authType
+    }
+    if (authConfig.WIDAssertionFile !== undefined) {
+      return AuthType.WorkloadIdentity
+    }
+    if (authConfig.federatedClientId !== undefined || authConfig.FICClientId !== undefined) {
+      return AuthType.FederatedCredentials
+    }
+    if (authConfig.clientSecret !== undefined) {
+      return AuthType.ClientSecret
+    }
+    if (authConfig.certPemFile !== undefined && authConfig.certKeyFile !== undefined) {
+      return AuthType.Certificate
+    }
+    if (authConfig.clientSecret === undefined && authConfig.certPemFile === undefined && authConfig.certKeyFile === undefined) {
+      return AuthType.UserManagedIdentity
+    }
+    return 'unknown'
+  }
+
+  private getFileCacheIdentity (path?: string): string {
+    if (!path) {
+      return ''
+    }
+
+    try {
+      const stat = fs.statSync(path)
+      return `${path}:${stat.size}:${stat.mtimeMs}`
+    } catch {
+      return path
+    }
+  }
+
+  private getAccessTokenCacheKey (authConfig: AuthConfiguration, scope: string): string {
+    const authType = this.getResolvedAuthType(authConfig)
+    let authority = this.resolveConfiguredAuthority(authConfig)
+    let credentialIdentity = ''
+
+    switch (authType) {
+      case AuthType.ClientSecret:
+        credentialIdentity = MsalTokenProvider.digest(authConfig.clientSecret)
+        break
+      case AuthType.Certificate:
+      case AuthType.CertificateSubjectName:
+        credentialIdentity = MsalTokenProvider.cacheKey(
+          this.getFileCacheIdentity(authConfig.certPemFile),
+          this.getFileCacheIdentity(authConfig.certKeyFile),
+          authConfig.sendX5C
+        )
+        break
+      case AuthType.WorkloadIdentity:
+        authority = `https://login.microsoftonline.com/${authConfig.tenantId}`
+        credentialIdentity = this.getFileCacheIdentity(authConfig.federatedTokenFile ?? authConfig.WIDAssertionFile)
+        break
+      case AuthType.FederatedCredentials:
+        credentialIdentity = authConfig.federatedClientId ?? authConfig.FICClientId ?? ''
+        break
+      case AuthType.UserManagedIdentity:
+        authority = 'managed-identity'
+        credentialIdentity = authConfig.clientId ?? ''
+        break
+      case AuthType.SystemManagedIdentity:
+        authority = 'managed-identity'
+        credentialIdentity = 'system'
+        break
+      default:
+        credentialIdentity = 'unknown'
+    }
+
+    return MsalTokenProvider.cacheKey(
+      'access-token',
+      authType,
+      authority,
+      authConfig.clientId,
+      scope,
+      authConfig.azureRegion,
+      credentialIdentity
+    )
+  }
+
+  private cacheAccessToken (cacheKey: string, token: string, expiresOn?: Date | null): void {
+    const ttlSeconds = this.getTokenCacheTtlSeconds(token, expiresOn)
+    if (ttlSeconds > 0) {
+      MsalTokenProvider._accessTokenCache.set(cacheKey, token, ttlSeconds)
+    }
+  }
+
+  private cacheAgenticToken (cacheKey: string, token: string, ttlSeconds: number): void {
+    const safeTtlSeconds = Math.floor(ttlSeconds) - 300
+    if (safeTtlSeconds > 0) {
+      MsalTokenProvider._agenticTokenCache.set(cacheKey, token, safeTtlSeconds)
+    }
+  }
+
+  private cacheAgenticAuthenticationResult (cacheKey: string, token: AuthenticationResult): void {
+    const ttlSeconds = this.getTokenCacheTtlSeconds(token.accessToken, token.expiresOn)
+    if (ttlSeconds > 0) {
+      MsalTokenProvider._agenticTokenCache.set(cacheKey, token.accessToken, ttlSeconds)
+    }
+  }
+
+  private getAgenticTokenCacheKey (
+    tenantId: string,
+    clientId: string,
+    scopes: string[],
+    tokenBodyParameters: { [key: string]: any }
+  ): string {
+    const bodyKey = Object.keys(tokenBodyParameters)
+      .sort()
+      .filter(key => key !== 'user_federated_identity_credential')
+      .map(key => `${key}=${MsalTokenProvider.digest(String(tokenBodyParameters[key]))}`)
+      .join('&')
+
+    return MsalTokenProvider.cacheKey(
+      'agentic-token',
+      this.resolveAuthority(tenantId),
+      clientId,
+      scopes.join(' '),
+      bodyKey
+    )
+  }
+
+  private getTokenCacheTtlSeconds (token: string, expiresOn?: Date | null): number {
+    const expiresAtMs = expiresOn?.getTime() ?? this.getJwtExpiresAtMs(token)
+    if (!expiresAtMs) {
+      return 0
+    }
+
+    return Math.floor((expiresAtMs - Date.now()) / 1000) - 300
+  }
+
+  private getJwtExpiresAtMs (token: string): number | undefined {
+    const payload = jwt.decode(token) as JwtPayload | string | null
+    if (!payload || typeof payload === 'string' || typeof payload.exp !== 'number') {
+      return undefined
+    }
+
+    return payload.exp * 1000
+  }
+
+  private getClientSecretClient (authConfig: AuthConfiguration): ConfidentialClientApplication {
+    const cacheKey = MsalTokenProvider.cacheKey(
+      'confidential-client',
+      AuthType.ClientSecret,
+      authConfig.clientId,
+      this.resolveConfiguredAuthority(authConfig),
+      MsalTokenProvider.digest(authConfig.clientSecret)
+    )
+
+    return this.getOrCreateConfidentialClient(cacheKey, () => new ConfidentialClientApplication({
+      auth: {
+        clientId: authConfig.clientId as string,
+        authority: this.resolveConfiguredAuthority(authConfig),
+        clientSecret: authConfig.clientSecret
+      },
+      system: this.sysOptions
+    }))
+  }
+
+  private getCertificateClient (authConfig: AuthConfiguration): ConfidentialClientApplication {
+    const cacheKey = MsalTokenProvider.cacheKey(
+      'confidential-client',
+      authConfig.authType ?? AuthType.Certificate,
+      authConfig.clientId,
+      this.resolveConfiguredAuthority(authConfig),
+      this.getFileCacheIdentity(authConfig.certPemFile),
+      this.getFileCacheIdentity(authConfig.certKeyFile),
+      authConfig.sendX5C
+    )
+
+    return this.getOrCreateConfidentialClient(cacheKey, () => {
+      const privateKeySource = fs.readFileSync(authConfig.certKeyFile as string)
+
+      const privateKeyObject = crypto.createPrivateKey({
+        key: privateKeySource,
+        format: 'pem'
+      })
+
+      const privateKey = privateKeyObject.export({
+        format: 'pem',
+        type: 'pkcs8'
+      })
+
+      const pemFile = fs.readFileSync(authConfig.certPemFile as string)
+      const pubKeyObject = new crypto.X509Certificate(pemFile)
+
+      return new ConfidentialClientApplication({
+        auth: {
+          clientId: authConfig.clientId || '',
+          authority: this.resolveConfiguredAuthority(authConfig),
+          clientCertificate: {
+            privateKey: privateKey as string,
+            thumbprint: pubKeyObject.fingerprint.replaceAll(':', ''),
+            x5c: pemFile.toString()
+          }
+        },
+        system: this.sysOptions
+      })
+    })
   }
 
   /**
@@ -77,6 +316,13 @@ export class MsalTokenProvider implements AuthProvider {
       if (!authConfig.clientId && process.env.NODE_ENV !== 'production') {
         record({ method: 'unknown' })
         return ''
+      }
+
+      const accessTokenCacheKey = this.getAccessTokenCacheKey(authConfig, actualScope)
+      const cachedAccessToken = MsalTokenProvider._accessTokenCache.get(accessTokenCacheKey)
+      if (cachedAccessToken) {
+        logger.debug('getAccessToken cache hit clientId=%s scope=%s', authConfig.clientId, actualScope)
+        return cachedAccessToken
       }
 
       let token
@@ -153,6 +399,7 @@ export class MsalTokenProvider implements AuthProvider {
         throw ExceptionHelper.generateException(Error, Errors.FailedToAcquireToken)
       }
 
+      this.cacheAccessToken(accessTokenCacheKey, token)
       return token
     })
   }
@@ -187,14 +434,7 @@ export class MsalTokenProvider implements AuthProvider {
       record({ scopes: actualScopes })
       logger.debug('acquireTokenOnBehalfOf clientId=%s scopes=%o', authConfig.clientId, actualScopes)
 
-      const cca = new ConfidentialClientApplication({
-        auth: {
-          clientId: authConfig.clientId as string,
-          authority: `${authConfig.authorityEndpoint ?? authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`,
-          clientSecret: authConfig.clientSecret
-        },
-        system: this.sysOptions
-      })
+      const cca = this.getClientSecretClient(authConfig)
       const token = await cca.acquireTokenOnBehalfOf({
         oboAssertion: actualOboAssertion,
         scopes: actualScopes
@@ -215,6 +455,19 @@ export class MsalTokenProvider implements AuthProvider {
       if (!this.connectionSettings) {
         throw new Error('Connection settings must be provided when calling getAgenticInstanceToken')
       }
+
+      const instanceTokenCacheKey = MsalTokenProvider.cacheKey(
+        'agentic-instance-token',
+        this.resolveAuthority(tenantId),
+        agentAppInstanceId,
+        this.connectionSettings.clientId,
+        this.connectionSettings.azureRegion
+      )
+      const cachedInstanceToken = MsalTokenProvider._agenticTokenCache.get(instanceTokenCacheKey)
+      if (cachedInstanceToken) {
+        return cachedInstanceToken
+      }
+
       const appToken = await this.getAgenticApplicationToken(tenantId, agentAppInstanceId)
       const cca = new ConfidentialClientApplication({
         auth: {
@@ -235,6 +488,7 @@ export class MsalTokenProvider implements AuthProvider {
         throw new Error(`Failed to acquire instance token for agent instance: ${agentAppInstanceId}`)
       }
 
+      this.cacheAgenticAuthenticationResult(instanceTokenCacheKey, token)
       return token.accessToken
     })
   }
@@ -286,9 +540,9 @@ export class MsalTokenProvider implements AuthProvider {
 
     logger.debug('acquireTokenForAgenticScenarios clientId=%s tenantId=%s scopes=%o grant_type=%s', clientId, tenantId, scopes, tokenBodyParameters.grant_type)
     // Check cache first
-    const cacheKey = `${clientId}/${Object.keys(tokenBodyParameters).map(key => key !== 'user_federated_identity_credential' ? `${key}=${tokenBodyParameters[key]}` : '').join('&')}/${scopes.join(';')}`
-    if (this._agenticTokenCache.get(cacheKey)) {
-      return this._agenticTokenCache.get(cacheKey) as string
+    const cacheKey = this.getAgenticTokenCacheKey(tenantId, clientId, scopes, tokenBodyParameters)
+    if (MsalTokenProvider._agenticTokenCache.get(cacheKey)) {
+      return MsalTokenProvider._agenticTokenCache.get(cacheKey) as string
     }
 
     const url = `${this.resolveAuthority(tenantId)}/oauth2/v2.0/token`
@@ -344,7 +598,7 @@ export class MsalTokenProvider implements AuthProvider {
     })
 
     // capture token, expire local cache 5 minutes early
-    this._agenticTokenCache.set(cacheKey, token.access_token, token.expires_in - 300)
+    this.cacheAgenticToken(cacheKey, token.access_token, token.expires_in)
     return token.access_token
   }
 
@@ -353,13 +607,22 @@ export class MsalTokenProvider implements AuthProvider {
       logger.debug('getAgenticUserToken tenantId=%s agentAppInstanceId=%s scopes=%o', tenantId, agentAppInstanceId, scopes)
       record({ agenticInstanceId: agentAppInstanceId, agenticUserId, scopes })
 
+      const userTokenParameters = {
+        user_id: agenticUserId,
+        grant_type: 'user_fic',
+      }
+      const userTokenCacheKey = this.getAgenticTokenCacheKey(tenantId, agentAppInstanceId, scopes, userTokenParameters)
+      const cachedUserToken = MsalTokenProvider._agenticTokenCache.get(userTokenCacheKey)
+      if (cachedUserToken) {
+        return cachedUserToken
+      }
+
       const agentToken = await this.getAgenticApplicationToken(tenantId, agentAppInstanceId)
       const instanceToken = await this.getAgenticInstanceToken(tenantId, agentAppInstanceId)
 
       const token = await this.acquireTokenForAgenticScenarios(tenantId, agentAppInstanceId, agentToken, scopes, {
-        user_id: agenticUserId,
+        ...userTokenParameters,
         user_federated_identity_credential: instanceToken,
-        grant_type: 'user_fic',
       })
 
       if (!token) {
@@ -559,33 +822,7 @@ export class MsalTokenProvider implements AuthProvider {
    * @returns A promise that resolves to the access token.
    */
   private async acquireTokenWithCertificate (authConfig: AuthConfiguration, scope: string) {
-    const privateKeySource = fs.readFileSync(authConfig.certKeyFile as string)
-
-    const privateKeyObject = crypto.createPrivateKey({
-      key: privateKeySource,
-      format: 'pem'
-    })
-
-    const privateKey = privateKeyObject.export({
-      format: 'pem',
-      type: 'pkcs8'
-    })
-
-    const pemFile = fs.readFileSync(authConfig.certPemFile as string)
-    const pubKeyObject = new crypto.X509Certificate(pemFile)
-
-    const cca = new ConfidentialClientApplication({
-      auth: {
-        clientId: authConfig.clientId || '',
-        authority: `${authConfig.authorityEndpoint ?? authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`,
-        clientCertificate: {
-          privateKey: privateKey as string,
-          thumbprint: pubKeyObject.fingerprint.replaceAll(':', ''),
-          x5c: pemFile.toString()
-        }
-      },
-      system: this.sysOptions
-    })
+    const cca = this.getCertificateClient(authConfig)
     const token = await cca.acquireTokenByClientCredential({
       scopes: [`${scope}/.default`],
       correlationId: randomUUID(),
@@ -604,14 +841,7 @@ export class MsalTokenProvider implements AuthProvider {
    * @returns A promise that resolves to the access token.
    */
   private async acquireAccessTokenViaSecret (authConfig: AuthConfiguration, scope: string) {
-    const cca = new ConfidentialClientApplication({
-      auth: {
-        clientId: authConfig.clientId as string,
-        authority: `${authConfig.authorityEndpoint ?? authConfig.authority}/${authConfig.tenantId || 'botframework.com'}`,
-        clientSecret: authConfig.clientSecret
-      },
-      system: this.sysOptions
-    })
+    const cca = this.getClientSecretClient(authConfig)
     const token = await cca.acquireTokenByClientCredential({
       scopes: [`${scope}/.default`],
       correlationId: randomUUID(),

--- a/packages/agents-hosting/src/oauth/userTokenClient.ts
+++ b/packages/agents-hosting/src/oauth/userTokenClient.ts
@@ -35,6 +35,10 @@ function formatHttpErrorMessage (error: HttpError): string {
 export class UserTokenClient {
   client: HttpClient
   private msAppId: string = ''
+  private authProvider?: AuthProvider
+  private authScope?: string
+  private authInitialized = false
+  private authInitialization?: Promise<void>
   /**
    * Creates a new instance of UserTokenClient.
    * @param msAppId The Microsoft application ID.
@@ -45,8 +49,15 @@ export class UserTokenClient {
    * @param httpClient The HttpClient instance.
    */
   constructor (httpClient: HttpClient)
+  /**
+   * Creates a new instance of UserTokenClient with lazy authentication.
+   * @param httpClient The HttpClient instance.
+   * @param authProvider The authentication provider.
+   * @param authScope The authentication scope.
+   */
+  constructor (httpClient: HttpClient, authProvider?: AuthProvider, authScope?: string)
 
-  constructor (param: string | HttpClient) {
+  constructor (param: string | HttpClient, authProvider?: AuthProvider, authScope?: string) {
     if (typeof param === 'string') {
       const baseURL = getTokenServiceEndpoint()
       this.client = new HttpClient({
@@ -59,6 +70,10 @@ export class UserTokenClient {
     } else {
       this.client = param
     }
+
+    this.authProvider = authProvider
+    this.authScope = authScope
+    this.authInitialized = Boolean(this.client.defaultHeaders.authorization)
   }
 
   /**
@@ -83,18 +98,12 @@ export class UserTokenClient {
       'Content-Type': 'application/json',
     })
 
-    const clientHeaders: Record<string, string> = { ...headerPropagation.outgoing }
-    const token = await authProvider?.getAccessToken(scope)
-    if (token && token.length > 1) {
-      clientHeaders.Authorization = `Bearer ${token}`
-    }
-
     const httpClient = new HttpClient({
       baseURL,
-      headers: clientHeaders,
+      headers: { ...headerPropagation.outgoing },
     })
 
-    return new UserTokenClient(httpClient)
+    return new UserTokenClient(httpClient, authProvider, scope)
   }
 
   /**
@@ -253,9 +262,13 @@ export class UserTokenClient {
 
   public updateAuthToken (token: string): void {
     this.client.setHeader('Authorization', `Bearer ${token}`)
+    this.authInitialized = true
+    this.authInitialization = undefined
   }
 
   private async executeRequest<T = unknown> (method: string, url: string, data?: unknown, options?: { params?: Record<string, string | undefined> }): Promise<{ data: T, status: number, statusText: string }> {
+    await this.ensureAuthorizationHeader()
+
     const { params } = options ?? {}
     const { Authorization, authorization, ...headersToLog } = this.client.defaultHeaders
     logger.debug('Request: ', {
@@ -304,5 +317,26 @@ export class UserTokenClient {
       }
       throw error
     }
+  }
+
+  private async ensureAuthorizationHeader (): Promise<void> {
+    if (this.authInitialized || !this.authProvider || !this.authScope) {
+      return
+    }
+
+    if (!this.authInitialization) {
+      this.authInitialization = this.authProvider.getAccessToken(this.authScope)
+        .then((token) => {
+          if (token && token.length > 1) {
+            this.client.setHeader('Authorization', `Bearer ${token}`)
+          }
+          this.authInitialized = true
+        })
+        .finally(() => {
+          this.authInitialization = undefined
+        })
+    }
+
+    await this.authInitialization
   }
 }

--- a/packages/agents-hosting/src/oauth/userTokenClient.ts
+++ b/packages/agents-hosting/src/oauth/userTokenClient.ts
@@ -329,8 +329,8 @@ export class UserTokenClient {
         .then((token) => {
           if (token && token.length > 1) {
             this.client.setHeader('Authorization', `Bearer ${token}`)
+            this.authInitialized = true
           }
-          this.authInitialized = true
         })
         .finally(() => {
           this.authInitialization = undefined

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -81,6 +81,37 @@ describe('MsalTokenProvider', () => {
     assert.strictEqual(acquireTokenStub.calledOnce, true)
   })
 
+  it('should reacquire shared access tokens after the JWT-derived cache TTL expires', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2026-01-01T00:00:00.000Z').getTime(), toFake: ['Date'] })
+    const firstAccessToken = createExpiringJwtToken(301)
+    const secondAccessToken = createExpiringJwtToken(3600)
+    const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential')
+    acquireTokenStub.onFirstCall().resolves({ accessToken: firstAccessToken } as any)
+    acquireTokenStub.onSecondCall().resolves({ accessToken: secondAccessToken } as any)
+
+    try {
+      const connectionSettings: AuthConfiguration = {
+        clientId: 'shared-client-id',
+        clientSecret: 'shared-secret',
+        tenantId: 'shared-tenant-id'
+      }
+
+      const firstProvider = new MsalTokenProvider(connectionSettings)
+      const secondProvider = new MsalTokenProvider({ ...connectionSettings })
+
+      assert.strictEqual(await firstProvider.getAccessToken('scope'), firstAccessToken)
+      assert.strictEqual(await secondProvider.getAccessToken('scope'), firstAccessToken)
+      assert.strictEqual(acquireTokenStub.calledOnce, true)
+
+      clock.tick(1001)
+
+      assert.strictEqual(await secondProvider.getAccessToken('scope'), secondAccessToken)
+      assert.strictEqual(acquireTokenStub.calledTwice, true)
+    } finally {
+      clock.restore()
+    }
+  })
+
   it('should reuse confidential clients across token provider instances', async () => {
     const clientInstances = new Set<unknown>()
     const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').callsFake(async function (this: unknown) {
@@ -377,6 +408,34 @@ describe('MsalTokenProvider', () => {
     assert.strictEqual(fetchStub.calledTwice, true)
     assert.strictEqual(getFetchUrl(fetchStub), 'https://login.microsoftonline.com/tenant-a/oauth2/v2.0/token')
     assert.strictEqual(fetchStub.getCall(1).args[0], 'https://login.microsoftonline.com/tenant-b/oauth2/v2.0/token')
+  })
+
+  it('should refetch agentic application tokens after the cache TTL expires', async () => {
+    const clock = sinon.useFakeTimers({ now: new Date('2026-01-01T00:00:00.000Z').getTime(), toFake: ['Date'] })
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      tenantId: 'common',
+    })
+
+    const fetchStub = sinon.stub(global, 'fetch')
+    fetchStub.onFirstCall().resolves(new Response(JSON.stringify({ access_token: 'agent-app-token-one', expires_in: 301 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    fetchStub.onSecondCall().resolves(new Response(JSON.stringify({ access_token: 'agent-app-token-two', expires_in: 3600 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+
+    try {
+      assert.strictEqual(await tokenProvider.getAgenticApplicationToken('tenant-id', 'agent-app-instance-id'), 'agent-app-token-one')
+      assert.strictEqual(await tokenProvider.getAgenticApplicationToken('tenant-id', 'agent-app-instance-id'), 'agent-app-token-one')
+      assert.strictEqual(fetchStub.calledOnce, true)
+
+      clock.tick(1001)
+
+      assert.strictEqual(await tokenProvider.getAgenticApplicationToken('tenant-id', 'agent-app-instance-id'), 'agent-app-token-two')
+      assert.strictEqual(fetchStub.calledTwice, true)
+    } finally {
+      MsalTokenProvider.clearSharedCaches()
+      fetchStub.restore()
+      clock.restore()
+    }
   })
 
   it('should return cached agentic user token before reacquiring prerequisite tokens', async () => {

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -240,9 +240,7 @@ describe('MsalTokenProvider', () => {
       assert.ok(url === 'https://foo.bar.com/agentic-tenant-id/oauth2/v2.0/token', `Expected URL to contain 'tenant-id', got: ${url}`)
       assert.ok(!url.includes('common'), `Expected URL to NOT contain 'common', got: ${url}`)
     } finally {
-      // stop caching
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
       fetchStub.restore()
     }
   })
@@ -263,8 +261,7 @@ describe('MsalTokenProvider', () => {
       const options = getFetchOptions(fetchStub)
       assert.ok(options.signal instanceof AbortSignal)
     } finally {
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
       fetchStub.restore()
     }
   })
@@ -301,8 +298,7 @@ describe('MsalTokenProvider', () => {
       await rejection
       assert.strictEqual(fetchStub.called, true)
     } finally {
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
       fetchStub.restore()
       clock.restore()
     }
@@ -328,9 +324,7 @@ describe('MsalTokenProvider', () => {
       assert.ok(url === 'https://login.microsoftonline.com/A0000009-0000-0000-0000-0000000000AF/oauth2/v2.0/token', `Expected URL to contain 'A0000009-0000-0000-0000-0000000000AF', got: ${url}`)
       assert.ok(!url.includes('common'), `Expected URL to NOT contain 'common', got: ${url}`)
     } finally {
-      // stop caching
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
       fetchStub.restore()
     }
   })
@@ -355,9 +349,7 @@ describe('MsalTokenProvider', () => {
       const url = getFetchUrl(fetchStub)
       assert.ok(url === 'http://foo.bar/original-tenant-id/oauth2/v2.0/token', `Expected URL to contain 'foo.bar', got: ${url}`)
     } finally {
-      // stop caching
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
       fetchStub.restore()
     }
   })
@@ -381,9 +373,7 @@ describe('MsalTokenProvider', () => {
       const url = getFetchUrl(fetchStub)
       assert.ok(url === 'https://login.microsoftonline.com/original-tenant-id/oauth2/v2.0/token', `Expected URL to contain 'https://login.microsoftonline.com/original-tenant-id/oauth2/v2.0/token', got: ${url}`)
     } finally {
-      // stop caching
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
       fetchStub.restore()
     }
   })
@@ -698,8 +688,7 @@ describe('MsalTokenProvider', () => {
       assert.strictEqual(signOptions.header.typ, 'JWT')
       assert.ok(signOptions.header['x5t#S256'], 'x5t#S256 thumbprint should be present')
     } finally {
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
     }
   })
 
@@ -737,8 +726,7 @@ describe('MsalTokenProvider', () => {
       const signOptions = jwtSignStub.getCall(0).args[2] as jwt.SignOptions & { header: any }
       assert.strictEqual(signOptions.header.x5c, undefined, 'x5c header should not be set when sendX5C is false')
     } finally {
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
     }
   })
 
@@ -775,8 +763,7 @@ describe('MsalTokenProvider', () => {
       const signOptions = jwtSignStub.getCall(0).args[2] as jwt.SignOptions & { header: any }
       assert.strictEqual(signOptions.header.x5c, undefined, 'x5c header should not be set when sendX5C is not provided')
     } finally {
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
     }
   })
 
@@ -832,8 +819,7 @@ describe('MsalTokenProvider', () => {
       assert.strictEqual(postData.client_assertion, 'fake-jwt-with-x5c', 'client_assertion should be the JWT signed with x5c')
       assert.strictEqual(postData.client_assertion_type, 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer')
     } finally {
-      // @ts-ignore
-      tokenProvider._agenticTokenCache.destroy()
+      MsalTokenProvider.clearSharedCaches()
     }
   })
 

--- a/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
+++ b/packages/agents-hosting/test/hosting/msalTokenProvider.test.ts
@@ -25,11 +25,16 @@ function getFetchOptions (fetchStub: sinon.SinonStub): RequestInit {
   return fetchStub.getCall(0).args[1] as RequestInit
 }
 
+function createExpiringJwtToken (expiresInSeconds = 3600): string {
+  return jwt.sign({ exp: Math.floor(Date.now() / 1000) + expiresInSeconds }, 'secret')
+}
+
 describe('MsalTokenProvider', () => {
   let msalTokenProvider: MsalTokenProvider
   let authConfig: AuthConfiguration
 
   beforeEach(() => {
+    MsalTokenProvider.clearSharedCaches()
     msalTokenProvider = new MsalTokenProvider()
     authConfig = {
       clientId: 'test-client-id',
@@ -42,6 +47,7 @@ describe('MsalTokenProvider', () => {
   })
 
   afterEach(() => {
+    MsalTokenProvider.clearSharedCaches()
     sinon.restore()
   })
 
@@ -56,6 +62,42 @@ describe('MsalTokenProvider', () => {
     sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken: 'test-token' })
     const token = await msalTokenProvider.getAccessToken(authConfig, 'scope')
     assert.strictEqual(token, 'test-token')
+  })
+
+  it('should share cached access tokens across token provider instances', async () => {
+    const accessToken = createExpiringJwtToken()
+    const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({ accessToken } as any)
+    const connectionSettings: AuthConfiguration = {
+      clientId: 'shared-client-id',
+      clientSecret: 'shared-secret',
+      tenantId: 'shared-tenant-id'
+    }
+
+    const firstProvider = new MsalTokenProvider(connectionSettings)
+    const secondProvider = new MsalTokenProvider({ ...connectionSettings })
+
+    assert.strictEqual(await firstProvider.getAccessToken('scope'), accessToken)
+    assert.strictEqual(await secondProvider.getAccessToken('scope'), accessToken)
+    assert.strictEqual(acquireTokenStub.calledOnce, true)
+  })
+
+  it('should reuse confidential clients across token provider instances', async () => {
+    const clientInstances = new Set<unknown>()
+    const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').callsFake(async function (this: unknown) {
+      clientInstances.add(this)
+      return { accessToken: 'opaque-token' } as any
+    })
+    const connectionSettings: AuthConfiguration = {
+      clientId: 'shared-client-id',
+      clientSecret: 'shared-secret',
+      tenantId: 'shared-tenant-id'
+    }
+
+    await new MsalTokenProvider(connectionSettings).getAccessToken('scope-one')
+    await new MsalTokenProvider({ ...connectionSettings }).getAccessToken('scope-two')
+
+    assert.strictEqual(acquireTokenStub.calledTwice, true)
+    assert.strictEqual(clientInstances.size, 1)
   })
 
   it('should acquire token with certificate', async () => {
@@ -313,6 +355,53 @@ describe('MsalTokenProvider', () => {
       tokenProvider._agenticTokenCache.destroy()
       fetchStub.restore()
     }
+  })
+
+  it('should isolate agentic application token cache by tenant authority', async () => {
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      authority: 'https://login.microsoftonline.com',
+      tenantId: 'common',
+    })
+
+    const fetchStub = sinon.stub(global, 'fetch')
+    fetchStub.onFirstCall().resolves(new Response(JSON.stringify({ access_token: 'tenant-a-token', expires_in: 3600 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    fetchStub.onSecondCall().resolves(new Response(JSON.stringify({ access_token: 'tenant-b-token', expires_in: 3600 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+
+    const tenantAToken = await tokenProvider.getAgenticApplicationToken('tenant-a', 'agent-app-instance-id')
+    const tenantBToken = await tokenProvider.getAgenticApplicationToken('tenant-b', 'agent-app-instance-id')
+
+    assert.strictEqual(tenantAToken, 'tenant-a-token')
+    assert.strictEqual(tenantBToken, 'tenant-b-token')
+    assert.strictEqual(fetchStub.calledTwice, true)
+    assert.strictEqual(getFetchUrl(fetchStub), 'https://login.microsoftonline.com/tenant-a/oauth2/v2.0/token')
+    assert.strictEqual(fetchStub.getCall(1).args[0], 'https://login.microsoftonline.com/tenant-b/oauth2/v2.0/token')
+  })
+
+  it('should return cached agentic user token before reacquiring prerequisite tokens', async () => {
+    const tokenProvider = new MsalTokenProvider({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      tenantId: 'common',
+    })
+
+    const fetchStub = sinon.stub(global, 'fetch')
+    fetchStub.onFirstCall().resolves(new Response(JSON.stringify({ access_token: 'agent-app-token', expires_in: 3600 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    fetchStub.onSecondCall().resolves(new Response(JSON.stringify({ access_token: 'agentic-user-token', expires_in: 3600 }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+
+    const acquireTokenStub = sinon.stub(ConfidentialClientApplication.prototype, 'acquireTokenByClientCredential').resolves({
+      accessToken: 'agentic-instance-token',
+      expiresOn: new Date(Date.now() + 3600 * 1000)
+    } as any)
+
+    const firstToken = await tokenProvider.getAgenticUserToken('tenant-id', 'agent-app-instance-id', 'agentic-user-id', ['scope.read'])
+    const secondToken = await tokenProvider.getAgenticUserToken('tenant-id', 'agent-app-instance-id', 'agentic-user-id', ['scope.read'])
+
+    assert.strictEqual(firstToken, 'agentic-user-token')
+    assert.strictEqual(secondToken, 'agentic-user-token')
+    assert.strictEqual(fetchStub.calledTwice, true)
+    assert.strictEqual(acquireTokenStub.calledOnce, true)
   })
 
   it('should call the right authority for multi-tenant setups based on incoming message', async () => {

--- a/packages/agents-hosting/test/hosting/oauth/userTokenClient..test.ts
+++ b/packages/agents-hosting/test/hosting/oauth/userTokenClient..test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from 'assert'
+import { afterEach, describe, it } from 'node:test'
+import sinon from 'sinon'
+import { UserTokenClient } from '../../../src/oauth'
+import { AuthProvider } from '../../../src/auth'
+
+describe('UserTokenClient', () => {
+  describe('UserTokenClient lazy authentication', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should not acquire a bearer token until a token-service API is called', async () => {
+      const authProvider = {
+        getAccessToken: sinon.stub().resolves('lazy-access-token')
+      } as unknown as AuthProvider
+      const fetchStub = sinon.stub(global, 'fetch').resolves(new Response(JSON.stringify([]), { status: 200 }))
+
+      const client = await UserTokenClient.createClientWithScope(
+        'https://api.botframework.com',
+        authProvider,
+        'https://api.botframework.com'
+      )
+
+      assert.strictEqual((authProvider.getAccessToken as sinon.SinonStub).notCalled, true)
+      assert.strictEqual(client.client.defaultHeaders.authorization, undefined)
+
+      await client.getTokenStatus('user-id', 'msteams')
+
+      assert.strictEqual((authProvider.getAccessToken as sinon.SinonStub).calledOnceWithExactly('https://api.botframework.com'), true)
+      assert.strictEqual(client.client.defaultHeaders.authorization, 'Bearer lazy-access-token')
+
+      const requestHeaders = fetchStub.getCall(0).args[1]?.headers as Headers
+      assert.strictEqual(requestHeaders.get('authorization'), 'Bearer lazy-access-token')
+    })
+
+    it('should reuse the lazy bearer token for later token-service API calls', async () => {
+      const authProvider = {
+        getAccessToken: sinon.stub().resolves('lazy-access-token')
+      } as unknown as AuthProvider
+      sinon.stub(global, 'fetch').callsFake(async () => new Response(JSON.stringify([]), { status: 200 }))
+
+      const client = await UserTokenClient.createClientWithScope(
+        'https://api.botframework.com',
+        authProvider,
+        'https://api.botframework.com'
+      )
+
+      await client.getTokenStatus('user-id', 'msteams')
+      await client.getTokenStatus('user-id', 'msteams')
+
+      assert.strictEqual((authProvider.getAccessToken as sinon.SinonStub).calledOnce, true)
+    })
+  })
+})

--- a/packages/agents-hosting/test/hosting/oauth/userTokenClient.test.ts
+++ b/packages/agents-hosting/test/hosting/oauth/userTokenClient.test.ts
@@ -51,5 +51,33 @@ describe('UserTokenClient', () => {
 
       assert.strictEqual((authProvider.getAccessToken as sinon.SinonStub).calledOnce, true)
     })
+
+    it('should retry lazy token acquisition after a short token response', async () => {
+      const getAccessToken = sinon.stub()
+      getAccessToken.onFirstCall().resolves('x')
+      getAccessToken.onSecondCall().resolves('retried-access-token')
+      const authProvider = { getAccessToken } as unknown as AuthProvider
+      const fetchStub = sinon.stub(global, 'fetch').callsFake(async () => new Response(JSON.stringify([]), { status: 200 }))
+
+      const client = await UserTokenClient.createClientWithScope(
+        'https://api.botframework.com',
+        authProvider,
+        'https://api.botframework.com'
+      )
+
+      await client.getTokenStatus('user-id', 'msteams')
+
+      assert.strictEqual(getAccessToken.calledOnceWithExactly('https://api.botframework.com'), true)
+      assert.strictEqual(client.client.defaultHeaders.authorization, undefined)
+      const firstRequestHeaders = fetchStub.getCall(0).args[1]?.headers as Headers
+      assert.strictEqual(firstRequestHeaders.get('authorization'), null)
+
+      await client.getTokenStatus('user-id', 'msteams')
+
+      assert.strictEqual(getAccessToken.calledTwice, true)
+      assert.strictEqual(client.client.defaultHeaders.authorization, 'Bearer retried-access-token')
+      const secondRequestHeaders = fetchStub.getCall(1).args[1]?.headers as Headers
+      assert.strictEqual(secondRequestHeaders.get('authorization'), 'Bearer retried-access-token')
+    })
   })
 })


### PR DESCRIPTION
Fixes # 1164

## Description

This PR introduces several improvements to authentication and token management in the `agents-hosting` package, focusing on enhanced caching, efficiency, and maintainability. The main changes include the introduction of process-wide shared caches for tokens and confidential clients in `MsalTokenProvider`, improved cache key generation, lazy instantiation and reuse of JWKS clients, and the addition of cache clearing methods for easier testing and debugging. The `UserTokenClient` now supports lazy authentication initialization.

### Detailed Changes
**Authentication and Token Caching Improvements:**

* Introduced process-wide shared caches for access tokens, agentic tokens, and confidential client applications in `MsalTokenProvider`, replacing per-instance caches. This centralizes and improves cache hit rates, and enables efficient cache clearing (`MsalTokenProvider.clearSharedCaches`). [[1]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L36-R282) [[2]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4R321-R327) [[3]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4R402) [[4]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4R458-R470) [[5]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4R491) [[6]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L289-R545) [[7]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L347-R601) [[8]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4R610-L362)
* Added robust cache key generation methods that consider all relevant authentication parameters and credentials, reducing cache collisions and ensuring correctness.
* Added a `clear()` method to `MemoryCache` to support explicit cache invalidation.

**Confidential Client and JWKS Management:**

* Implemented process-wide caching and lazy instantiation of `ConfidentialClientApplication` instances in `MsalTokenProvider`, reducing redundant client creation and improving performance. [[1]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L36-R282) [[2]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L190-R437) [[3]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L562-R825) [[4]](diffhunk://#diff-905409fe9c4feacb23276d2fb4dba8da9ff6ac877247075531dab809b2b96ff4L607-R844)
* Added a shared JWKS client cache in JWT middleware to avoid repeated instantiation and improve key retrieval efficiency. [[1]](diffhunk://#diff-5753848bd6f397a0c487f0ef226e11f34e6b037c68a4a050aefa67d8597d59fdR14) [[2]](diffhunk://#diff-5753848bd6f397a0c487f0ef226e11f34e6b037c68a4a050aefa67d8597d59fdR28-R37) [[3]](diffhunk://#diff-5753848bd6f397a0c487f0ef226e11f34e6b037c68a4a050aefa67d8597d59fdL58-R72)

**API and Interface Enhancements:**

* Updated `UserTokenClient` to support lazy authentication initialization via optional `AuthProvider` and `authScope` parameters, improving flexibility for consumers. [[1]](diffhunk://#diff-394ddc5894236f1228ead6d2141128a24f9d83477dd2e2908f56149e63c3f787R38-R41) [[2]](diffhunk://#diff-394ddc5894236f1228ead6d2141128a24f9d83477dd2e2908f56149e63c3f787R52-R60)

These changes collectively improve authentication performance, reduce redundant work, and make the authentication system more robust and testable.

## Testing
These images show the auto-signing sample working.

BEFORE: The token is retrieved in the two oauth steps and for _ConnectorClient_ and _UserTokenClient_ (4 requests).
<img width="1704" height="1392" alt="image" src="https://github.com/user-attachments/assets/7d926047-f8f3-40ec-9320-30b6a1352934" />

AFTER: It fetches only one token for _ConnectorClient_ and it reuses it for _UserTokenClient_ when it needs it (1 request).
<img width="1796" height="1394" alt="image" src="https://github.com/user-attachments/assets/6aa2d0f8-7a93-4e4b-9b66-5bbf3fe1a344" />

<img width="1799" height="483" alt="image" src="https://github.com/user-attachments/assets/6a1caac7-b5fe-4d25-b454-0cfe4ae81453" />
