### PR TITLE
Fix unit test execution in CI pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:deps": "knip",
     "lint:deps:ci": "knip --reporter github-actions",
     "compat": "node compat.mjs",
-    "test": "node --test  --test-reporter=spec  --import tsx  --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-report.xml ./packages/*/test/**/*.test.ts",
+    "test": "node --test  --test-reporter=spec  --import tsx  --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-report.xml \"./packages/*/test/**/*.test.ts\"",
     "docs": "typedoc --skipErrorChecking",
     "clean:dist": "rm -rfv packages/*/dist",
     "clean": "git clean -xdf",

--- a/packages/agents-hosting-directline-namedpipes/src/namedPipeServer.ts
+++ b/packages/agents-hosting-directline-namedpipes/src/namedPipeServer.ts
@@ -190,10 +190,18 @@ export class NamedPipeService {
   }
 
   private _createReadyPromise (): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
+    const ready = new Promise<void>((resolve, reject) => {
       this._readyResolve = resolve
       this._readyReject = reject
     })
+
+    // `ready` is an internally managed promise that may reject before callers
+    // choose to await it. Mark it handled here so a rejected readiness state
+    // does not surface as an unhandled rejection when callers only await
+    // `start()`.
+    ready.catch(() => {})
+
+    return ready
   }
 
   private _resolveReady (): void {

--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -674,108 +674,6 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   // ============================================================================
-  // Entra Agent ID Sidecar Authentication Errors (-120800 to -120849)
-  // ============================================================================
-
-  /**
-   * Error thrown when the Entra sidecar auth provider is used without connection settings.
-   */
-  SidecarConnectionSettingsRequired: {
-    code: -120800,
-    description: 'Connection settings must be provided when using the Entra sidecar auth provider'
-  },
-
-  /**
-   * Error thrown when the resolved sidecar base URL is not a valid absolute URL.
-   */
-  SidecarBaseUrlInvalid: {
-    code: -120801,
-    description: 'The resolved sidecar base URL `{url}` is not a valid absolute URL'
-  },
-
-  /**
-   * Error thrown when the resolved sidecar base URL does not use the http or https scheme.
-   */
-  SidecarBaseUrlInsecureScheme: {
-    code: -120802,
-    description: 'The resolved sidecar base URL `{url}` must use the http or https scheme'
-  },
-
-  /**
-   * Error thrown when the resolved sidecar base URL contains userinfo (credentials).
-   */
-  SidecarBaseUrlUserInfo: {
-    code: -120803,
-    description: 'The resolved sidecar base URL `{url}` must not contain userinfo (credentials)'
-  },
-
-  /**
-   * Error thrown when the resolved sidecar base URL points to a non-loopback, non-private address.
-   */
-  SidecarBaseUrlNotLocal: {
-    code: -120804,
-    description: 'The resolved sidecar base URL `{url}` points to a non-loopback, non-private address. The Entra Agent ID sidecar (agent container) must be reachable only from within the agent\'s network boundary. Set `bypassLocalNetworkRestriction` to true in the connection configuration to override this safety check (UNSAFE: only for carefully validated private-network configurations)'
-  },
-
-  /**
-   * Error thrown when both AgentUsername and AgentUserId are supplied on a sidecar request (mutually exclusive).
-   */
-  SidecarUserIdentityMutuallyExclusive: {
-    code: -120805,
-    description: 'AgentUsername and AgentUserId are mutually exclusive; set only one on the sidecar request options'
-  },
-
-  /**
-   * Error thrown when a sidecar request fails after exhausting all retry attempts.
-   */
-  SidecarRequestFailed: {
-    code: -120806,
-    description: 'Sidecar request failed after {attempts} attempt(s): {message}'
-  },
-
-  /**
-   * Error thrown when the sidecar responds with a non-success status code.
-   */
-  SidecarErrorResponse: {
-    code: -120807,
-    description: 'Sidecar returned error status {status}: {message}'
-  },
-
-  /**
-   * Error thrown when the sidecar response is missing the authorizationHeader field.
-   */
-  SidecarResponseMissingAuthorizationHeader: {
-    code: -120808,
-    description: 'Sidecar response missing `authorizationHeader` field'
-  },
-
-  /**
-   * Error thrown when the sidecar response body cannot be parsed.
-   */
-  SidecarResponseUnparsable: {
-    code: -120809,
-    description: 'Sidecar returned an unparsable response body'
-  },
-
-  /**
-   * Error thrown when acquireTokenOnBehalfOf is called on the sidecar provider, which does not support OBO in Phase 1.
-   */
-  OnBehalfOfNotSupportedBySidecar: {
-    code: -120810,
-    description: 'acquireTokenOnBehalfOf is not supported by the Entra sidecar auth provider in Phase 1'
-  },
-
-  /**
-   * Error thrown when the sidecar returns a token with an authorization scheme other than Bearer.
-   * The hosting stack always transmits tokens as `Bearer {token}`, so a non-Bearer scheme cannot be
-   * honored and is rejected rather than silently sent as an invalid Authorization header.
-   */
-  SidecarUnsupportedAuthScheme: {
-    code: -120811,
-    description: 'The Entra Agent ID sidecar returned an unsupported authorization scheme `{scheme}`. Only the Bearer scheme is supported'
-  },
-
-  // ============================================================================
   // Agent and Client Errors (-120600 to -120650)
   // ============================================================================
 
@@ -1012,7 +910,109 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   // ============================================================================
-  // Hosting / Web layer errors (-120800 to -120840)
+  // Entra Agent ID Sidecar Authentication Errors (-120800 to -120849)
+  // ============================================================================
+
+  /**
+   * Error thrown when the Entra sidecar auth provider is used without connection settings.
+   */
+  SidecarConnectionSettingsRequired: {
+    code: -120800,
+    description: 'Connection settings must be provided when using the Entra sidecar auth provider'
+  },
+
+  /**
+   * Error thrown when the resolved sidecar base URL is not a valid absolute URL.
+   */
+  SidecarBaseUrlInvalid: {
+    code: -120801,
+    description: 'The resolved sidecar base URL `{url}` is not a valid absolute URL'
+  },
+
+  /**
+   * Error thrown when the resolved sidecar base URL does not use the http or https scheme.
+   */
+  SidecarBaseUrlInsecureScheme: {
+    code: -120802,
+    description: 'The resolved sidecar base URL `{url}` must use the http or https scheme'
+  },
+
+  /**
+   * Error thrown when the resolved sidecar base URL contains userinfo (credentials).
+   */
+  SidecarBaseUrlUserInfo: {
+    code: -120803,
+    description: 'The resolved sidecar base URL `{url}` must not contain userinfo (credentials)'
+  },
+
+  /**
+   * Error thrown when the resolved sidecar base URL points to a non-loopback, non-private address.
+   */
+  SidecarBaseUrlNotLocal: {
+    code: -120804,
+    description: 'The resolved sidecar base URL `{url}` points to a non-loopback, non-private address. The Entra Agent ID sidecar (agent container) must be reachable only from within the agent\'s network boundary. Set `bypassLocalNetworkRestriction` to true in the connection configuration to override this safety check (UNSAFE: only for carefully validated private-network configurations)'
+  },
+
+  /**
+   * Error thrown when both AgentUsername and AgentUserId are supplied on a sidecar request (mutually exclusive).
+   */
+  SidecarUserIdentityMutuallyExclusive: {
+    code: -120805,
+    description: 'AgentUsername and AgentUserId are mutually exclusive; set only one on the sidecar request options'
+  },
+
+  /**
+   * Error thrown when a sidecar request fails after exhausting all retry attempts.
+   */
+  SidecarRequestFailed: {
+    code: -120806,
+    description: 'Sidecar request failed after {attempts} attempt(s): {message}'
+  },
+
+  /**
+   * Error thrown when the sidecar responds with a non-success status code.
+   */
+  SidecarErrorResponse: {
+    code: -120807,
+    description: 'Sidecar returned error status {status}: {message}'
+  },
+
+  /**
+   * Error thrown when the sidecar response is missing the authorizationHeader field.
+   */
+  SidecarResponseMissingAuthorizationHeader: {
+    code: -120808,
+    description: 'Sidecar response missing `authorizationHeader` field'
+  },
+
+  /**
+   * Error thrown when the sidecar response body cannot be parsed.
+   */
+  SidecarResponseUnparsable: {
+    code: -120809,
+    description: 'Sidecar returned an unparsable response body'
+  },
+
+  /**
+   * Error thrown when acquireTokenOnBehalfOf is called on the sidecar provider, which does not support OBO in Phase 1.
+   */
+  OnBehalfOfNotSupportedBySidecar: {
+    code: -120810,
+    description: 'acquireTokenOnBehalfOf is not supported by the Entra sidecar auth provider in Phase 1'
+  },
+
+  /**
+   * Error thrown when the sidecar returns a token with an authorization scheme other than Bearer.
+   * The hosting stack always transmits tokens as `Bearer {token}`, so a non-Bearer scheme cannot be
+   * honored and is rejected rather than silently sent as an invalid Authorization header.
+   */
+  SidecarUnsupportedAuthScheme: {
+    code: -120811,
+    description: 'The Entra Agent ID sidecar returned an unsupported authorization scheme `{scheme}`. Only the Bearer scheme is supported'
+  },
+
+  // ============================================================================
+  // Hosting / Web layer errors (-120830 to -120840)
   // ============================================================================
 
   /**
@@ -1020,7 +1020,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
    * Indicates the hosting layer (e.g. express.json() or Fastify's JSON parser) was not configured.
    */
   MissingRequestBody: {
-    code: -120800,
+    code: -120830,
     description: '`request.body` parameter required; ensure your hosting layer parses JSON request bodies before invoking the adapter (e.g., express.json() with Express or Fastify\'s built-in JSON parser).'
   },
 
@@ -1028,7 +1028,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
    * Error thrown by verifyToken when the provided JWT cannot be decoded.
    */
   InvalidJwtToken: {
-    code: -120810,
+    code: -120831,
     description: 'invalid token'
   },
 
@@ -1036,7 +1036,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
    * Error thrown by verifyToken when the token audience does not match any configured connection clientId.
    */
   JwtAudienceMismatch: {
-    code: -120820,
+    code: -120832,
     description: 'Audience mismatch'
   },
 

--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -910,7 +910,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   // ============================================================================
-  // Entra Agent ID Sidecar Authentication Errors (-120800 to -120849)
+  // Entra Agent ID Sidecar Authentication Errors (-120800 to -120811)
   // ============================================================================
 
   /**
@@ -1012,7 +1012,7 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   // ============================================================================
-  // Hosting / Web layer errors (-120830 to -120840)
+  // Hosting / Web layer errors (-120830 to -120832)
   // ============================================================================
 
   /**

--- a/packages/agents-hosting/test/hosting/adapter/cloudAdapter.webresponse.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/cloudAdapter.webresponse.test.ts
@@ -79,7 +79,7 @@ describe('CloudAdapter.process (WebResponse contract)', () => {
       adapter.process(req, res, async () => {}),
       (err: any) => {
         assert.ok(err instanceof TypeError, 'should be a TypeError')
-        assert.strictEqual(err.code, -120800, 'should expose MissingRequestBody AgentError code')
+        assert.strictEqual(err.code, -120830, 'should expose MissingRequestBody AgentError code')
         assert.ok(typeof err.helpLink === 'string' && err.helpLink.length > 0, 'should expose helpLink')
         assert.ok(/request\.body/.test(err.message), 'message should reference request.body')
         return true


### PR DESCRIPTION
This pull request includes several changes focused on improving error handling consistency and robustness in the agent hosting codebase, as well as a minor fix to the test script invocation. The most notable updates are the **reorganization and renumbering of error codes** for Entra Agent ID Sidecar Authentication and Hosting/Web layer errors, and **an improvement to promise rejection handling in the named pipe service**.

**Error handling improvements:**

* The Entra Agent ID Sidecar Authentication error definitions in `errorHelper.ts` were moved and renumbered to the range -120800 to -120811, and are now grouped together for clarity. [[1]](diffhunk://#diff-a99d0b88336dd114b0573b8c64cca81a0e18eef6206caead4f18258cff0b7d94L676-L777) [[2]](diffhunk://#diff-a99d0b88336dd114b0573b8c64cca81a0e18eef6206caead4f18258cff0b7d94L1015-R1039)
* Hosting/Web layer error codes were shifted to a new range (-120830 to -120832) and their usages updated accordingly, including the `MissingRequestBody`, `InvalidJwtToken`, and `JwtAudienceMismatch` errors. [[1]](diffhunk://#diff-a99d0b88336dd114b0573b8c64cca81a0e18eef6206caead4f18258cff0b7d94L1015-R1039) [[2]](diffhunk://#diff-1dde8adcd6294f08c7de3b9b03e99c61327222dff1b76147738b5d74d9eb7f9fL82-R82)

**Promise rejection handling:**

* The `NamedPipeService` class now marks its internal readiness promise as handled to prevent unhandled rejection warnings if the service fails before `start()` is awaited.

**Test and script fixes:**

* The test script in `package.json` now correctly quotes the glob pattern for test files, improving cross-platform compatibility.
* The test for `CloudAdapter.process` was updated to expect the new error code for `MissingRequestBody`.

## Testing
Tests discovered before by the CI pipeline before the changes.
<img width="304" height="200" alt="image" src="https://github.com/user-attachments/assets/2fc384c8-80f6-4746-861a-b9ea41d313b6" />

Tests discovered by the CI pipeline after the changes.
<img width="310" height="194" alt="image" src="https://github.com/user-attachments/assets/14ba9fcf-70a6-422f-ba54-4506be1fb9bf" />
