### PR TITLE
Fix Adaptive Card Refresh Loops

### DIFF
--- a/packages/agents-hosting/src/app/adaptiveCards/adaptiveCardsActions.ts
+++ b/packages/agents-hosting/src/app/adaptiveCards/adaptiveCardsActions.ts
@@ -100,12 +100,30 @@ export class AdaptiveCardsActions<TState extends TurnState> {
    * @param verb - A string, RegExp, RouteSelector, or an array of these to match the action verb.
    * @param handler - A function to handle the action execution.
    * @returns The Teams application instance.
+   *
+   * @remarks
+   * The delivery behavior depends on the action trigger and
+   * `adaptiveCardsOptions.actionExecuteResponseType`:
+   *
+   * | Response type | Automatic trigger | Manual trigger |
+   * | --- | --- | --- |
+   * | `REPLACE_FOR_INTERACTOR` | User response | User response |
+   * | `REPLACE_FOR_ALL` | User response | Shared update |
+   * | `NEW_MESSAGE_FOR_ALL` | User response | New message |
+   *
+   * - **User response** — Return an Adaptive Card invoke response only to the requesting or interacting user.
+   * - **Shared update** — Update the shared activity for all users and return an Adaptive Card invoke response to the interacting user.
+   * - **New message** — Send a new activity for all users and return a message acknowledgement to the interacting user.
+   *
+   * Automatic refresh actions always return only an Adaptive Card invoke response.
+   * Updating or sending a refreshable card while processing an automatic refresh
+   * would cause Teams to invoke the refresh action again.
    */
   public actionExecute<TData = Record<string, any>>(
     verb: string | RegExp | RouteSelector | (string | RegExp | RouteSelector)[],
     handler: (context: TurnContext, state: TState, data: TData) => Promise<AdaptiveCard | string>
   ): AgentApplication<TState> {
-    let actionExecuteResponseType = this._app.options.adaptiveCardsOptions?.actionExecuteResponseType ?? AdaptiveCardActionExecuteResponseType.REPLACE_FOR_INTERACTOR;
+    const actionExecuteResponseType = this._app.options.adaptiveCardsOptions?.actionExecuteResponseType ?? AdaptiveCardActionExecuteResponseType.REPLACE_FOR_INTERACTOR;
     (Array.isArray(verb) ? verb : [verb]).forEach((v) => {
       const selector = createActionExecuteSelector(v)
       this._app.addRoute(
@@ -113,6 +131,7 @@ export class AdaptiveCardsActions<TState extends TurnState> {
         async (context, state) => {
           const a = context?.activity
           const invokeAction = parseValueActionExecuteSelector(a.value)
+          const isAutomaticRefresh = (a.value as { trigger?: string } | undefined)?.trigger === 'automatic'
           if (
             a?.type !== ActivityTypes.Invoke ||
                         a?.name !== ACTION_INVOKE_NAME ||
@@ -138,20 +157,15 @@ export class AdaptiveCardsActions<TState extends TurnState> {
               }
               await sendInvokeResponse(context, response)
             } else {
-              if (
-                result.refresh &&
-                                actionExecuteResponseType !== AdaptiveCardActionExecuteResponseType.NEW_MESSAGE_FOR_ALL
-              ) {
-                actionExecuteResponseType = AdaptiveCardActionExecuteResponseType.REPLACE_FOR_ALL
-              }
-
               const activity = MessageFactory.attachment(CardFactory.adaptiveCard(result))
               response = {
                 statusCode: 200,
                 type: AdaptiveCardInvokeResponseType.ADAPTIVE,
                 value: result
               }
-              if (
+              if (isAutomaticRefresh) {
+                await sendInvokeResponse(context, response)
+              } else if (
                 actionExecuteResponseType === AdaptiveCardActionExecuteResponseType.NEW_MESSAGE_FOR_ALL
               ) {
                 await sendInvokeResponse(context, {

--- a/packages/agents-hosting/src/invoke/adaptiveCardInvokeValue.ts
+++ b/packages/agents-hosting/src/invoke/adaptiveCardInvokeValue.ts
@@ -22,4 +22,9 @@ export interface AdaptiveCardInvokeValue {
    * The state of the adaptive card.
    */
   state: string
+  /**
+   * Indicates whether Teams initiated the action while rendering a refreshable
+   * card or a user explicitly selected an action.
+   */
+  trigger?: 'automatic' | 'manual'
 }

--- a/packages/agents-hosting/test/hosting/app/adaptiveCardsActions.test.ts
+++ b/packages/agents-hosting/test/hosting/app/adaptiveCardsActions.test.ts
@@ -1,0 +1,119 @@
+import { strict as assert } from 'node:assert'
+import { describe, it } from 'node:test'
+import { Activity } from '@microsoft/agents-activity'
+import { AgentApplication } from '../../../src/app/agentApplication'
+import { AdaptiveCardActionExecuteResponseType } from '../../../src/app/adaptiveCards/adaptiveCardActionExecuteResponseType'
+import { TurnContext } from '../../../src/turnContext'
+import { TestAdapter } from '../testStubs'
+
+class RecordingAdapter extends TestAdapter {
+  public readonly sent: Activity[] = []
+  public readonly updated: Activity[] = []
+
+  setAgentName (_name?: string): void {}
+  connectionManager = undefined
+
+  override async sendActivities (context: TurnContext, activities: Activity[]) {
+    this.sent.push(...activities.map(Activity.fromObject))
+    return await super.sendActivities(context, activities)
+  }
+
+  override async updateActivity (_context: TurnContext, activity: Activity) {
+    this.updated.push(Activity.fromObject(activity))
+    return { id: activity.id ?? '' }
+  }
+}
+
+const card = () => ({
+  type: 'AdaptiveCard' as const,
+  version: '1.5',
+  body: [],
+  refresh: { action: { type: 'Action.Execute', verb: 'refresh' }, userIds: ['29:user'] }
+})
+
+const invoke = (trigger: 'automatic' | 'manual') => Activity.fromObject({
+  type: 'invoke',
+  name: 'adaptiveCard/action',
+  channelId: 'msteams',
+  serviceUrl: 'https://service',
+  from: { id: '29:user' },
+  recipient: { id: 'bot' },
+  conversation: { id: 'conversation' },
+  replyToId: 'base-card-id',
+  value: { action: { type: 'Action.Execute', verb: 'refresh' }, trigger }
+})
+
+async function runAction (responseType: AdaptiveCardActionExecuteResponseType, trigger: 'automatic' | 'manual') {
+  const adapter = new RecordingAdapter()
+  const app = new AgentApplication({
+    adapter: adapter as any,
+    adaptiveCardsOptions: { actionExecuteResponseType: responseType }
+  })
+  app.adaptiveCards.actionExecute('refresh', async () => card())
+  await app.runInternal(new TurnContext(adapter, invoke(trigger)))
+  return adapter
+}
+
+describe('AdaptiveCardsActions', () => {
+  it('returns an automatic refresh response without updating the shared card', async () => {
+    const adapter = await runAction(AdaptiveCardActionExecuteResponseType.REPLACE_FOR_ALL, 'automatic')
+
+    assert.equal(adapter.updated.length, 0)
+    assert.equal(adapter.sent.length, 1)
+    const response = adapter.sent[0].value as { body: { type: string, value: Record<string, unknown> } }
+    assert.equal(response.body.type, 'application/vnd.microsoft.card.adaptive')
+    assert.notEqual(response.body.value.refresh, undefined)
+  })
+
+  it('returns an automatic refresh response for the interactor without publishing a card', async () => {
+    const adapter = await runAction(AdaptiveCardActionExecuteResponseType.REPLACE_FOR_INTERACTOR, 'automatic')
+    const response = adapter.sent[0].value as { body: { type: string, value: Record<string, unknown> } }
+
+    assert.equal(adapter.updated.length, 0)
+    assert.equal(adapter.sent.length, 1)
+    assert.equal(response.body.type, 'application/vnd.microsoft.card.adaptive')
+    assert.notEqual(response.body.value.refresh, undefined)
+  })
+
+  it('returns an automatic refresh response without posting a new message', async () => {
+    const adapter = await runAction(AdaptiveCardActionExecuteResponseType.NEW_MESSAGE_FOR_ALL, 'automatic')
+    const response = adapter.sent[0].value as { body: { type: string, value: Record<string, unknown> } }
+
+    assert.equal(adapter.sent.filter(activity => activity.type === 'message').length, 0)
+    assert.equal(response.body.type, 'application/vnd.microsoft.card.adaptive')
+    assert.notEqual(response.body.value.refresh, undefined)
+  })
+
+  it('returns a manual refresh response for the interactor without publishing a card', async () => {
+    const adapter = await runAction(AdaptiveCardActionExecuteResponseType.REPLACE_FOR_INTERACTOR, 'manual')
+    const response = adapter.sent[0].value as { body: { type: string, value: Record<string, unknown> } }
+
+    assert.equal(adapter.updated.length, 0)
+    assert.equal(adapter.sent.length, 1)
+    assert.equal(response.body.type, 'application/vnd.microsoft.card.adaptive')
+    assert.notEqual(response.body.value.refresh, undefined)
+  })
+
+  it('updates the shared card and returns the manual replace-for-all response', async () => {
+    const adapter = await runAction(AdaptiveCardActionExecuteResponseType.REPLACE_FOR_ALL, 'manual')
+    const published = adapter.updated[0].attachments?.[0].content as Record<string, unknown>
+    const response = adapter.sent[0].value as { body: { type: string, value: Record<string, unknown> } }
+
+    assert.notEqual(published.refresh, undefined)
+    assert.equal(response.body.type, 'application/vnd.microsoft.card.adaptive')
+    assert.notEqual(response.body.value.refresh, undefined)
+  })
+
+  it('posts a new card after a manual new-message action', async () => {
+    const adapter = await runAction(AdaptiveCardActionExecuteResponseType.NEW_MESSAGE_FOR_ALL, 'manual')
+    const acknowledgement = adapter.sent[0].value as { body: { type: string } }
+    const message = adapter.sent[1]
+    const published = message.attachments?.[0].content as Record<string, unknown>
+
+    assert.equal(adapter.updated.length, 0)
+    assert.equal(adapter.sent.length, 2)
+    assert.equal(acknowledgement.body.type, 'application/vnd.microsoft.activity.message')
+    assert.equal(message.type, 'message')
+    assert.notEqual(published.refresh, undefined)
+  })
+})


### PR DESCRIPTION
Fixes # 1202

## Summary

Automatic `adaptiveCard/action` invokes now return only the Adaptive Card invoke response. They no longer publish a shared update or new message, preventing refreshable cards from repeatedly triggering Teams refresh.

Manual actions preserve configured behavior:

| Response type | Behavior |
| --- | --- |
| `REPLACE_FOR_INTERACTOR` | Updates only interacting user |
| `REPLACE_FOR_ALL` | Updates shared conversation card |
| `NEW_MESSAGE_FOR_ALL` | Sends new conversation message |

Also adds `trigger` typing to `AdaptiveCardInvokeValue`, documents behavior matrix, and expands adaptive-card response tests.

## Validation

- Targeted Adaptive Card tests: 6/6 passing
- Hosting package build: passing
- Sample build: passing
- ESLint: passing
- Manually verified all three response modes in Teams

## Testing
The following gifs show all 3 scenarios.

**new message**
<img width="1209" height="374" alt="new_message_for_all" src="https://github.com/user-attachments/assets/d6d85114-b988-440f-a016-5bd314de1a95" />

**for all**
<img width="1209" height="374" alt="replace_for_all" src="https://github.com/user-attachments/assets/5d037bee-6cd5-4a72-a516-1ffad81971b7" />

**interactor**
<img width="1209" height="374" alt="replace_for_interactor" src="https://github.com/user-attachments/assets/56d0ca23-7094-40ab-8f40-3c24830b5c4e" />

