### PR TITLE
[#1183] agents-copilotstudio-client: Use segment encoding for URL interpolation

### DIFF
--- a/packages/agents-copilotstudio-client/src/powerPlatformEnvironment.ts
+++ b/packages/agents-copilotstudio-client/src/powerPlatformEnvironment.ts
@@ -185,7 +185,7 @@ function createURL (base: string, conversationId?: string): URL {
 
   url.pathname = `${url.pathname}/conversations`
   if (conversationId) {
-    url.pathname = `${url.pathname}/${conversationId}`
+    url.pathname = `${url.pathname}/${encodeURIComponent(conversationId)}`
   }
 
   return url

--- a/packages/agents-copilotstudio-client/src/strategies/prebuiltBotStrategy.ts
+++ b/packages/agents-copilotstudio-client/src/strategies/prebuiltBotStrategy.ts
@@ -28,7 +28,7 @@ export class PrebuiltBotStrategy implements Strategy {
     const host = settings.host
 
     this.baseURL = new URL(
-      `/copilotstudio/prebuilt/authenticated/bots/${schema}`,
+      `/copilotstudio/prebuilt/authenticated/bots/${encodeURIComponent(schema)}`,
       host
     )
     this.baseURL.searchParams.append('api-version', this.API_VERSION)
@@ -39,7 +39,7 @@ export class PrebuiltBotStrategy implements Strategy {
     conversationUrl.pathname = `${conversationUrl.pathname}/conversations`
 
     if (conversationId) {
-      conversationUrl.pathname = `${conversationUrl.pathname}/${conversationId}`
+      conversationUrl.pathname = `${conversationUrl.pathname}/${encodeURIComponent(conversationId)}`
     }
 
     return conversationUrl.href

--- a/packages/agents-copilotstudio-client/src/strategies/publishedBotStrategy.ts
+++ b/packages/agents-copilotstudio-client/src/strategies/publishedBotStrategy.ts
@@ -23,7 +23,7 @@ export class PublishedBotStrategy implements Strategy {
     const { schema, host } = settings
 
     this.baseURL = new URL(
-      `/copilotstudio/dataverse-backed/authenticated/bots/${schema}`,
+      `/copilotstudio/dataverse-backed/authenticated/bots/${encodeURIComponent(schema)}`,
       host
     )
     this.baseURL.searchParams.append('api-version', this.API_VERSION)
@@ -34,7 +34,7 @@ export class PublishedBotStrategy implements Strategy {
     conversationUrl.pathname = `${conversationUrl.pathname}/conversations`
 
     if (conversationId) {
-      conversationUrl.pathname = `${conversationUrl.pathname}/${conversationId}`
+      conversationUrl.pathname = `${conversationUrl.pathname}/${encodeURIComponent(conversationId)}`
     }
 
     return conversationUrl.href

--- a/packages/agents-copilotstudio-client/test/powerPlatformEnvironment.test.ts
+++ b/packages/agents-copilotstudio-client/test/powerPlatformEnvironment.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from 'assert'
+import { describe, it } from 'node:test'
+import {
+  ConnectionSettings,
+  getCopilotStudioConnectionUrl,
+  getCopilotStudioSubscribeUrl,
+  getTokenAudience,
+  PowerPlatformCloud
+} from '../src'
+
+describe('powerPlatformEnvironment', function () {
+  const directConnectUrl = 'https://api.example.test/copilotstudio/bots/test-bot'
+  const conversationId = 'conversation/id?with#reserved characters'
+
+  it('should create a direct connection URL with an encoded conversation ID path segment', function () {
+    const settings: ConnectionSettings = { directConnectUrl }
+
+    assert.equal(
+      getCopilotStudioConnectionUrl(settings, conversationId),
+      `https://api.example.test/copilotstudio/bots/test-bot/conversations/${encodeURIComponent(conversationId)}?api-version=2022-03-01-preview`
+    )
+  })
+
+  it('should create a subscribe URL for a direct connection', function () {
+    const settings: ConnectionSettings = { directConnectUrl }
+
+    assert.equal(
+      getCopilotStudioSubscribeUrl(settings, conversationId),
+      `https://api.example.test/copilotstudio/bots/test-bot/conversations/${encodeURIComponent(conversationId)}/subscribe?api-version=2022-03-01-preview`
+    )
+  })
+
+  it('should get the token audience from a direct connection URL', function () {
+    assert.equal(
+      getTokenAudience(undefined, PowerPlatformCloud.Unknown, '', 'https://api.powerplatform.com/copilotstudio/bots/test-bot'),
+      'https://api.powerplatform.com/.default'
+    )
+  })
+})

--- a/packages/agents-copilotstudio-client/test/prebuiltBotStrategy.test.ts
+++ b/packages/agents-copilotstudio-client/test/prebuiltBotStrategy.test.ts
@@ -1,0 +1,19 @@
+import { strict as assert } from 'assert'
+import { describe, it } from 'node:test'
+import { PrebuiltBotStrategy } from '../src/strategies/prebuiltBotStrategy'
+
+describe('PrebuiltBotStrategy', function () {
+  it('should get conversation URL with encoded schema and conversation ID as path segments', function () {
+    const schema = 'bot/name?with#reserved characters'
+    const conversationId = 'conversation/id?with#reserved characters'
+    const strategy = new PrebuiltBotStrategy({
+      host: new URL('https://api.example.test'),
+      schema
+    })
+
+    assert.equal(
+      strategy.getConversationUrl(conversationId),
+      `https://api.example.test/copilotstudio/prebuilt/authenticated/bots/${encodeURIComponent(schema)}/conversations/${encodeURIComponent(conversationId)}?api-version=2022-03-01-preview`
+    )
+  })
+})

--- a/packages/agents-copilotstudio-client/test/publishedBotStrategy.test.ts
+++ b/packages/agents-copilotstudio-client/test/publishedBotStrategy.test.ts
@@ -1,0 +1,19 @@
+import { strict as assert } from 'assert'
+import { describe, it } from 'node:test'
+import { PublishedBotStrategy } from '../src/strategies/publishedBotStrategy'
+
+describe('PublishedBotStrategy', function () {
+  it('should get conversation URL with encoded schema and conversation ID as URL path segments', function () {
+    const schema = 'bot/name?with#reserved characters'
+    const conversationId = 'conversation/id?with#reserved characters'
+    const strategy = new PublishedBotStrategy({
+      host: new URL('https://api.example.test'),
+      schema
+    })
+
+    assert.equal(
+      strategy.getConversationUrl(conversationId),
+      `https://api.example.test/copilotstudio/dataverse-backed/authenticated/bots/${encodeURIComponent(schema)}/conversations/${encodeURIComponent(conversationId)}?api-version=2022-03-01-preview`
+    )
+  })
+})


### PR DESCRIPTION
Fixes # 1183

## Description
This pull request improves the handling of URL path segments in the Copilot Studio client by ensuring that both `schema` and `conversationId` values are properly URL-encoded wherever they are used to construct URLs. This prevents errors when these values contain reserved or special characters. The changes are verified by new tests covering these encoding scenarios.

**URL Encoding Improvements:**

* Updated `createURL` in `powerPlatformEnvironment.ts` to encode `conversationId` when appending it to the URL path.
* Updated `PrebuiltBotStrategy` and `PublishedBotStrategy` to encode `schema` and `conversationId` in URL path segments. [[1]](diffhunk://#diff-e81f9d924cc2bb480d61a5551d43797e4452c8cef222277435d004b4688a5343L31-R31) [[2]](diffhunk://#diff-e81f9d924cc2bb480d61a5551d43797e4452c8cef222277435d004b4688a5343L42-R42) [[3]](diffhunk://#diff-67c510061d52be3d886c7288152976c324254636410892c3a0193d7d0d63f29fL26-R26) [[4]](diffhunk://#diff-67c510061d52be3d886c7288152976c324254636410892c3a0193d7d0d63f29fL37-R37)

**Testing Enhancements:**

* Added tests for URL encoding in `powerPlatformEnvironment.test.ts`, `prebuiltBotStrategy.test.ts`, and `publishedBotStrategy.test.ts` to ensure correct URL construction with reserved characters. [[1]](diffhunk://#diff-9dfc15f3453c34de6b9dcde2b147e007f5c84ebd62be4ba3500590e9a38b3df5R1-R39) [[2]](diffhunk://#diff-f0521c1ce5d510c1b415dd4ee485a6052ae296329b917217a02f3032dd919c43R1-R19) [[3]](diffhunk://#diff-a38cf7d7d86e6e9f0a6fa622a08b7cbb5ea6cab6b245ae83ab6c27be40bd5833R1-R19)

## Testing
This image shows the copilotstudio-webchat sample working and the encoded _conversationId_ interpolated in the url.
<img width="1848" height="309" alt="image" src="https://github.com/user-attachments/assets/ca332d9c-ee3e-4856-8c52-3381d2cf2010" />
