### PR TITLE
[#1191] Create workflow to detect differences between Teams API and Agents Teams Extension

### DIFF
--- a/.github/workflows/teams-api-drift.yml
+++ b/.github/workflows/teams-api-drift.yml
@@ -1,0 +1,288 @@
+name: Teams API Drift Detector
+
+on:
+  workflow_dispatch:
+    inputs:
+      from:
+        description: Baseline @microsoft/teams.api version
+        required: true
+        type: string
+      to:
+        description: Candidate @microsoft/teams.api version
+        required: true
+        type: string
+  pull_request:
+    branches:
+      - main
+      - release/*
+    # This workflow analyzes declared @microsoft/teams.api dependency updates only.
+    paths:
+      - packages/agents-hosting-extensions-msteams/package.json
+
+permissions:
+  contents: read
+  copilot-requests: write
+  pull-requests: write
+
+jobs:
+  analysis-scope:
+    name: Determine analysis scope
+    runs-on: ubuntu-latest
+    outputs:
+      run_dependency_drift_analysis: ${{ steps.select-checks.outputs.run_dependency_drift_analysis }}
+      baseline_version: ${{ steps.resolve-versions.outputs.baseline_version }}
+      candidate_version: ${{ steps.resolve-versions.outputs.candidate_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Manual runs always analyze the requested versions; pull requests run only for dependency updates.
+      - id: select-checks
+        name: Select required checks
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "run_dependency_drift_analysis=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          dependency_changed=false
+          if git diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- packages/agents-hosting-extensions-msteams/package.json | grep -q '"@microsoft/teams.api"'; then
+            dependency_changed=true
+          fi
+
+          echo "run_dependency_drift_analysis=$dependency_changed" >> "$GITHUB_OUTPUT"
+
+      - id: resolve-versions
+        name: Resolve comparison versions
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          INPUT_FROM: ${{ inputs.from }}
+          INPUT_TO: ${{ inputs.to }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "baseline_version=$INPUT_FROM" >> "$GITHUB_OUTPUT"
+            echo "candidate_version=$INPUT_TO" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base_range=$(git show "$BASE_SHA:packages/agents-hosting-extensions-msteams/package.json" | node -e "let input=''; process.stdin.on('data', value => { input += value }); process.stdin.on('end', () => { const version = JSON.parse(input).dependencies['@microsoft/teams.api']; const match = version?.match(/[0-9]+\\.[0-9]+\\.[0-9]+/); if (!match) process.exit(1); console.log(match[0]) })")
+          candidate_range=$(node -p "require('./packages/agents-hosting-extensions-msteams/package.json').dependencies['@microsoft/teams.api']")
+          candidate_version=$(node -e "const match = process.argv[1].match(/[0-9]+\\.[0-9]+\\.[0-9]+/); if (!match) process.exit(1); console.log(match[0])" "$candidate_range")
+          echo "baseline_version=$base_range" >> "$GITHUB_OUTPUT"
+          echo "candidate_version=$candidate_version" >> "$GITHUB_OUTPUT"
+
+  # Verify teams.api dependency compatibility when the dependency version changes.
+  teams-api-compatibility:
+    name: Analyze teams.api compatibility
+    needs: analysis-scope
+    if: needs.analysis-scope.outputs.run_dependency_drift_analysis == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+
+      # Continue so reports and artifacts describe all checks before the final policy fails the run.
+      - id: build
+        name: Build
+        run: npm run build
+        continue-on-error: true
+      - id: verify-usage-manifest
+        name: Verify dependency usage manifest
+        if: always()
+        run: test -f packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+        continue-on-error: true
+      # Capture the complete upstream API delta before determining whether this extension consumes it.
+      - id: compare-upstream-api-models
+        name: Compare teams.api API models
+        if: always() && steps.build.outcome == 'success'
+        run: |
+          npm run compare:teams-api -- \
+            --from "${{ needs.analysis-scope.outputs.baseline_version }}" \
+            --to "${{ needs.analysis-scope.outputs.candidate_version }}" \
+            --output artifacts/teams-api-drift
+        continue-on-error: true
+      - id: run-compile-time-contracts-tests
+        name: Run compile-time contracts tests
+        if: always() && steps.build.outcome == 'success'
+        run: npm run test:teams-api-contracts
+        continue-on-error: true
+      - id: run-runtime-boundaries-tests
+        name: Run Teams API runtime boundaries tests
+        if: always() && steps.build.outcome == 'success'
+        run: node --test --import tsx packages/agents-hosting-extensions-msteams/test/boundaries/teamsApiClientBehavior.test.ts
+        continue-on-error: true
+      # Intersect the upstream delta with actual extension usage; defer fail-on-drift to preserve reports.
+      - id: classify-usage-impact
+        name: Classify direct compatibility impact
+        if: always() && steps.compare-upstream-api-models.outcome == 'success'
+        run: npm run detect:teams-api-drifts -- --comparison artifacts/teams-api-drift/raw-api-diff.json --output artifacts/teams-api-drift --fail-on-drift
+        continue-on-error: true
+      - id: write-verification-summary
+        name: Write verification summary
+        if: always()
+        run: >-
+          npm run write:teams-api-test-summary --
+          --build "${{ steps.build.outcome }}"
+          --usage-collection "${{ steps.verify-usage-manifest.outcome }}"
+          --api-extraction "${{ steps.compare-upstream-api-models.outcome }}"
+          --api-comparison "${{ steps.compare-upstream-api-models.outcome }}"
+          --contract-tests "${{ steps.run-compile-time-contracts-tests.outcome }}"
+          --boundary-tests "${{ steps.run-runtime-boundaries-tests.outcome }}"
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+      - id: render-deterministic-report
+        name: Render deterministic report
+        if: always() && steps.classify-usage-impact.outcome != 'skipped' && steps.write-verification-summary.outcome == 'success'
+        run: npm run render:teams-api-drift-report -- --findings artifacts/teams-api-drift/findings.json --test-summary artifacts/teams-api-drift/test-summary.json --output artifacts/teams-api-drift
+        continue-on-error: true
+      # Trusted runs only: Copilot receives bounded context and is denied all repository tools.
+      - id: prepare-agent-context
+        name: Prepare bounded AI agent context
+        if: >-
+          always() &&
+          steps.render-deterministic-report.outcome == 'success' &&
+          (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request')
+        run: >-
+          npm run prepare:teams-api-agent-report --
+          --findings artifacts/teams-api-drift/findings.json
+          --usage-manifest packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+          --capabilities packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
+          --deterministic-report artifacts/teams-api-drift/deterministic-report.md
+          --test-summary artifacts/teams-api-drift/test-summary.json
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+      - id: install-copilot-cli
+        name: Install GitHub Copilot CLI
+        if: always() && steps.prepare-agent-context.outcome == 'success'
+        run: npm install --global @github/copilot
+        continue-on-error: true
+      - id: generate-advisory-report
+        name: Generate advisory AI report
+        if: always() && steps.install-copilot-cli.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PROMPT_FILE: scripts/teams-api-drift/teams-api-agent-report-prompt.md
+          CONTEXT_FILE: artifacts/teams-api-drift/agent-context.json
+          REPORT_FILE: artifacts/teams-api-drift/agent-report.md
+        run: |
+          agent_prompt=$(cat "$PROMPT_FILE")
+          agent_context=$(cat "$CONTEXT_FILE")
+          copilot \
+            -s \
+            -p "$agent_prompt
+
+          ## Runtime context
+
+          \`\`\`json
+          $agent_context
+          \`\`\`" \
+            --deny-tool='shell,write,read,url,memory,github' \
+            --no-ask-user \
+            > "$REPORT_FILE"
+          test -s "$REPORT_FILE"
+        continue-on-error: true
+      - id: validate-advisory-report
+        name: Validate advisory AI report
+        if: always() && steps.generate-advisory-report.outcome == 'success'
+        run: >-
+          npm run validate:teams-api-agent-report --
+          --findings artifacts/teams-api-drift/findings.json
+          --report artifacts/teams-api-drift/agent-report.md
+          --output artifacts/teams-api-drift
+        continue-on-error: true
+      # Upload all evidence before the final policy turns collected failures into a failed workflow.
+      - name: Upload compatibility artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: teams-api-drift-${{ github.run_id }}
+          path: artifacts/teams-api-drift
+          if-no-files-found: warn
+          retention-days: 14
+      # Upsert one marker-based summary comment only for trusted pull requests.
+      - name: Publish pull-request comment
+        if: always() && github.event_name == 'pull_request' && steps.render-deterministic-report.outcome == 'success'
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require('fs')
+            const findings = JSON.parse(fs.readFileSync('artifacts/teams-api-drift/findings.json', 'utf8'))
+            const marker = '<!-- teams-api-drift-report -->'
+            const actionable = findings.findings
+              .filter(finding => finding.classification !== 'no-action')
+              .slice(0, 5)
+            const lines = [
+              marker,
+              '## TEAMS API drift analysis',
+              '',
+              `Compared \`${findings.fromVersion}\` to \`${findings.toVersion}\`.`,
+              `The analysis identified **${findings.findings.length}** total findings, of which **${actionable.length}** require attention.`,
+              `Blocking: **${findings.summary.blocking}** · Required: **${findings.summary.required}** · Review: **${findings.summary.review}**.`,
+              '',
+              ...actionable.map(finding => `- **${finding.id}** — ${finding.classification} · ${finding.kind}: \`${finding.upstreamSymbol}${finding.member ? `.${finding.member}` : ''}\``),
+              '',
+              `Find the full report and artifacts in: ${process.env.ARTIFACT_URL}`
+            ]
+            const body = lines.join('\n')
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            })
+            const existing = comments.find(comment => comment.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body })
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body })
+            }
+      # Convert deferred check outcomes into the final workflow result after reports and artifacts are available.
+      - name: Report final workflow result
+        if: always()
+        env:
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          USAGE_MANIFEST_OUTCOME: ${{ steps.verify-usage-manifest.outcome }}
+          UPSTREAM_COMPARISON_OUTCOME: ${{ steps.compare-upstream-api-models.outcome }}
+          COMPILE_TIME_CONTRACTS_OUTCOME: ${{ steps.run-compile-time-contracts-tests.outcome }}
+          RUNTIME_BOUNDARIES_OUTCOME: ${{ steps.run-runtime-boundaries-tests.outcome }}
+          IMPACT_CLASSIFICATION_OUTCOME: ${{ steps.classify-usage-impact.outcome }}
+          VERIFICATION_SUMMARY_OUTCOME: ${{ steps.write-verification-summary.outcome }}
+          DETERMINISTIC_REPORT_OUTCOME: ${{ steps.render-deterministic-report.outcome }}
+          RUN_AI_AGENT: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+          AGENT_CONTEXT_OUTCOME: ${{ steps.prepare-agent-context.outcome }}
+          COPILOT_INSTALL_OUTCOME: ${{ steps.install-copilot-cli.outcome }}
+          AGENT_REPORT_OUTCOME: ${{ steps.generate-advisory-report.outcome }}
+          AGENT_VALIDATION_OUTCOME: ${{ steps.validate-advisory-report.outcome }}
+        run: |
+          for outcome in "$BUILD_OUTCOME" "$USAGE_MANIFEST_OUTCOME" "$UPSTREAM_COMPARISON_OUTCOME" "$COMPILE_TIME_CONTRACTS_OUTCOME" "$RUNTIME_BOUNDARIES_OUTCOME" "$IMPACT_CLASSIFICATION_OUTCOME" "$VERIFICATION_SUMMARY_OUTCOME" "$DETERMINISTIC_REPORT_OUTCOME"; do
+            if [ "$outcome" != success ]; then
+              echo "Blocking teams.api drift check outcome: $outcome"
+              exit 1
+            fi
+          done
+
+          if [ "$RUN_AI_AGENT" = true ]; then
+            for outcome in "$AGENT_CONTEXT_OUTCOME" "$COPILOT_INSTALL_OUTCOME" "$AGENT_REPORT_OUTCOME" "$AGENT_VALIDATION_OUTCOME"; do
+              if [ "$outcome" != success ]; then
+                echo "Blocking teams.api AI report outcome: $outcome"
+                exit 1
+              fi
+            done
+          fi

--- a/.github/workflows/teams-api-drift.yml
+++ b/.github/workflows/teams-api-drift.yml
@@ -229,15 +229,15 @@ jobs:
             const fs = require('fs')
             const findings = JSON.parse(fs.readFileSync('artifacts/teams-api-drift/findings.json', 'utf8'))
             const marker = '<!-- teams-api-drift-report -->'
-            const actionable = findings.findings
+            const actionableFindings = findings.findings
               .filter(finding => finding.classification !== 'no-action')
-              .slice(0, 5)
+            const actionable = actionableFindings.slice(0, 5)
             const lines = [
               marker,
               '## TEAMS API drift analysis',
               '',
               `Compared \`${findings.fromVersion}\` to \`${findings.toVersion}\`.`,
-              `The analysis identified **${findings.findings.length}** total findings, of which **${actionable.length}** require attention.`,
+              `The analysis identified **${findings.findings.length}** total findings, of which **${actionableFindings.length}** require attention.`,
               `Blocking: **${findings.summary.blocking}** · Required: **${findings.summary.required}** · Review: **${findings.summary.review}**.`,
               '',
               ...actionable.map(finding => `- **${finding.id}** — ${finding.classification} · ${finding.kind}: \`${finding.upstreamSymbol}${finding.member ? `.${finding.member}` : ''}\``),

--- a/.github/workflows/teams-api-drift.yml
+++ b/.github/workflows/teams-api-drift.yml
@@ -1,5 +1,7 @@
 name: Teams API Drift Detector
 
+# Compares a declared @microsoft/teams.api update with the extension's recorded usage.
+# It classifies compatibility impact, publishes deterministic evidence, and generates an advisory report.
 on:
   workflow_dispatch:
     inputs:
@@ -176,6 +178,7 @@ jobs:
         name: Generate advisory AI report
         if: always() && steps.install-copilot-cli.outcome == 'success'
         env:
+          # Authenticates GitHub Copilot CLI with this workflow's copilot-requests permission.
           GITHUB_TOKEN: ${{ github.token }}
           PROMPT_FILE: scripts/teams-api-drift/teams-api-agent-report-prompt.md
           CONTEXT_FILE: artifacts/teams-api-drift/agent-context.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/express": "5.0.6",
         "@types/node": "25.6.0",
         "@types/sinon": "21.0.0",
+        "diff": "8.0.3",
         "esbuild": "0.28.1",
         "eslint": "9.39.2",
         "knip": "5.86.0",
@@ -30,7 +31,8 @@
         "sinon": "21.0.3",
         "tsx": "4.22.4",
         "typedoc": "0.28.18",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "yaml": "2.8.3"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,13 @@
     "lint": "eslint",
     "lint:deps": "knip",
     "lint:deps:ci": "knip --reporter github-actions",
+    "compare:teams-api": "node --import tsx scripts/teams-api-drift/compare-teams-api.ts",
+    "detect:teams-api-drifts": "node --import tsx scripts/teams-api-drift/detect-teams-api-drifts.ts",
+    "render:teams-api-drift-report": "node --import tsx scripts/teams-api-drift/render-teams-api-drift-report.ts",
+    "prepare:teams-api-agent-report": "node --import tsx scripts/teams-api-drift/prepare-teams-api-agent-context.ts",
+    "validate:teams-api-agent-report": "node --import tsx scripts/teams-api-drift/validate-teams-api-agent-report.ts",
+    "write:teams-api-test-summary": "node --import tsx scripts/teams-api-drift/write-teams-api-test-summary.ts",
+    "test:teams-api-contracts": "tsc -p packages/agents-hosting-extensions-msteams/test/contracts/tsconfig.json --noEmit",
     "compat": "node compat.mjs",
     "test": "node --test  --test-reporter=spec  --import tsx  --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-report.xml ./packages/*/test/**/*.test.ts",
     "docs": "typedoc --skipErrorChecking",
@@ -48,6 +55,7 @@
     "@types/express": "5.0.6",
     "@types/node": "25.6.0",
     "@types/sinon": "21.0.0",
+    "diff": "8.0.3",
     "esbuild": "0.28.1",
     "eslint": "9.39.2",
     "knip": "5.86.0",
@@ -57,7 +65,8 @@
     "sinon": "21.0.3",
     "tsx": "4.22.4",
     "typedoc": "0.28.18",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "yaml": "2.8.3"
   },
   "peerDependencies": {
     "@rushstack/terminal": "*"

--- a/packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
+++ b/packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
@@ -1,0 +1,115 @@
+# Curated ownership map for classifying new @microsoft/teams.api surface area.
+# This package consumes selected Teams API types and clients; it is not a wrapper
+# for the full upstream package. Direct compatibility findings take precedence
+# over these advisory adoption policies.
+schemaVersion: 1
+
+dependency:
+  package: "@microsoft/teams.api"
+
+capabilities:
+  teams-api-client:
+    description: "Creates, stores, and exposes the Teams API client for a Teams turn."
+    owners:
+      - "src/teamsApiClientExtensions.ts"
+      - "src/teamsTurnContext.ts"
+      - "src/teamsAgentExtension.ts"
+    upstreamAreas:
+      - "clients"
+    adoptionPolicy: "strict-compatibility"
+
+  activity-data:
+    description: "Parses Teams channel data and provides Teams-specific activity helpers."
+    owners:
+      - "src/activity-extensions/**"
+      - "src/teamsActivityExtensions.ts"
+      - "src/teamsModelExtensions.ts"
+    upstreamAreas:
+      - "models.channel-data"
+      - "activities"
+    adoptionPolicy: "strict-compatibility"
+
+  channels:
+    description: "Routes Teams channel lifecycle and membership events."
+    owners:
+      - "src/channels/**"
+    upstreamAreas:
+      - "clients.team"
+      - "models.channel-data.channel-info"
+      - "models.channel-data"
+    adoptionPolicy: "review-new-members"
+
+  teams:
+    description: "Routes Teams team lifecycle events."
+    owners:
+      - "src/teams/**"
+    upstreamAreas:
+      - "models.channel-data.team-info"
+      - "models.channel-data"
+    adoptionPolicy: "review-new-members"
+
+  meetings:
+    description: "Routes meeting lifecycle and participant events."
+    owners:
+      - "src/meetings/**"
+    upstreamAreas:
+      - "models.meeting"
+      - "models.account"
+      - "activities.event"
+    adoptionPolicy: "review-new-members"
+
+  message-extensions:
+    description: "Handles message extension invokes, query parsing, actions, and responses."
+    owners:
+      - "src/messageExtensions/**"
+    upstreamAreas:
+      - "models.messaging-extension"
+      - "models.app-based-link-query"
+      - "activities.invoke.message-extension"
+    adoptionPolicy: "review-new-members"
+
+  task-modules:
+    description: "Handles Teams task module fetch and submit invokes."
+    owners:
+      - "src/taskModules/**"
+    upstreamAreas:
+      - "models.task-module"
+      - "activities.invoke"
+    adoptionPolicy: "review-new-members"
+
+  file-consents:
+    description: "Handles file consent accept and decline invoke payloads."
+    owners:
+      - "src/fileConsents/**"
+    upstreamAreas:
+      - "models.file"
+    adoptionPolicy: "review-new-members"
+
+  app-configuration:
+    description: "Handles Teams app configuration fetch and submit invokes."
+    owners:
+      - "src/config/**"
+    upstreamAreas:
+      - "models.config"
+      - "activities.invoke.config"
+    adoptionPolicy: "review-new-members"
+
+  message-actions:
+    description: "Handles message lifecycle events, read receipts, and connector-card execute actions."
+    owners:
+      - "src/messages/**"
+      - "src/models/readReceiptInfo.ts"
+    upstreamAreas:
+      - "models.o365"
+      - "activities.message"
+      - "activities.event"
+    adoptionPolicy: "review-new-members"
+
+  app-routing:
+    description: "Provides Teams route registration, feedback-loop, and handoff helpers over agent activities."
+    owners:
+      - "src/app/**"
+      - "src/teamsRouteHandler.ts"
+    upstreamAreas:
+      - "activities"
+    adoptionPolicy: "advisory-only"

--- a/packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+++ b/packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
@@ -1,0 +1,169 @@
+{
+  "dependency": "@microsoft/teams.api",
+  "declaredVersion": "^2.0.13",
+  "sourceRoot": "src",
+  "usages": [
+    {
+      "upstreamSymbol": "Client",
+      "usage": "instantiated",
+      "files": [
+        "src/teamsApiClientExtensions.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "Client",
+      "usage": "type-reference",
+      "files": [
+        "src/teamsAgentExtension.ts",
+        "src/teamsApiClientExtensions.ts",
+        "src/teamsTurnContext.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "AppBasedLinkQuery",
+      "usage": "request-model",
+      "propertiesValidated": [
+        "state",
+        "url"
+      ],
+      "files": [
+        "src/messageExtensions/messageExtension.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "ChannelData",
+      "usage": "parsed-model",
+      "propertiesRead": [
+        "channel",
+        "eventType",
+        "meeting",
+        "team"
+      ],
+      "files": [
+        "src/activity-extensions/teamsChannelData.ts",
+        "src/channels/teamsChannel.ts",
+        "src/messages/message.ts",
+        "src/teams/teamsTeam.ts",
+        "src/teamsActivityExtensions.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "ChannelInfo",
+      "usage": "event-model",
+      "files": [
+        "src/channels/teamsChannel.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "ConfigResponse",
+      "usage": "response-model",
+      "files": [
+        "src/config/config.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "FileConsentCardResponse",
+      "usage": "request-model",
+      "files": [
+        "src/fileConsents/fileConsent.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "MeetingDetails",
+      "usage": "event-model",
+      "files": [
+        "src/meetings/meeting.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "MessagingExtensionAction",
+      "usage": "request-model",
+      "propertiesRead": [
+        "botActivityPreview",
+        "data"
+      ],
+      "files": [
+        "src/messageExtensions/messageExtension.ts",
+        "src/teamsModelExtensions.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "MessagingExtensionActionResponse",
+      "usage": "response-model",
+      "files": [
+        "src/messageExtensions/messageExtension.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "MessagingExtensionQuery",
+      "usage": "request-model",
+      "propertiesValidated": [
+        "commandId",
+        "parameters",
+        "parameters[].name",
+        "parameters[].value",
+        "queryOptions",
+        "queryOptions.count",
+        "queryOptions.skip",
+        "state"
+      ],
+      "files": [
+        "src/messageExtensions/messageExtension.ts",
+        "src/messageExtensions/messagingExtensionQuery.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "MessagingExtensionResponse",
+      "usage": "response-model",
+      "files": [
+        "src/messageExtensions/messageExtension.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "O365ConnectorCardActionQuery",
+      "usage": "request-model",
+      "files": [
+        "src/messages/message.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "OnBehalfOf",
+      "usage": "return-model",
+      "files": [
+        "src/teamsActivityExtensions.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "TaskModuleRequest",
+      "usage": "request-model",
+      "propertiesRead": [
+        "data"
+      ],
+      "files": [
+        "src/taskModules/taskModule.ts",
+        "src/teamsModelExtensions.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "TaskModuleResponse",
+      "usage": "response-model",
+      "files": [
+        "src/taskModules/taskModule.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "TeamInfo",
+      "usage": "event-model",
+      "files": [
+        "src/teams/teamsTeam.ts"
+      ]
+    },
+    {
+      "upstreamSymbol": "TeamsChannelAccount",
+      "usage": "nested-event-model",
+      "files": [
+        "src/meetings/meeting.ts"
+      ]
+    }
+  ]
+}

--- a/packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+++ b/packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
@@ -1,6 +1,6 @@
 {
   "dependency": "@microsoft/teams.api",
-  "declaredVersion": "^2.0.13",
+  "declaredVersion": "2.0.13",
   "sourceRoot": "src",
   "usages": [
     {

--- a/packages/agents-hosting-extensions-msteams/test/boundaries/teamsApiClientBehavior.test.ts
+++ b/packages/agents-hosting-extensions-msteams/test/boundaries/teamsApiClientBehavior.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { Activity } from '@microsoft/agents-activity'
+import { TurnContext } from '@microsoft/agents-hosting'
+import { Client as TeamsClient } from '@microsoft/teams.api'
+import { setTeamsApiClient, TeamsClientKey } from '../../src/teamsApiClientExtensions'
+
+function createContext (serviceUrl: string | undefined, connectorBaseUrl: string = 'https://connector.example.com'): TurnContext {
+  const adapter = {
+    ConnectorClientKey: Symbol('ConnectorClient'),
+    async sendActivities (_context: TurnContext, activities: Activity[]) {
+      return activities.map((_activity, index) => ({ id: `activity-${index}` }))
+    }
+  } as any
+  const context = new TurnContext(
+    adapter,
+    Activity.fromObject({
+      type: 'message',
+      channelId: 'msteams',
+      serviceUrl,
+      conversation: { id: 'conversation-id' },
+      recipient: { id: 'bot' },
+      from: { id: 'user' }
+    }),
+    {}
+  )
+
+  context.turnState.set(adapter.ConnectorClientKey, {
+    httpClient: {
+      baseURL: connectorBaseUrl,
+      defaultHeaders: {
+        Authorization: 'Bearer connector-token',
+        'Content-Type': 'application/json',
+        'User-Agent': 'agents-test/1.0'
+      }
+    }
+  })
+
+  return context
+}
+
+function getClientHeaders (client: TeamsClient): Record<string, string> {
+  return (client as any).http.options.headers
+}
+
+describe('Teams API client boundary', () => {
+  it('should use the activity service URL and propagate connector headers to the Teams client', () => {
+    const context = createContext('https://activity.example.com')
+
+    setTeamsApiClient(context)
+
+    const client = context.turnState.get<TeamsClient>(TeamsClientKey)
+    assert.ok(client)
+    assert.strictEqual(client.serviceUrl, 'https://activity.example.com')
+    assert.deepStrictEqual(getClientHeaders(client), {
+      Authorization: 'Bearer connector-token',
+      'Content-Type': 'application/json',
+      'User-Agent': 'agents-test/1.0'
+    })
+  })
+
+  it('should fall back to the connector base URL and snapshot headers once per turn', () => {
+    const context = createContext(undefined)
+    const connectorClient = context.turnState.get<any>(context.adapter.ConnectorClientKey)
+
+    setTeamsApiClient(context)
+    const client = context.turnState.get<TeamsClient>(TeamsClientKey)
+    assert.ok(client)
+    connectorClient.httpClient.defaultHeaders.Authorization = 'Bearer changed-token'
+    setTeamsApiClient(context)
+
+    assert.strictEqual(client.serviceUrl, 'https://connector.example.com')
+    assert.strictEqual(getClientHeaders(client).Authorization, 'Bearer connector-token')
+    assert.strictEqual(context.turnState.get<TeamsClient>(TeamsClientKey), client)
+  })
+})

--- a/packages/agents-hosting-extensions-msteams/test/contracts/teamsApi.contract.ts
+++ b/packages/agents-hosting-extensions-msteams/test/contracts/teamsApi.contract.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import type { Activity } from '@microsoft/agents-activity'
+import {
+  Client,
+  type AppBasedLinkQuery,
+  type ChannelData,
+  type ChannelInfo,
+  type ConfigResponse,
+  type FileConsentCardResponse,
+  type MeetingDetails,
+  type MessagingExtensionAction,
+  type MessagingExtensionActionResponse,
+  type MessagingExtensionQuery,
+  type MessagingExtensionResponse,
+  type O365ConnectorCardActionQuery,
+  type OnBehalfOf,
+  type TaskModuleRequest,
+  type TaskModuleResponse,
+  type TeamInfo,
+  type TeamsChannelAccount
+} from '@microsoft/teams.api'
+import { parseTeamsChannelData } from '../../src/activity-extensions/teamsChannelData'
+import { teamsGetChannelId, teamsGetMeetingInfo, teamsGetTeamInfo, teamsGetTeamOnBehalfOf } from '../../src/teamsActivityExtensions'
+import { teamsGetDataAs } from '../../src/teamsModelExtensions'
+
+declare const activity: Activity
+declare const appBasedLinkQuery: AppBasedLinkQuery
+declare const channelData: ChannelData
+declare const channelInfo: ChannelInfo
+declare const configResponse: ConfigResponse
+declare const fileConsentResponse: FileConsentCardResponse
+declare const meetingDetails: MeetingDetails
+declare const messageExtensionAction: MessagingExtensionAction
+declare const messageExtensionActionResponse: MessagingExtensionActionResponse
+declare const messageExtensionQuery: MessagingExtensionQuery
+declare const messageExtensionResponse: MessagingExtensionResponse
+declare const o365ConnectorCardActionQuery: O365ConnectorCardActionQuery
+declare const onBehalfOf: OnBehalfOf
+declare const taskModuleRequest: TaskModuleRequest
+declare const taskModuleResponse: TaskModuleResponse
+declare const teamInfo: TeamInfo
+declare const teamsChannelAccount: TeamsChannelAccount
+
+function consume (..._values: unknown[]): void {}
+
+// Client construction and the public member consumed by TeamsTurnContext.
+const client: Client = new Client('https://service.example.com', {
+  headers: { Authorization: 'Bearer token' }
+})
+const serviceUrl: string = client.serviceUrl
+
+// Parsed models and the properties validated or read by this package.
+const parsedChannelData: ChannelData = parseTeamsChannelData({})
+consume(
+  channelData.channel,
+  channelData.eventType,
+  channelData.meeting,
+  channelData.team,
+  parsedChannelData.channel,
+  parsedChannelData.eventType,
+  parsedChannelData.meeting,
+  parsedChannelData.team,
+  appBasedLinkQuery.state,
+  appBasedLinkQuery.url,
+  messageExtensionAction.botActivityPreview,
+  messageExtensionAction.data,
+  messageExtensionQuery.commandId,
+  messageExtensionQuery.parameters,
+  messageExtensionQuery.parameters?.[0]?.name,
+  messageExtensionQuery.parameters?.[0]?.value,
+  messageExtensionQuery.queryOptions,
+  messageExtensionQuery.queryOptions?.count,
+  messageExtensionQuery.queryOptions?.skip,
+  messageExtensionQuery.state,
+  taskModuleRequest.data
+)
+
+// Public helpers preserve the Teams API types and generic payload contract.
+const channelId: string | undefined = teamsGetChannelId(activity)
+const meetingInfo: ChannelData['meeting'] | undefined = teamsGetMeetingInfo(activity)
+const returnedTeamInfo: ChannelData['team'] | undefined = teamsGetTeamInfo(activity)
+const onBehalfOfEntries: OnBehalfOf[] | undefined = teamsGetTeamOnBehalfOf(activity)
+const data: { id: string } | undefined = teamsGetDataAs<{ id: string }>(taskModuleRequest)
+
+// Keep all response and event models in the contract even where this package
+// forwards them without reading individual properties.
+consume(
+  channelInfo,
+  configResponse,
+  fileConsentResponse,
+  meetingDetails,
+  messageExtensionActionResponse,
+  messageExtensionResponse,
+  o365ConnectorCardActionQuery,
+  onBehalfOf,
+  taskModuleResponse,
+  teamInfo,
+  teamsChannelAccount,
+  serviceUrl,
+  channelId,
+  meetingInfo,
+  returnedTeamInfo,
+  onBehalfOfEntries,
+  data
+)

--- a/packages/agents-hosting-extensions-msteams/test/contracts/tsconfig.json
+++ b/packages/agents-hosting-extensions-msteams/test/contracts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../..",
+    "composite": false,
+    "declaration": false,
+    "incremental": false
+  },
+  "include": [
+    "./**/*.contract.ts",
+    "../../src/**/*.ts"
+  ]
+}

--- a/packages/agents-hosting-extensions-msteams/test/drift/teamsApiAgentReportValidation.test.ts
+++ b/packages/agents-hosting-extensions-msteams/test/drift/teamsApiAgentReportValidation.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { validateAgentReport } from '../../../../scripts/teams-api-drift/validate-teams-api-agent-report'
+
+type Finding = {
+  id: string
+  classification: 'blocking' | 'required' | 'review' | 'no-action'
+}
+
+function findings (...items: Finding[]) {
+  return {
+    schemaVersion: 1 as const,
+    dependency: '@microsoft/teams.api',
+    findings: items
+  }
+}
+
+function report (overrides: Partial<Record<string, string>> = {}): string {
+  const sections: Array<[string, string]> = [
+    ['Summary', 'This is an advisory report.'],
+    ['Compatibility breaks', '- No compatibility breaks were identified.'],
+    ['Required adaptations', '- No required adaptations were identified.'],
+    ['Feature-review candidates', '- No feature-review candidates were identified.'],
+    ['Internal implementation opportunities', '- No internal implementation opportunities were identified.'],
+    ['Maintainer decisions', '- No maintainer decisions are required.'],
+    ['No action', '- No action is required.'],
+    ['Suggested implementation issues', '- No implementation issues are suggested.'],
+    ['Validation checklist', '- [x] Deterministic findings were reviewed.']
+  ]
+  return [
+    '# teams.api Impact Report',
+    ...sections.flatMap(([heading, content]) => [`## ${heading}`, overrides[heading] ?? content])
+  ].join('\n')
+}
+
+describe('teams.api agent report validation', () => {
+  it('should require the title to be the first line', () => {
+    const validation = validateAgentReport(`Preface\n${report()}`, findings())
+
+    assert.ok(validation.errors.includes('Report must start with "# teams.api Impact Report".'))
+  })
+
+  it('should detect missing required sections', () => {
+    const validation = validateAgentReport(report().replace('## Required adaptations\n- No required adaptations were identified.\n', ''), findings())
+
+    assert.ok(validation.errors.includes('Missing required section: Required adaptations.'))
+  })
+
+  it('should require recommendations to be labeled advisory', () => {
+    const validation = validateAgentReport(report({ Summary: 'This report contains recommendations.' }), findings())
+
+    assert.ok(validation.errors.includes('Report must label recommendations as advisory.'))
+  })
+
+  it('should require blocking and required finding IDs', () => {
+    const validation = validateAgentReport(report(), findings(
+      { id: 'TSAPI-0001', classification: 'blocking' },
+      { id: 'TSAPI-0002', classification: 'required' }
+    ))
+
+    assert.deepEqual(validation.missingMandatoryFindingIds, ['TSAPI-0001', 'TSAPI-0002'])
+  })
+
+  it('should reject unknown finding IDs', () => {
+    const validation = validateAgentReport(report({ Summary: 'This is an advisory report. TSAPI-9999 requires review.' }), findings())
+
+    assert.deepEqual(validation.unknownFindingIds, ['TSAPI-9999'])
+    assert.ok(validation.errors.includes('Unknown finding ID(s): TSAPI-9999.'))
+  })
+
+  it('should reject action bullets that are not tied to a finding ID', () => {
+    const validation = validateAgentReport(report({ 'Required adaptations': '- Update the conversion logic.' }), findings())
+
+    assert.ok(validation.errors.includes('Action item is not tied to a finding ID: - Update the conversion logic.'))
+  })
+})

--- a/packages/agents-hosting-extensions-msteams/test/drift/teamsApiAgentReportValidation.test.ts
+++ b/packages/agents-hosting-extensions-msteams/test/drift/teamsApiAgentReportValidation.test.ts
@@ -20,7 +20,7 @@ function findings (...items: Finding[]) {
 
 function report (overrides: Partial<Record<string, string>> = {}): string {
   const sections: Array<[string, string]> = [
-    ['Summary', 'This is an advisory report.'],
+    ['Summary', 'This is an advisory report; it does not make or authorize implementation decisions.'],
     ['Compatibility breaks', '- No compatibility breaks were identified.'],
     ['Required adaptations', '- No required adaptations were identified.'],
     ['Feature-review candidates', '- No feature-review candidates were identified.'],
@@ -52,7 +52,7 @@ describe('teams.api agent report validation', () => {
   it('should require recommendations to be labeled advisory', () => {
     const validation = validateAgentReport(report({ Summary: 'This report contains recommendations.' }), findings())
 
-    assert.ok(validation.errors.includes('Report must label recommendations as advisory.'))
+    assert.ok(validation.errors.includes('Summary section must start with: "This is an advisory report; it does not make or authorize implementation decisions.".'))
   })
 
   it('should require blocking and required finding IDs', () => {
@@ -65,7 +65,7 @@ describe('teams.api agent report validation', () => {
   })
 
   it('should reject unknown finding IDs', () => {
-    const validation = validateAgentReport(report({ Summary: 'This is an advisory report. TSAPI-9999 requires review.' }), findings())
+    const validation = validateAgentReport(report({ Summary: 'This is an advisory report; it does not make or authorize implementation decisions. TSAPI-9999 requires review.' }), findings())
 
     assert.deepEqual(validation.unknownFindingIds, ['TSAPI-9999'])
     assert.ok(validation.errors.includes('Unknown finding ID(s): TSAPI-9999.'))

--- a/scripts/teams-api-drift/compare-teams-api.ts
+++ b/scripts/teams-api-drift/compare-teams-api.ts
@@ -1,0 +1,511 @@
+/**
+ * Extracts normalized API models for baseline and candidate teams.api versions.
+ * Writes the raw API delta and extractor artifacts consumed by the drift classifier.
+ */
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+import { createRequire } from 'node:module'
+import { execFileSync } from 'node:child_process'
+import { Extractor, ExtractorConfig } from '@microsoft/api-extractor'
+import { createTwoFilesPatch, diffLines } from 'diff'
+import ts from 'typescript'
+
+const dependency = '@microsoft/teams.api'
+const require = createRequire(import.meta.url)
+
+type Compatibility = 'breaking' | 'non-breaking' | 'potentially-breaking' | 'unknown'
+
+interface Settings {
+  from?: string
+  to?: string
+  output?: string
+  verbose: boolean
+  help: boolean
+}
+
+interface ParameterModel {
+  name: string
+  optional: boolean
+  type: string
+}
+
+interface SignatureModel {
+  parameters: ParameterModel[]
+  returnType: string
+}
+
+interface PropertyModel {
+  optional: boolean
+  type: string
+}
+
+interface SymbolModel {
+  name: string
+  kind: string
+  properties: Record<string, PropertyModel>
+  methods: Record<string, SignatureModel[]>
+  constructors: SignatureModel[]
+  enumMembers: string[]
+  deprecated: boolean
+  releaseTag?: string
+  exportPath: string
+}
+
+interface ApiModel {
+  schemaVersion: 1
+  dependency: string
+  version: string
+  symbols: SymbolModel[]
+}
+
+interface ApiReport {
+  version: string
+  text: string
+  model: ApiModel
+}
+
+interface ApiChange {
+  id: string
+  kind: string
+  symbol: string
+  member?: string
+  before?: string
+  after?: string
+  compatibility: Compatibility
+  evidence: ['normalized-api-model']
+}
+
+interface ComparisonResult {
+  schemaVersion: 1
+  dependency: string
+  fromVersion: string
+  toVersion: string
+  apiExtractorVersion: string
+  current: { version: string }
+  candidate: { requested: string, version: string }
+  changed: boolean
+  changes: ApiChange[]
+  addedLines: string[]
+  removedLines: string[]
+  diff: string
+}
+
+const help = `Usage:
+  npm run compare:teams-api [--] [candidate-version] [--from <version>] [--to <version>] [--output <file-or-directory>] [--verbose]
+
+Extracts normalized public API models for two ${dependency} versions and emits a
+structured delta. Without --from, the installed version is the baseline. Without
+a candidate or --to, the latest stable npm release is selected.
+
+Examples:
+  npm run compare:teams-api
+  npm run compare:teams-api -- 2.0.14
+  npm run compare:teams-api -- --from 2.0.12 --to 2.0.14 --output artifacts/teams-api-drift
+  npm run compare:teams-api -- 2.0.14 --output result.json
+`
+
+function parseSettings (args: string[]): Settings {
+  const positional: string[] = []
+  const settings: Settings = { verbose: false, help: false }
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { ...settings, help: true }
+    if (argument === '--verbose' || argument === '-v') {
+      settings.verbose = true
+      continue
+    }
+    if (argument === '--from' || argument === '--to' || argument === '--output' || argument === '-o') {
+      const value = args[++index]
+      if (!value) throw new Error(`${argument} requires a value.`)
+      if (argument === '--from') settings.from = value
+      else if (argument === '--to') settings.to = value
+      else settings.output = value
+      continue
+    }
+    if (argument.startsWith('-')) throw new Error(`Unknown option: ${argument}`)
+    positional.push(argument)
+  }
+
+  if (positional.length > 1) throw new Error('Specify at most one positional candidate version.')
+  if (settings.to && positional[0]) throw new Error('Use either --to or a positional candidate version, not both.')
+  settings.to ??= positional[0]
+  return settings
+}
+
+function npmCommand (): string {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm'
+}
+
+function runNpm (args: string[], workingDirectory?: string): string {
+  const useWindowsCommandShell = process.platform === 'win32'
+  const command = useWindowsCommandShell ? process.env.ComSpec ?? 'cmd.exe' : npmCommand()
+  const commandArgs = useWindowsCommandShell ? ['/d', '/s', '/c', npmCommand(), ...args] : args
+  return execFileSync(command, commandArgs, {
+    cwd: workingDirectory,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+}
+
+function isStableVersion (version: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(version)
+}
+
+function isVersion (version: string): boolean {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)
+}
+
+function compareVersions (left: string, right: string): number {
+  const leftParts = left.split('.').map(Number)
+  const rightParts = right.split('.').map(Number)
+  for (let index = 0; index < 3; index++) {
+    const difference = leftParts[index] - rightParts[index]
+    if (difference !== 0) return difference
+  }
+  return 0
+}
+
+function getLatestStableVersion (): string {
+  const result = JSON.parse(runNpm(['view', dependency, 'versions', '--json'])) as string[] | string
+  const versions = (Array.isArray(result) ? result : [result]).filter(isStableVersion)
+  if (versions.length === 0) throw new Error(`No stable npm release was found for ${dependency}. Supply --to explicitly.`)
+  return versions.sort(compareVersions).at(-1)!
+}
+
+function readPackageJson (packageRoot: string): { name: string, version: string, types?: string } {
+  return JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as { name: string, version: string, types?: string }
+}
+
+function resolveTypesEntryPoint (packageRoot: string, packageJson: { name: string, types?: string }): string {
+  if (!packageJson.types) throw new Error(`${packageJson.name} does not declare a public types entry point.`)
+  const entryPoint = resolve(packageRoot, packageJson.types)
+  if (!entryPoint.startsWith(`${packageRoot}\\`) && !entryPoint.startsWith(`${packageRoot}/`)) {
+    throw new Error(`${packageJson.name} types entry point resolves outside the package.`)
+  }
+  return entryPoint
+}
+
+function getSymbolKind (declaration: ts.Declaration): string {
+  if (ts.isClassDeclaration(declaration)) return 'class'
+  if (ts.isInterfaceDeclaration(declaration)) return 'interface'
+  if (ts.isTypeAliasDeclaration(declaration)) return 'type'
+  if (ts.isFunctionDeclaration(declaration)) return 'function'
+  if (ts.isEnumDeclaration(declaration)) return 'enum'
+  if (ts.isVariableDeclaration(declaration)) return 'variable'
+  if (ts.isModuleDeclaration(declaration)) return 'namespace'
+  return ts.SyntaxKind[declaration.kind]
+}
+
+function getReleaseTag (declaration: ts.Declaration): string | undefined {
+  const text = declaration.getFullText()
+  return ['public', 'beta', 'alpha', 'internal'].find(tag => new RegExp(`@${tag}\\b`).test(text))
+}
+
+function getPropertyModel (checker: ts.TypeChecker, symbol: ts.Symbol, fallback: ts.Node): PropertyModel {
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0] ?? fallback
+  return {
+    optional: Boolean(symbol.flags & ts.SymbolFlags.Optional),
+    type: checker.typeToString(checker.getTypeOfSymbolAtLocation(symbol, declaration), declaration, ts.TypeFormatFlags.NoTruncation)
+  }
+}
+
+function getSignatureModels (checker: ts.TypeChecker, signatures: readonly ts.Signature[], fallback: ts.Node): SignatureModel[] {
+  return signatures.map(signature => {
+    const declaration = signature.getDeclaration() ?? fallback
+    return {
+      parameters: signature.getParameters().map(parameter => getPropertyModel(checker, parameter, declaration)).map((parameter, index) => ({
+        ...parameter,
+        name: signature.getParameters()[index].getName()
+      })),
+      returnType: checker.typeToString(signature.getReturnType(), declaration, ts.TypeFormatFlags.NoTruncation)
+    }
+  }).sort((left, right) => stringifySignature(left).localeCompare(stringifySignature(right)))
+}
+
+function isMethodSymbol (symbol: ts.Symbol): boolean {
+  return (symbol.declarations ?? []).some(declaration =>
+    ts.isMethodDeclaration(declaration) || ts.isMethodSignature(declaration))
+}
+
+function isSyntheticSymbol (symbol: ts.Symbol): boolean {
+  return symbol.getName().startsWith('__@')
+}
+
+function extractApiModel (packageRoot: string, version: string): ApiModel {
+  const packageJson = readPackageJson(packageRoot)
+  const entryPoint = resolveTypesEntryPoint(packageRoot, packageJson)
+  const program = ts.createProgram([entryPoint], {
+    skipLibCheck: true,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    target: ts.ScriptTarget.ES2022
+  })
+  const checker = program.getTypeChecker()
+  const entryPointFile = program.getSourceFile(entryPoint)
+  if (!entryPointFile) throw new Error(`TypeScript could not load ${entryPoint}.`)
+  const moduleSymbol = checker.getSymbolAtLocation(entryPointFile)
+  if (!moduleSymbol) throw new Error(`TypeScript could not resolve the ${dependency} module symbol.`)
+
+  const symbols = checker.getExportsOfModule(moduleSymbol).map(exportedSymbol => {
+    const symbol = exportedSymbol.flags & ts.SymbolFlags.Alias
+      ? checker.getAliasedSymbol(exportedSymbol)
+      : exportedSymbol
+    const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0]
+    if (!declaration) throw new Error(`Could not resolve a declaration for ${exportedSymbol.getName()}.`)
+    const declaredType = checker.getDeclaredTypeOfSymbol(symbol)
+    const valueType = checker.getTypeOfSymbolAtLocation(symbol, declaration)
+    const type = declaredType.getProperties().length > 0 || declaredType.getCallSignatures().length > 0 || declaredType.getConstructSignatures().length > 0
+      ? declaredType
+      : valueType
+    const properties: Record<string, PropertyModel> = {}
+    const methods: Record<string, SignatureModel[]> = {}
+    for (const member of checker.getPropertiesOfType(type)) {
+      if (isSyntheticSymbol(member)) continue
+      if (isMethodSymbol(member)) {
+        const memberDeclaration = member.valueDeclaration ?? member.declarations?.[0] ?? declaration
+        methods[member.getName()] = getSignatureModels(checker, checker.getTypeOfSymbolAtLocation(member, memberDeclaration).getCallSignatures(), memberDeclaration)
+      } else {
+        properties[member.getName()] = getPropertyModel(checker, member, declaration)
+      }
+    }
+    const enumMembers = ts.isEnumDeclaration(declaration)
+      ? declaration.members.map(member => member.name.getText()).sort()
+      : []
+    const callSignatures = getSignatureModels(checker, type.getCallSignatures(), declaration)
+    if (callSignatures.length > 0 && Object.keys(methods).length === 0) methods.$call = callSignatures
+
+    return {
+      name: exportedSymbol.getName(),
+      kind: getSymbolKind(declaration),
+      properties,
+      methods,
+      constructors: getSignatureModels(checker, type.getConstructSignatures(), declaration),
+      enumMembers,
+      deprecated: ts.getJSDocTags(declaration).some(tag => tag.tagName.text === 'deprecated'),
+      releaseTag: getReleaseTag(declaration),
+      exportPath: dependency
+    }
+  }).sort((left, right) => left.name.localeCompare(right.name))
+
+  return { schemaVersion: 1, dependency, version, symbols }
+}
+
+function generateApiReport (packageRoot: string, workRoot: string): ApiReport {
+  const packageJsonPath = join(packageRoot, 'package.json')
+  const packageJson = readPackageJson(packageRoot)
+  const reportDirectory = join(workRoot, packageJson.version)
+  const reportTempDirectory = join(reportDirectory, 'temp')
+  mkdirSync(reportDirectory, { recursive: true })
+  writeFileSync(join(reportDirectory, 'teams-api.api.md'), '')
+
+  const config = ExtractorConfig.prepare({
+    packageJsonFullPath: packageJsonPath,
+    configObjectFullPath: join(reportDirectory, 'api-extractor.json'),
+    configObject: {
+      projectFolder: packageRoot,
+      mainEntryPointFilePath: resolveTypesEntryPoint(packageRoot, packageJson),
+      compiler: {
+        overrideTsconfig: { compilerOptions: { module: 'NodeNext', moduleResolution: 'NodeNext', skipLibCheck: true } },
+        skipLibCheck: true
+      },
+      apiReport: { enabled: true, reportFileName: 'teams-api', reportFolder: reportDirectory, reportTempFolder: reportTempDirectory },
+      docModel: { enabled: false },
+      dtsRollup: { enabled: false },
+      tsdocMetadata: { enabled: false }
+    }
+  })
+
+  const result = Extractor.invoke(config, { localBuild: true, messageCallback: () => {} })
+  if (!result.succeeded) throw new Error(`API Extractor failed for ${dependency}@${packageJson.version} with ${result.errorCount} error(s).`)
+  return {
+    version: packageJson.version,
+    text: readFileSync(join(reportDirectory, 'teams-api.api.md'), 'utf8'),
+    model: extractApiModel(packageRoot, packageJson.version)
+  }
+}
+
+function installPackage (packageSpec: string, workRoot: string, name: string): string {
+  const installRoot = join(workRoot, name)
+  mkdirSync(installRoot, { recursive: true })
+  writeFileSync(join(installRoot, 'package.json'), '{ "private": true }\n')
+  try {
+    runNpm(['install', '--ignore-scripts', '--no-package-lock', '--no-save', '--cache', join(workRoot, 'npm-cache'), packageSpec], installRoot)
+  } catch (error) {
+    const details = error instanceof Error && 'stderr' in error && error.stderr != null
+      ? String(error.stderr).trim()
+      : error instanceof Error ? error.message : String(error)
+    throw new Error(`Unable to install ${packageSpec}. ${details}`)
+  }
+  const packageRoot = join(installRoot, 'node_modules', ...dependency.split('/'))
+  const packageJson = readPackageJson(packageRoot)
+  if (packageJson.name !== dependency) throw new Error(`Expected ${dependency}, but ${packageSpec} installed ${packageJson.name}.`)
+  return packageRoot
+}
+
+function stringifyProperty (property: PropertyModel | undefined): string | undefined {
+  return property && `${property.optional ? '?' : ''}: ${property.type}`
+}
+
+function stringifySignature (signature: SignatureModel): string {
+  return `(${signature.parameters.map(parameter => `${parameter.name}${parameter.optional ? '?' : ''}: ${parameter.type}`).join(', ')}) => ${signature.returnType}`
+}
+
+function addChange (changes: Omit<ApiChange, 'id'>[], change: Omit<ApiChange, 'id'>): void {
+  changes.push(change)
+}
+
+function compareSignatures (changes: Omit<ApiChange, 'id'>[], symbol: string, member: string, before: SignatureModel[], after: SignatureModel[]): void {
+  if (before.length !== after.length) {
+    addChange(changes, {
+      kind: before.length < after.length ? 'overload-added' : 'overload-removed',
+      symbol,
+      member,
+      before: String(before.length),
+      after: String(after.length),
+      compatibility: before.length < after.length ? 'non-breaking' : 'breaking',
+      evidence: ['normalized-api-model']
+    })
+  }
+  for (let index = 0; index < Math.min(before.length, after.length); index++) {
+    const oldSignature = before[index]
+    const newSignature = after[index]
+    if (oldSignature.returnType !== newSignature.returnType) {
+      addChange(changes, { kind: 'return-type-changed', symbol, member: `${member}#${index + 1}`, before: oldSignature.returnType, after: newSignature.returnType, compatibility: 'potentially-breaking', evidence: ['normalized-api-model'] })
+    }
+    if (oldSignature.parameters.length !== newSignature.parameters.length) {
+      const added = newSignature.parameters.slice(oldSignature.parameters.length)
+      addChange(changes, {
+        kind: oldSignature.parameters.length < newSignature.parameters.length ? 'parameter-added' : 'parameter-removed',
+        symbol,
+        member: `${member}#${index + 1}`,
+        before: stringifySignature(oldSignature),
+        after: stringifySignature(newSignature),
+        compatibility: added.some(parameter => !parameter.optional) ? 'breaking' : 'potentially-breaking',
+        evidence: ['normalized-api-model']
+      })
+    }
+    for (let parameterIndex = 0; parameterIndex < Math.min(oldSignature.parameters.length, newSignature.parameters.length); parameterIndex++) {
+      const oldParameter = oldSignature.parameters[parameterIndex]
+      const newParameter = newSignature.parameters[parameterIndex]
+      const parameterName = `${member}#${index + 1}.${oldParameter.name}`
+      if (oldParameter.optional !== newParameter.optional) {
+        addChange(changes, { kind: 'parameter-requiredness-changed', symbol, member: parameterName, before: String(!oldParameter.optional), after: String(!newParameter.optional), compatibility: newParameter.optional ? 'non-breaking' : 'breaking', evidence: ['normalized-api-model'] })
+      }
+      if (oldParameter.type !== newParameter.type) {
+        addChange(changes, { kind: 'parameter-type-changed', symbol, member: parameterName, before: oldParameter.type, after: newParameter.type, compatibility: 'potentially-breaking', evidence: ['normalized-api-model'] })
+      }
+    }
+  }
+}
+
+function createChanges (before: ApiModel, after: ApiModel): ApiChange[] {
+  const changes: Omit<ApiChange, 'id'>[] = []
+  const beforeSymbols = new Map(before.symbols.map(symbol => [symbol.name, symbol]))
+  const afterSymbols = new Map(after.symbols.map(symbol => [symbol.name, symbol]))
+  for (const name of new Set([...beforeSymbols.keys(), ...afterSymbols.keys()])) {
+    const oldSymbol = beforeSymbols.get(name)
+    const newSymbol = afterSymbols.get(name)
+    if (!oldSymbol || !newSymbol) {
+      addChange(changes, { kind: oldSymbol ? 'symbol-removed' : 'symbol-added', symbol: name, compatibility: oldSymbol ? 'breaking' : 'non-breaking', evidence: ['normalized-api-model'] })
+      continue
+    }
+    if (oldSymbol.exportPath !== newSymbol.exportPath) addChange(changes, { kind: 'export-path-changed', symbol: name, before: oldSymbol.exportPath, after: newSymbol.exportPath, compatibility: 'potentially-breaking', evidence: ['normalized-api-model'] })
+    if (oldSymbol.deprecated !== newSymbol.deprecated) addChange(changes, { kind: newSymbol.deprecated ? 'deprecation-added' : 'deprecation-removed', symbol: name, compatibility: 'unknown', evidence: ['normalized-api-model'] })
+    if (oldSymbol.releaseTag !== newSymbol.releaseTag) addChange(changes, { kind: 'release-tag-changed', symbol: name, before: oldSymbol.releaseTag, after: newSymbol.releaseTag, compatibility: 'unknown', evidence: ['normalized-api-model'] })
+    for (const property of new Set([...Object.keys(oldSymbol.properties), ...Object.keys(newSymbol.properties)])) {
+      const oldProperty = oldSymbol.properties[property]
+      const newProperty = newSymbol.properties[property]
+      if (!oldProperty || !newProperty) {
+        addChange(changes, { kind: oldProperty ? 'property-removed' : 'property-added', symbol: name, member: property, before: stringifyProperty(oldProperty), after: stringifyProperty(newProperty), compatibility: oldProperty ? 'breaking' : 'non-breaking', evidence: ['normalized-api-model'] })
+        continue
+      }
+      if (oldProperty.optional !== newProperty.optional) addChange(changes, { kind: 'property-requiredness-changed', symbol: name, member: property, before: String(!oldProperty.optional), after: String(!newProperty.optional), compatibility: newProperty.optional ? 'non-breaking' : 'potentially-breaking', evidence: ['normalized-api-model'] })
+      if (oldProperty.type !== newProperty.type) addChange(changes, { kind: 'property-type-changed', symbol: name, member: property, before: oldProperty.type, after: newProperty.type, compatibility: 'potentially-breaking', evidence: ['normalized-api-model'] })
+    }
+    for (const method of new Set([...Object.keys(oldSymbol.methods), ...Object.keys(newSymbol.methods)])) {
+      const oldMethod = oldSymbol.methods[method]
+      const newMethod = newSymbol.methods[method]
+      if (!oldMethod || !newMethod) {
+        addChange(changes, { kind: oldMethod ? 'method-removed' : 'method-added', symbol: name, member: method, compatibility: oldMethod ? 'breaking' : 'non-breaking', evidence: ['normalized-api-model'] })
+      } else compareSignatures(changes, name, method, oldMethod, newMethod)
+    }
+    compareSignatures(changes, name, 'constructor', oldSymbol.constructors, newSymbol.constructors)
+    for (const member of new Set([...oldSymbol.enumMembers, ...newSymbol.enumMembers])) {
+      if (!oldSymbol.enumMembers.includes(member) || !newSymbol.enumMembers.includes(member)) addChange(changes, { kind: oldSymbol.enumMembers.includes(member) ? 'enum-member-removed' : 'enum-member-added', symbol: name, member, compatibility: oldSymbol.enumMembers.includes(member) ? 'breaking' : 'non-breaking', evidence: ['normalized-api-model'] })
+    }
+  }
+  return changes.sort((left, right) => `${left.symbol}.${left.member ?? ''}.${left.kind}`.localeCompare(`${right.symbol}.${right.member ?? ''}.${right.kind}`)).map((change, index) => ({ ...change, id: `TSAPI-${String(index + 1).padStart(4, '0')}` }))
+}
+
+function createComparison (current: ApiReport, candidate: ApiReport, requestedCandidate: string): ComparisonResult {
+  const lineChanges = diffLines(current.text, candidate.text)
+  const addedLines = lineChanges.filter(change => change.added).flatMap(change => change.value.split('\n').filter(Boolean))
+  const removedLines = lineChanges.filter(change => change.removed).flatMap(change => change.value.split('\n').filter(Boolean))
+  const changes = createChanges(current.model, candidate.model)
+  return {
+    schemaVersion: 1,
+    dependency,
+    fromVersion: current.version,
+    toVersion: candidate.version,
+    apiExtractorVersion: Extractor.version,
+    current: { version: current.version },
+    candidate: { requested: requestedCandidate, version: candidate.version },
+    changed: changes.length > 0,
+    changes,
+    addedLines,
+    removedLines,
+    diff: createTwoFilesPatch(`${dependency}@${current.version}`, `${dependency}@${candidate.version}`, current.text, candidate.text, '', '', { context: 3 })
+  }
+}
+
+function writeJson (destination: string, value: unknown): void {
+  mkdirSync(dirname(destination), { recursive: true })
+  writeFileSync(destination, `${JSON.stringify(value, undefined, 2)}\n`)
+}
+
+function writeOutput (result: ComparisonResult, current: ApiReport, candidate: ApiReport, output: string): void {
+  const destination = resolve(output)
+  if (extname(destination).toLowerCase() === '.json') {
+    writeJson(destination, result)
+    console.log(`Wrote comparison result to ${relative(process.cwd(), destination) || basename(destination)}`)
+    return
+  }
+  mkdirSync(destination, { recursive: true })
+  writeJson(join(destination, 'teams-api-before.api.json'), current.model)
+  writeJson(join(destination, 'teams-api-after.api.json'), candidate.model)
+  writeJson(join(destination, 'raw-api-diff.json'), result)
+  console.log(`Wrote API models and raw delta to ${relative(process.cwd(), destination) || basename(destination)}`)
+}
+
+function main (): void {
+  const settings = parseSettings(process.argv.slice(2))
+  if (settings.help) {
+    console.log(help)
+    return
+  }
+
+  const installedPackageRoot = dirname(require.resolve(`${dependency}/package.json`))
+  const installedVersion = readPackageJson(installedPackageRoot).version
+  const fromVersion = settings.from ?? installedVersion
+  const toVersion = settings.to ?? getLatestStableVersion()
+  if (!isVersion(fromVersion) || !isVersion(toVersion)) throw new Error('--from and --to must be complete versions, optionally with a prerelease suffix.')
+
+  const workRoot = mkdtempSync(join(tmpdir(), 'teams-api-compare-'))
+  try {
+    console.log(`Comparing ${dependency}@${fromVersion} with ${dependency}@${toVersion}...`)
+    const currentPackageRoot = fromVersion === installedVersion ? installedPackageRoot : installPackage(`${dependency}@${fromVersion}`, workRoot, 'baseline')
+    const candidatePackageRoot = toVersion === installedVersion ? installedPackageRoot : installPackage(`${dependency}@${toVersion}`, workRoot, 'candidate')
+    const current = generateApiReport(currentPackageRoot, workRoot)
+    const candidate = generateApiReport(candidatePackageRoot, workRoot)
+    const comparison = createComparison(current, candidate, toVersion)
+    console.log(comparison.changed ? `${comparison.changes.length} structured API change(s) detected.` : 'No public API changes detected.')
+    if (comparison.changed && settings.verbose) console.log(comparison.diff)
+    if (settings.output) writeOutput(comparison, current, candidate, settings.output)
+  } finally {
+    rmSync(workRoot, { recursive: true, force: true })
+  }
+}
+
+main()

--- a/scripts/teams-api-drift/detect-teams-api-drifts.ts
+++ b/scripts/teams-api-drift/detect-teams-api-drifts.ts
@@ -1,0 +1,408 @@
+/**
+ * Intersects an upstream API delta with the extension's dependency usage manifest.
+ * Produces deterministic compatibility findings and optional public-API exposure context.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+import { parse } from 'yaml'
+
+const dependency = '@microsoft/teams.api'
+const packageRoot = 'packages/agents-hosting-extensions-msteams'
+const defaultManifestPath = join(packageRoot, 'teams-api-usage-manifest.json')
+const defaultComparisonPath = 'artifacts/teams-api-drift/raw-api-diff.json'
+const defaultCapabilitiesPath = join(packageRoot, 'config/teams-capabilities.yaml')
+
+type Classification = 'blocking' | 'required' | 'review' | 'no-action'
+type Exposure = 'internal-only' | 'publicly-exposed' | 're-exported' | 'runtime-used' | 'type-only' | 'unknown'
+type FindingCategory = 'feature-review' | 'internal-opportunity' | 'maintainer-decision'
+type AdoptionPolicy = 'strict-compatibility' | 'review-new-members' | 'advisory-only'
+
+interface Usage {
+  upstreamSymbol: string
+  usage: string
+  usageKinds?: string[]
+  exposure?: Exposure
+  methodsCalled?: string[]
+  propertiesRead?: string[]
+  propertiesValidated?: string[]
+  propertiesWritten?: string[]
+  files: string[]
+}
+
+interface UsageManifest {
+  dependency: string
+  usages: Usage[]
+}
+
+interface ApiChange {
+  id: string
+  kind: string
+  symbol: string
+  member?: string
+  before?: string
+  after?: string
+  compatibility: 'breaking' | 'non-breaking' | 'potentially-breaking' | 'unknown'
+  evidence: string[]
+}
+
+interface ComparisonResult {
+  schemaVersion: number
+  dependency: string
+  fromVersion: string
+  toVersion: string
+  changes: ApiChange[]
+}
+
+interface Settings {
+  comparison: string
+  manifest: string
+  capabilities: string
+  publicApiReport?: string
+  output?: string
+  failOnDrift: boolean
+  help: boolean
+}
+
+interface Finding {
+  id: string
+  source: 'api-diff' | 'public-api'
+  classification: Classification
+  category?: FindingCategory
+  kind: string
+  upstreamSymbol: string
+  member?: string
+  capability?: string
+  usageKinds: string[]
+  exposure: Exposure
+  affectedFiles: string[]
+  before?: string
+  after?: string
+  evidence: string[]
+  recommendedAction: string
+}
+
+interface FindingsResult {
+  schemaVersion: 1
+  dependency: string
+  fromVersion: string
+  toVersion: string
+  summary: Record<Classification, number>
+  publicApi?: PublicApiFindingSummary
+  findings: Finding[]
+}
+
+interface Capability {
+  upstreamAreas: string[]
+  adoptionPolicy: AdoptionPolicy
+}
+
+interface CapabilitiesDocument {
+  schemaVersion: 1
+  dependency: { package: string }
+  capabilities: Record<string, Capability>
+}
+
+interface PublicApiSymbolChange {
+  kind: 'public-symbol-added' | 'public-symbol-removed' | 'public-symbol-changed'
+  symbol: string
+  before?: string
+  after?: string
+  releaseDecision: 'patch' | 'minor' | 'major' | 'maintainer-review'
+}
+
+interface PublicApiTypeLeak {
+  upstreamSymbol: string
+  importKind: 'type-only' | 'runtime'
+  publicExports: string[]
+}
+
+interface PublicApiReport {
+  schemaVersion: 1
+  package: string
+  baseline: string
+  entrypoint: string
+  status: 'unchanged' | 'changed'
+  releaseDecision: 'patch' | 'minor' | 'major' | 'maintainer-review'
+  publicSymbolChanges: PublicApiSymbolChange[]
+  upstreamTypeLeaks: PublicApiTypeLeak[]
+}
+
+interface PublicApiFindingSummary {
+  status: 'unchanged' | 'changed'
+  releaseDecision: PublicApiReport['releaseDecision']
+  baseline: string
+  entrypoint: string
+  upstreamTypeLeaks: PublicApiTypeLeak[]
+}
+
+const help = `Usage:
+  npm run detect:teams-api-drifts -- [--comparison <file>] [--manifest <file>] [--capabilities <file>] [--public-api-report <file>] [--output <file-or-directory>] [--fail-on-drift]
+
+Joins a Stage 3 raw API delta with the Teams extension's dependency usage manifest.
+The result classifies changes as blocking, required, review, or no-action and
+includes the source files affected by every direct-use finding.
+
+Defaults:
+  comparison: ${defaultComparisonPath}
+  manifest:   ${defaultManifestPath}
+  capabilities: ${defaultCapabilitiesPath}
+
+Examples:
+  npm run compare:teams-api -- --from 2.0.13 --to 2.0.14 --output artifacts/teams-api-drift
+  npm run detect:teams-api-drifts -- --comparison artifacts/teams-api-drift/raw-api-diff.json --output artifacts/teams-api-drift
+  npm run detect:teams-api-drifts -- --public-api-report artifacts/teams-api-drift/public-api-report.json --output artifacts/teams-api-drift
+`
+
+function parseSettings (args: string[]): Settings {
+  const settings: Settings = {
+    comparison: defaultComparisonPath,
+    manifest: defaultManifestPath,
+    capabilities: defaultCapabilitiesPath,
+    failOnDrift: false,
+    help: false
+  }
+
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { ...settings, help: true }
+    if (argument === '--fail-on-drift') {
+      settings.failOnDrift = true
+      continue
+    }
+    if (argument === '--comparison' || argument === '-c' || argument === '--manifest' || argument === '-m' || argument === '--capabilities' || argument === '--public-api-report' || argument === '--output' || argument === '-o') {
+      const value = args[++index]
+      if (!value) throw new Error(`${argument} requires a file path.`)
+      if (argument === '--comparison' || argument === '-c') settings.comparison = value
+      else if (argument === '--manifest' || argument === '-m') settings.manifest = value
+      else if (argument === '--capabilities') settings.capabilities = value
+      else if (argument === '--public-api-report') settings.publicApiReport = value
+      else settings.output = value
+      continue
+    }
+    throw new Error(`Unknown option: ${argument}`)
+  }
+
+  return settings
+}
+
+function readJson<T> (filePath: string): T {
+  const fullPath = resolve(filePath)
+  if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`)
+  return JSON.parse(readFileSync(fullPath, 'utf8')) as T
+}
+
+function readCapabilities (filePath: string): CapabilitiesDocument {
+  const fullPath = resolve(filePath)
+  if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`)
+  const document = parse(readFileSync(fullPath, 'utf8')) as CapabilitiesDocument
+  if (document?.schemaVersion !== 1 || document.dependency?.package !== dependency || !document.capabilities) {
+    throw new Error(`Capabilities file must be a schemaVersion 1 ownership map for ${dependency}.`)
+  }
+  return document
+}
+
+function getExposure (usage: Usage): Exposure {
+  if (usage.exposure) return usage.exposure
+  if (usage.usage === 'instantiated') return 'runtime-used'
+  if (usage.usage === 'type-reference') return 'type-only'
+  return 'unknown'
+}
+
+function getUsageKinds (usage: Usage): string[] {
+  return usage.usageKinds ?? [usage.usage]
+}
+
+function propertyPaths (usage: Usage): string[] {
+  return [...(usage.propertiesRead ?? []), ...(usage.propertiesWritten ?? []), ...(usage.propertiesValidated ?? [])]
+}
+
+function propertyMatches (member: string | undefined, usage: Usage): boolean {
+  if (!member) return false
+  return propertyPaths(usage).some(path => path === member || path.replace(/\[\]/g, '').split('.')[0] === member)
+}
+
+function methodMatches (symbol: string, member: string | undefined, usage: Usage): boolean {
+  if (!member) return false
+  if (usage.upstreamSymbol === `${symbol}.${member}`) return true
+  if (usage.upstreamSymbol !== symbol) return false
+  return (usage.methodsCalled ?? []).some(method => method === member || method === `${symbol}.${member}`)
+}
+
+function isDirectlyRelevant (change: ApiChange, usages: Usage[]): Usage[] {
+  return usages.filter(usage => {
+    if (change.kind.startsWith('property-')) return usage.upstreamSymbol === change.symbol && propertyMatches(change.member, usage)
+    if (change.kind.startsWith('method-') || change.kind.startsWith('overload-') || change.kind.startsWith('parameter-') || change.kind === 'return-type-changed') return methodMatches(change.symbol, change.member?.split('#')[0], usage)
+    return usage.upstreamSymbol === change.symbol
+  })
+}
+
+function upstreamAreasFor (change: ApiChange): string[] {
+  if (change.symbol === 'Client') return ['clients']
+  if (change.symbol.endsWith('Client')) return [`clients.${change.symbol.slice(0, -'Client'.length).toLowerCase()}`]
+  if (change.symbol === 'ChannelData') return ['models.channel-data']
+  if (change.symbol === 'ChannelInfo') return ['models.channel-data.channel-info']
+  if (change.symbol === 'TeamInfo') return ['models.channel-data.team-info']
+  if (change.symbol.startsWith('Meeting')) return ['models.meeting']
+  if (change.symbol.startsWith('MessagingExtension')) return ['models.messaging-extension']
+  if (change.symbol.startsWith('TaskModule')) return ['models.task-module']
+  if (change.symbol.startsWith('File')) return ['models.file']
+  if (change.symbol.startsWith('Config')) return ['models.config']
+  return []
+}
+
+function capabilityFor (change: ApiChange, capabilities: CapabilitiesDocument): { name: string, policy: AdoptionPolicy } | undefined {
+  const upstreamAreas = upstreamAreasFor(change)
+  const matches = Object.entries(capabilities.capabilities).flatMap(([name, capability]) => capability.upstreamAreas
+    .filter(area => upstreamAreas.some(candidate => candidate === area || candidate.startsWith(`${area}.`)))
+    .map(area => ({ name, policy: capability.adoptionPolicy, area })))
+  const match = matches.sort((left, right) => right.area.length - left.area.length || left.name.localeCompare(right.name))[0]
+  return match && { name: match.name, policy: match.policy }
+}
+
+function isAdditiveChange (change: ApiChange): boolean {
+  return change.kind === 'symbol-added' || change.kind === 'property-added' || change.kind === 'method-added' || change.kind === 'overload-added' || change.kind === 'enum-member-added'
+}
+
+function categoryFor (change: ApiChange, usages: Usage[], capability: { name: string, policy: AdoptionPolicy } | undefined): FindingCategory | undefined {
+  if (!isAdditiveChange(change) || usages.length > 0 || !capability) return undefined
+  if (capability.policy === 'review-new-members') return 'feature-review'
+  if (capability.policy === 'strict-compatibility') return 'internal-opportunity'
+  return undefined
+}
+
+function classify (change: ApiChange, usages: Usage[], publiclyExposed: boolean): Classification {
+  if (usages.length === 0) return 'no-action'
+  if (change.kind === 'symbol-removed' || change.kind === 'property-removed' || change.kind === 'method-removed' || change.kind === 'overload-removed') return 'blocking'
+  if (change.kind === 'parameter-requiredness-changed' && change.after === 'true') return 'blocking'
+  if (change.kind === 'property-type-changed' || change.kind === 'property-requiredness-changed' || change.kind === 'parameter-type-changed' || change.kind === 'parameter-removed' || change.kind === 'return-type-changed') {
+    return publiclyExposed || usages.some(usage => getExposure(usage) === 'publicly-exposed' || getExposure(usage) === 're-exported') ? 'blocking' : 'required'
+  }
+  if (change.kind === 'export-path-changed' || change.kind === 'deprecation-added' || change.kind === 'release-tag-changed') return 'review'
+  return 'review'
+}
+
+function recommendedAction (classification: Classification, change: ApiChange, category?: FindingCategory): string {
+  if (classification === 'blocking') return `Adapt or remove the use of ${change.symbol}${change.member ? `.${change.member}` : ''} before adopting the candidate version.`
+  if (classification === 'required') return 'Review the affected type contract and update the extension\'s mapping or nullability handling as needed.'
+  if (category === 'feature-review') return 'Review this new upstream capability for adoption by the owning Teams extension feature.'
+  if (category === 'internal-opportunity') return 'Consider whether this new upstream API can improve the extension\'s internal implementation.'
+  if (classification === 'review') return 'Review the upstream change for behavioral or public API impact; no automatic feature adoption is implied.'
+  return 'No direct usage intersects this API change.'
+}
+
+function createFindings (comparison: ComparisonResult, manifest: UsageManifest, capabilities: CapabilitiesDocument, publicApiReport?: PublicApiReport): FindingsResult {
+  const publiclyExposedSymbols = new Set(publicApiReport?.upstreamTypeLeaks.map(leak => leak.upstreamSymbol) ?? [])
+  const findings: Finding[] = comparison.changes.map(change => {
+    const usages = isDirectlyRelevant(change, manifest.usages)
+    const publiclyExposed = publiclyExposedSymbols.has(change.symbol)
+    const capability = capabilityFor(change, capabilities)
+    const category = categoryFor(change, usages, capability)
+    const classification = category ? 'review' : classify(change, usages, publiclyExposed)
+    return {
+      id: change.id,
+      source: 'api-diff' as const,
+      classification,
+      ...(category && { category }),
+      kind: change.kind,
+      upstreamSymbol: change.symbol,
+      ...(change.member && { member: change.member }),
+      ...(capability && { capability: capability.name }),
+      usageKinds: [...new Set(usages.flatMap(getUsageKinds))],
+      exposure: publiclyExposed
+        ? 'publicly-exposed'
+        : usages.reduce<Exposure>((strictest, usage) => {
+          const exposure = getExposure(usage)
+          return ['publicly-exposed', 're-exported'].includes(exposure) ? exposure : strictest
+        }, usages[0] ? getExposure(usages[0]) : 'unknown'),
+      affectedFiles: [...new Set(usages.flatMap(usage => usage.files))].sort(),
+      ...(change.before !== undefined && { before: change.before }),
+      ...(change.after !== undefined && { after: change.after }),
+      evidence: [...new Set([...change.evidence, 'dependency-usage', ...(capability ? ['teams-capabilities'] : []), ...(publiclyExposed ? ['public-api-report'] : [])])],
+      recommendedAction: recommendedAction(classification, change, category)
+    }
+  })
+  if (publicApiReport?.status === 'changed') {
+    for (const change of publicApiReport.publicSymbolChanges) {
+      findings.push({
+        id: `EXTAPI-${String(findings.length + 1).padStart(4, '0')}`,
+        source: 'public-api',
+        classification: 'review',
+        kind: change.kind,
+        upstreamSymbol: `${publicApiReport.package}.${change.symbol}`,
+        usageKinds: ['public-api'],
+        exposure: 'publicly-exposed',
+        affectedFiles: [publicApiReport.entrypoint],
+        ...(change.before !== undefined && { before: change.before }),
+        ...(change.after !== undefined && { after: change.after }),
+        evidence: ['public-api-report'],
+        recommendedAction: `Review the ${change.releaseDecision} release impact before changing the public API baseline.`
+      })
+    }
+  }
+  const summary: Record<Classification, number> = { blocking: 0, required: 0, review: 0, 'no-action': 0 }
+  for (const finding of findings) summary[finding.classification]++
+  return {
+    schemaVersion: 1,
+    dependency,
+    fromVersion: comparison.fromVersion,
+    toVersion: comparison.toVersion,
+    summary,
+    ...(publicApiReport && {
+      publicApi: {
+        status: publicApiReport.status,
+        releaseDecision: publicApiReport.releaseDecision,
+        baseline: publicApiReport.baseline,
+        entrypoint: publicApiReport.entrypoint,
+        upstreamTypeLeaks: publicApiReport.upstreamTypeLeaks
+      }
+    }),
+    findings
+  }
+}
+
+function writeJson (destination: string, value: unknown): void {
+  mkdirSync(dirname(destination), { recursive: true })
+  writeFileSync(destination, `${JSON.stringify(value, undefined, 2)}\n`)
+}
+
+function writeOutput (result: FindingsResult, output: string): void {
+  const destination = resolve(output)
+  if (extname(destination).toLowerCase() === '.json') {
+    writeJson(destination, result)
+    console.log(`Wrote findings to ${relative(process.cwd(), destination) || basename(destination)}`)
+    return
+  }
+  mkdirSync(destination, { recursive: true })
+  const findingsPath = join(destination, 'findings.json')
+  writeJson(findingsPath, result)
+  console.log(`Wrote findings to ${relative(process.cwd(), findingsPath) || basename(findingsPath)}`)
+}
+
+function main (): void {
+  const settings = parseSettings(process.argv.slice(2))
+  if (settings.help) {
+    console.log(help)
+    return
+  }
+
+  const comparison = readJson<ComparisonResult>(settings.comparison)
+  const manifest = readJson<UsageManifest>(settings.manifest)
+  const capabilities = readCapabilities(settings.capabilities)
+  const publicApiReport = settings.publicApiReport ? readJson<PublicApiReport>(settings.publicApiReport) : undefined
+  if (comparison.schemaVersion !== 1 || !Array.isArray(comparison.changes)) {
+    throw new Error('Comparison result must be a schemaVersion 1 raw API delta. Re-run compare:teams-api with --output <directory>.')
+  }
+  if (comparison.dependency !== dependency || manifest.dependency !== dependency) {
+    throw new Error(`Both input files must describe ${dependency}.`)
+  }
+  if (publicApiReport && (publicApiReport.schemaVersion !== 1 || publicApiReport.package !== '@microsoft/agents-hosting-extensions-msteams')) {
+    throw new Error('Public API report must be a schemaVersion 1 report for @microsoft/agents-hosting-extensions-msteams.')
+  }
+
+  const result = createFindings(comparison, manifest, capabilities, publicApiReport)
+  console.log(`Classified ${result.findings.length} API change(s): ${JSON.stringify(result.summary)}`)
+  if (settings.output) writeOutput(result, settings.output)
+  if (settings.failOnDrift && (result.summary.blocking > 0 || result.summary.required > 0)) process.exitCode = 1
+}
+
+main()

--- a/scripts/teams-api-drift/prepare-teams-api-agent-context.ts
+++ b/scripts/teams-api-drift/prepare-teams-api-agent-context.ts
@@ -1,0 +1,176 @@
+/**
+ * Builds the bounded, redacted context supplied to the advisory AI report generator.
+ * Includes deterministic artifacts and only source files relevant to actionable findings.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+
+const packageRoot = 'packages/agents-hosting-extensions-msteams'
+const defaultArtifactDirectory = 'artifacts/teams-api-drift'
+
+interface Finding {
+  id: string
+  classification: 'blocking' | 'required' | 'review' | 'no-action'
+  capability?: string
+  affectedFiles: string[]
+}
+
+interface FindingsResult {
+  schemaVersion: 1
+  dependency: string
+  findings: Finding[]
+}
+
+interface SourceSlice {
+  path: string
+  content: string
+  truncated: boolean
+}
+
+interface AgentContext {
+  schemaVersion: 1
+  package: '@microsoft/agents-hosting-extensions-msteams'
+  dependency: '@microsoft/teams.api'
+  authoritativeArtifacts: {
+    findings: unknown
+    usageManifest: unknown
+    capabilitiesYaml: string
+    deterministicReport: string
+    testSummary?: unknown
+    publicApiReport?: unknown
+  }
+  relevantSourceFiles: SourceSlice[]
+  omittedSourceFiles: string[]
+}
+
+interface Settings {
+  findings: string
+  usageManifest: string
+  capabilities: string
+  deterministicReport: string
+  testSummary?: string
+  publicApiReport?: string
+  output: string
+  help: boolean
+}
+
+const help = `Usage:
+  npm run prepare:teams-api-agent-report -- [--findings <file>] [--usage-manifest <file>] [--capabilities <file>] [--deterministic-report <file>] [--test-summary <file>] [--public-api-report <file>] [--output <file-or-directory>]
+
+Builds the bounded context for an external AI report. Only source files named by
+actionable findings under ${packageRoot}/src are included; no environment or
+repository-wide content is collected.
+`
+
+function parseSettings (args: string[]): Settings {
+  const settings: Settings = {
+    findings: join(defaultArtifactDirectory, 'findings.json'),
+    usageManifest: join(packageRoot, 'teams-api-usage-manifest.json'),
+    capabilities: join(packageRoot, 'config/teams-capabilities.yaml'),
+    deterministicReport: join(defaultArtifactDirectory, 'deterministic-report.md'),
+    output: join(defaultArtifactDirectory, 'agent-context.json'),
+    help: false
+  }
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { ...settings, help: true }
+    if (argument === '--findings' || argument === '--usage-manifest' || argument === '--capabilities' || argument === '--deterministic-report' || argument === '--test-summary' || argument === '--public-api-report' || argument === '--output' || argument === '-o') {
+      const value = args[++index]
+      if (!value) throw new Error(`${argument} requires a file path.`)
+      if (argument === '--findings') settings.findings = value
+      else if (argument === '--usage-manifest') settings.usageManifest = value
+      else if (argument === '--capabilities') settings.capabilities = value
+      else if (argument === '--deterministic-report') settings.deterministicReport = value
+      else if (argument === '--test-summary') settings.testSummary = value
+      else if (argument === '--public-api-report') settings.publicApiReport = value
+      else settings.output = value
+      continue
+    }
+    throw new Error(`Unknown option: ${argument}`)
+  }
+  return settings
+}
+
+function readText (filePath: string): string {
+  const fullPath = resolve(filePath)
+  if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`)
+  return readFileSync(fullPath, 'utf8')
+}
+
+function readJson (filePath: string): unknown {
+  return JSON.parse(readText(filePath))
+}
+
+function redactSource (content: string): string {
+  return content
+    .replace(/(authorization\s*[:=]\s*['"`]?)(?:bearer\s+)?[^'"`\s,}]+/gi, '$1[REDACTED]')
+    .replace(/((?:clientSecret|apiKey|password|token)\s*[:=]\s*['"`])[^'"`]+/gi, '$1[REDACTED]')
+}
+
+export function selectRelevantSourceFiles (findings: FindingsResult, sourceRoot: string = packageRoot): { sourceFiles: SourceSlice[], omittedFiles: string[] } {
+  const packageSourceRoot = resolve(sourceRoot, 'src')
+  const selectedPaths = [...new Set(findings.findings
+    .filter(finding => finding.classification !== 'no-action')
+    .flatMap(finding => finding.affectedFiles)
+    .filter(path => path.replace(/\\/g, '/').startsWith('src/')))].sort()
+  const sourceFiles: SourceSlice[] = []
+  const omittedFiles: string[] = []
+
+  for (const sourcePath of selectedPaths) {
+    const fullPath = resolve(sourceRoot, sourcePath)
+    const containedPath = relative(packageSourceRoot, fullPath)
+    if (containedPath.startsWith('..') || !existsSync(fullPath)) {
+      omittedFiles.push(sourcePath)
+      continue
+    }
+    const content = redactSource(readFileSync(fullPath, 'utf8'))
+    const maximumLength = 12000
+    sourceFiles.push({
+      path: sourcePath.replace(/\\/g, '/'),
+      content: content.slice(0, maximumLength),
+      truncated: content.length > maximumLength
+    })
+  }
+
+  return { sourceFiles, omittedFiles }
+}
+
+function outputPathFor (destination: string): string {
+  const fullPath = resolve(destination)
+  return extname(fullPath).toLowerCase() === '.json' ? fullPath : join(fullPath, 'agent-context.json')
+}
+
+function main (): void {
+  const settings = parseSettings(process.argv.slice(2))
+  if (settings.help) {
+    console.log(help)
+    return
+  }
+
+  const findings = readJson(settings.findings) as FindingsResult
+  if (findings.schemaVersion !== 1 || findings.dependency !== '@microsoft/teams.api') {
+    throw new Error('Findings must be a schemaVersion 1 result for @microsoft/teams.api.')
+  }
+  const selected = selectRelevantSourceFiles(findings)
+  const context: AgentContext = {
+    schemaVersion: 1,
+    package: '@microsoft/agents-hosting-extensions-msteams',
+    dependency: '@microsoft/teams.api',
+    authoritativeArtifacts: {
+      findings,
+      usageManifest: readJson(settings.usageManifest),
+      capabilitiesYaml: readText(settings.capabilities),
+      deterministicReport: readText(settings.deterministicReport),
+      ...(settings.testSummary && { testSummary: readJson(settings.testSummary) }),
+      ...(settings.publicApiReport && { publicApiReport: readJson(settings.publicApiReport) })
+    },
+    relevantSourceFiles: selected.sourceFiles,
+    omittedSourceFiles: selected.omittedFiles
+  }
+  const outputPath = outputPathFor(settings.output)
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, `${JSON.stringify(context, undefined, 2)}\n`)
+  console.log(`Wrote agent context to ${relative(process.cwd(), outputPath) || basename(outputPath)} (${context.relevantSourceFiles.length} source file(s)).`)
+}
+
+main()

--- a/scripts/teams-api-drift/prepare-teams-api-agent-context.ts
+++ b/scripts/teams-api-drift/prepare-teams-api-agent-context.ts
@@ -4,6 +4,7 @@
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const packageRoot = 'packages/agents-hosting-extensions-msteams'
 const defaultArtifactDirectory = 'artifacts/teams-api-drift'
@@ -173,4 +174,5 @@ function main (): void {
   console.log(`Wrote agent context to ${relative(process.cwd(), outputPath) || basename(outputPath)} (${context.relevantSourceFiles.length} source file(s)).`)
 }
 
-main()
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined
+if (invokedPath === fileURLToPath(import.meta.url)) main()

--- a/scripts/teams-api-drift/render-teams-api-drift-report.ts
+++ b/scripts/teams-api-drift/render-teams-api-drift-report.ts
@@ -123,7 +123,7 @@ function outputPathFor (destination: string): string {
 }
 
 function markdownCell (value: string): string {
-  return value.replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' ')
+  return value.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' ')
 }
 
 function displayPath (path: string): string {

--- a/scripts/teams-api-drift/render-teams-api-drift-report.ts
+++ b/scripts/teams-api-drift/render-teams-api-drift-report.ts
@@ -1,0 +1,307 @@
+/**
+ * Renders a deterministic Markdown report from classified drift findings and check outcomes.
+ * The report is the human-readable companion to the JSON artifacts emitted by earlier stages.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dependency = '@microsoft/teams.api'
+const defaultArtifactDirectory = 'artifacts/teams-api-drift'
+const defaultFindingsPath = join(defaultArtifactDirectory, 'findings.json')
+const defaultOutputPath = join(defaultArtifactDirectory, 'deterministic-report.md')
+
+type Classification = 'blocking' | 'required' | 'review' | 'no-action'
+
+export interface Finding {
+  id: string
+  source: 'api-diff' | 'public-api'
+  classification: Classification
+  category?: 'feature-review' | 'internal-opportunity' | 'maintainer-decision'
+  kind: string
+  upstreamSymbol: string
+  member?: string
+  capability?: string
+  usageKinds: string[]
+  exposure: string
+  affectedFiles: string[]
+  before?: string
+  after?: string
+  evidence: string[]
+  recommendedAction: string
+}
+
+interface PublicApiTypeLeak {
+  upstreamSymbol: string
+  importKind: 'type-only' | 'runtime'
+  publicExports: string[]
+}
+
+interface PublicApiSummary {
+  status: 'unchanged' | 'changed'
+  releaseDecision: 'patch' | 'minor' | 'major' | 'maintainer-review'
+  baseline: string
+  entrypoint: string
+  upstreamTypeLeaks: PublicApiTypeLeak[]
+}
+
+export interface FindingsResult {
+  schemaVersion: 1
+  dependency: string
+  fromVersion: string
+  toVersion: string
+  summary: Record<Classification, number>
+  checks?: Record<string, string>
+  publicApi?: PublicApiSummary
+  findings: Finding[]
+}
+
+interface TestSummary {
+  checks?: Record<string, string>
+  build?: string
+  contractTests?: string
+  boundaryTests?: string
+  publicApiCheck?: string
+}
+
+interface RenderContext {
+  findingsPath: string
+  outputPath: string
+  artifactPaths: string[]
+  checks: Record<string, string>
+}
+
+interface Settings {
+  findings: string
+  output: string
+  testSummary?: string
+  help: boolean
+}
+
+const help = `Usage:
+  npm run render:teams-api-drift-report -- [--findings <file>] [--test-summary <file>] [--output <file-or-directory>]
+
+Renders a deterministic Markdown report from Stage 4 findings. It does not call
+an AI service and only links to local artifacts that already exist.
+
+Defaults:
+  findings: ${defaultFindingsPath}
+  output:   ${defaultOutputPath}
+
+Examples:
+  npm run render:teams-api-drift-report
+  npm run render:teams-api-drift-report -- --findings artifacts/teams-api-drift/findings.json --test-summary artifacts/teams-api-drift/test-summary.json
+`
+
+function parseSettings (args: string[]): Settings {
+  const settings: Settings = { findings: defaultFindingsPath, output: defaultOutputPath, help: false }
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { ...settings, help: true }
+    if (argument === '--findings' || argument === '-f' || argument === '--test-summary' || argument === '--output' || argument === '-o') {
+      const value = args[++index]
+      if (!value) throw new Error(`${argument} requires a file path.`)
+      if (argument === '--findings' || argument === '-f') settings.findings = value
+      else if (argument === '--test-summary') settings.testSummary = value
+      else settings.output = value
+      continue
+    }
+    throw new Error(`Unknown option: ${argument}`)
+  }
+  return settings
+}
+
+function readJson<T> (filePath: string): T {
+  const fullPath = resolve(filePath)
+  if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`)
+  return JSON.parse(readFileSync(fullPath, 'utf8')) as T
+}
+
+function outputPathFor (destination: string): string {
+  const fullPath = resolve(destination)
+  return extname(fullPath).toLowerCase() === '.md' ? fullPath : join(fullPath, 'deterministic-report.md')
+}
+
+function markdownCell (value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' ')
+}
+
+function displayPath (path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+function artifactLink (path: string, outputPath: string): string {
+  const target = relative(dirname(outputPath), resolve(path)) || basename(path)
+  return `[${basename(path)}](${displayPath(target)})`
+}
+
+function sortedFindings (findings: Finding[]): Finding[] {
+  return [...findings].sort((left, right) => {
+    const capability = (left.capability ?? 'Unmapped').localeCompare(right.capability ?? 'Unmapped')
+    return capability !== 0 ? capability : left.id.localeCompare(right.id)
+  })
+}
+
+function renderFindings (findings: Finding[], emptyMessage: string): string[] {
+  if (findings.length === 0) return [emptyMessage]
+  const groups = new Map<string, Finding[]>()
+  for (const finding of sortedFindings(findings)) {
+    const capability = finding.capability ?? 'Unmapped'
+    groups.set(capability, [...(groups.get(capability) ?? []), finding])
+  }
+
+  const lines: string[] = []
+  for (const [capability, groupedFindings] of [...groups].sort(([left], [right]) => left.localeCompare(right))) {
+    lines.push(`### ${capability}`)
+    lines.push('')
+    for (const finding of groupedFindings) {
+      const symbol = `${finding.upstreamSymbol}${finding.member ? `.${finding.member}` : ''}`
+      const files = finding.affectedFiles.length > 0 ? finding.affectedFiles.map(displayPath).join(', ') : 'No direct source file'
+      lines.push(`- **${finding.id}** — \`${symbol}\` (${finding.kind}; ${finding.exposure}). ${finding.recommendedAction}`)
+      lines.push(`  - Files: ${files}`)
+      lines.push(`  - Evidence: ${finding.evidence.join(', ') || 'None recorded'}`)
+    }
+    lines.push('')
+  }
+  return lines
+}
+
+function checkEntries (checks: Record<string, string>): [string, string][] {
+  return Object.entries(checks).sort(([left], [right]) => left.localeCompare(right))
+}
+
+function getSectionFindings (findings: Finding[], section: 'blocking' | 'required' | 'feature-review' | 'internal-opportunity' | 'maintainer-decision' | 'no-action'): Finding[] {
+  if (section === 'feature-review') return findings.filter(finding => finding.category === 'feature-review')
+  if (section === 'internal-opportunity') return findings.filter(finding => finding.category === 'internal-opportunity')
+  if (section === 'maintainer-decision') return findings.filter(finding => finding.category === 'maintainer-decision' || (finding.classification === 'review' && !finding.category))
+  return findings.filter(finding => finding.classification === section)
+}
+
+function summaryLine (summary: Record<Classification, number>): string {
+  return `**${summary.blocking} blocking**, **${summary.required} required**, **${summary.review} review**, and **${summary['no-action']} no-action** finding(s).`
+}
+
+function suggestedChecklist (findings: FindingsResult): string[] {
+  const actionable = findings.findings.filter(finding => finding.classification !== 'no-action')
+  if (actionable.length === 0) return ['- [x] No direct compatibility or public API work is required for this comparison.']
+  return actionable
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map(finding => `- [ ] **${finding.id}** — ${finding.recommendedAction}`)
+}
+
+export function renderDeterministicReport (findings: FindingsResult, context: RenderContext): string {
+  if (findings.schemaVersion !== 1) throw new Error('Findings must use schemaVersion 1.')
+  if (findings.dependency !== dependency) throw new Error(`Findings must describe ${dependency}.`)
+  const lines: string[] = [
+    '# teams.api Deterministic Impact Report',
+    '',
+    'This report is generated from deterministic artifacts only; it contains no AI-generated conclusions.',
+    '',
+    '## Executive summary',
+    '',
+    `Compared ${dependency} **${findings.fromVersion}** to **${findings.toVersion}** for \`@microsoft/agents-hosting-extensions-msteams\`.`,
+    '',
+    summaryLine(findings.summary),
+    '',
+    '## Compared versions',
+    '',
+    '| Dependency | Baseline | Candidate |',
+    '| --- | --- | --- |',
+    `| ${dependency} | ${findings.fromVersion} | ${findings.toVersion} |`,
+    '',
+    '## Build and test status',
+    ''
+  ]
+
+  const checks = checkEntries(context.checks)
+  if (checks.length === 0) lines.push('No build or test summary was supplied.')
+  else {
+    lines.push('| Check | Status |')
+    lines.push('| --- | --- |')
+    for (const [name, status] of checks) lines.push(`| ${markdownCell(name)} | ${markdownCell(status)} |`)
+  }
+
+  const sections: Array<[string, Parameters<typeof getSectionFindings>[1], string]> = [
+    ['Blocking compatibility issues', 'blocking', 'No blocking compatibility issues were detected.'],
+    ['Required adaptations', 'required', 'No required adaptations were detected.'],
+    ['Feature-review candidates', 'feature-review', 'No feature-review candidates were identified.'],
+    ['Internal implementation opportunities', 'internal-opportunity', 'No internal implementation opportunities were identified.'],
+    ['Maintainer decisions required', 'maintainer-decision', 'No maintainer decisions are required.'],
+    ['No-action upstream changes', 'no-action', 'No no-action upstream changes were recorded.']
+  ]
+  for (const [title, section, emptyMessage] of sections) {
+    lines.push('', `## ${title}`, '', ...renderFindings(getSectionFindings(findings.findings, section), emptyMessage))
+  }
+
+  lines.push('', '## Public API impact', '')
+  if (!findings.publicApi) lines.push('Public API impact was not evaluated. Run `check:teams-extension-public-api` and pass its report to the classifier.')
+  else {
+    lines.push(`Public API status: **${findings.publicApi.status}**. Suggested release decision: **${findings.publicApi.releaseDecision}**.`)
+    lines.push('')
+    if (findings.publicApi.upstreamTypeLeaks.length === 0) lines.push('No @microsoft/teams.api types leak through the public extension API.')
+    else {
+      lines.push('| Exposed upstream type | Import kind | Public extension exports |')
+      lines.push('| --- | --- | --- |')
+      for (const leak of findings.publicApi.upstreamTypeLeaks) {
+        lines.push(`| ${markdownCell(leak.upstreamSymbol)} | ${leak.importKind} | ${markdownCell(leak.publicExports.join(', '))} |`)
+      }
+    }
+  }
+
+  lines.push('', '## Evidence and artifact links', '')
+  lines.push(`- ${artifactLink(context.findingsPath, context.outputPath)} — classified findings.`)
+  for (const artifactPath of [...new Set(context.artifactPaths)].sort()) {
+    if (resolve(artifactPath) === resolve(context.findingsPath)) continue
+    lines.push(`- ${artifactLink(artifactPath, context.outputPath)}`)
+  }
+
+  lines.push('', '## Suggested checklist', '', ...suggestedChecklist(findings), '')
+  return lines.join('\n')
+}
+
+function collectChecks (findings: FindingsResult, testSummary?: TestSummary): Record<string, string> {
+  return {
+    ...(findings.checks ?? {}),
+    ...(testSummary?.checks ?? {}),
+    ...(testSummary?.build && { build: testSummary.build }),
+    ...(testSummary?.contractTests && { contractTests: testSummary.contractTests }),
+    ...(testSummary?.boundaryTests && { boundaryTests: testSummary.boundaryTests }),
+    ...(testSummary?.publicApiCheck && { publicApiCheck: testSummary.publicApiCheck })
+  }
+}
+
+function existingArtifacts (paths: Array<string | undefined>): string[] {
+  return paths.filter((path): path is string => path !== undefined && existsSync(resolve(path)))
+}
+
+function main (): void {
+  const settings = parseSettings(process.argv.slice(2))
+  if (settings.help) {
+    console.log(help)
+    return
+  }
+
+  const findings = readJson<FindingsResult>(settings.findings)
+  const testSummary = settings.testSummary ? readJson<TestSummary>(settings.testSummary) : undefined
+  const outputPath = outputPathFor(settings.output)
+  // Findings, raw API diff, and optional public API report are produced together.
+  // The report may be written elsewhere, so its output directory is not an artifact location.
+  const artifactDirectory = dirname(resolve(settings.findings))
+  const report = renderDeterministicReport(findings, {
+    findingsPath: settings.findings,
+    outputPath,
+    checks: collectChecks(findings, testSummary),
+    artifactPaths: existingArtifacts([
+      settings.testSummary,
+      join(artifactDirectory, 'raw-api-diff.json'),
+      join(artifactDirectory, 'public-api-report.json'),
+      'packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json'
+    ])
+  })
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, report)
+  console.log(`Wrote deterministic report to ${relative(process.cwd(), outputPath) || basename(outputPath)}`)
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined
+if (invokedPath === fileURLToPath(import.meta.url)) main()

--- a/scripts/teams-api-drift/render-teams-api-drift-report.ts
+++ b/scripts/teams-api-drift/render-teams-api-drift-report.ts
@@ -234,7 +234,7 @@ export function renderDeterministicReport (findings: FindingsResult, context: Re
   }
 
   lines.push('', '## Public API impact', '')
-  if (!findings.publicApi) lines.push('Public API impact was not evaluated. Run `check:teams-extension-public-api` and pass its report to the classifier.')
+  if (!findings.publicApi) lines.push('Public API impact was not evaluated. Re-run detect:teams-api-drifts with --public-api-report <file> to include it.')
   else {
     lines.push(`Public API status: **${findings.publicApi.status}**. Suggested release decision: **${findings.publicApi.releaseDecision}**.`)
     lines.push('')

--- a/scripts/teams-api-drift/teams-api-agent-report-prompt.md
+++ b/scripts/teams-api-drift/teams-api-agent-report-prompt.md
@@ -1,0 +1,61 @@
+# teams.api drift report task
+
+This prompt defines the bounded advisory report generated after deterministic drift analysis.
+It receives only the runtime context appended by the workflow and must not inspect repository state.
+
+Generate an advisory maintainer report from the runtime context appended to this
+prompt. The runtime context is the only authoritative input. Do not inspect the
+repository, invoke tools, invent findings, or infer changes that are not supported
+by the supplied artifacts and source slices.
+
+Return Markdown only. Do not wrap the report in a code fence or add a preamble.
+The first line must be exactly:
+
+# teams.api Impact Report
+
+Use each of these level-two headings exactly once and in this order:
+
+## Summary
+
+## Compatibility breaks
+
+## Required adaptations
+
+## Feature-review candidates
+
+## Internal implementation opportunities
+
+## Maintainer decisions
+
+## No action
+
+## Suggested implementation issues
+
+## Validation checklist
+
+Follow these rules:
+
+- Treat `authoritativeArtifacts.findings` as the source of truth for finding
+  identifiers, classifications, evidence, and affected files.
+- Mention every blocking and required finding by its exact finding ID.
+- Do not create finding IDs. Only use IDs present in the findings artifact.
+- Tie every bullet in an action-oriented section to a finding ID. If a section
+  has no supported items, write a bullet beginning with `- No `.
+- Use `Feature-review candidates` for review findings whose capability policy
+  identifies a potentially useful new public capability.
+- Use `Internal implementation opportunities` for review findings whose
+  capability policy identifies an additive API that could improve the
+  extension's internals without changing its public feature surface.
+- Use `Maintainer decisions` for other review findings that require a human
+  decision, including deprecations or ambiguous migrations.
+- Use `No action` for no-action findings.
+- Start the `Summary` section with this exact sentence: `This is an advisory report; it does not make or authorize implementation decisions.`
+- Label every recommendation with `Advisory:`. Do not claim that code was
+  changed, tests were run, or behavior was verified beyond what the supplied
+  artifacts report.
+- Distinguish deterministic evidence from interpretation and state uncertainty
+  when the context does not establish a migration path.
+- Suggested implementation issues must remain proposals, not automatically
+  created work items.
+
+The runtime context follows after this prompt under `## Runtime context`.

--- a/scripts/teams-api-drift/validate-teams-api-agent-report.ts
+++ b/scripts/teams-api-drift/validate-teams-api-agent-report.ts
@@ -122,7 +122,7 @@ export function validateAgentReport (report: string, findings: FindingsResult): 
   if (missingMandatoryFindingIds.length > 0) errors.push(`Missing blocking or required finding ID(s): ${missingMandatoryFindingIds.join(', ')}.`)
 
   for (const section of actionSections(report)) {
-    for (const line of section.split(/\r?\n/).filter(line => line.startsWith('- '))) {
+    for (const line of section.split(/\r?\n/).filter(line => /^[-*+] /.test(line))) {
       if (!/\b(?:TSAPI|EXTAPI)-[A-Za-z0-9-]+\b/.test(line) && !/^- No /i.test(line)) {
         errors.push(`Action item is not tied to a finding ID: ${line}`)
       }

--- a/scripts/teams-api-drift/validate-teams-api-agent-report.ts
+++ b/scripts/teams-api-drift/validate-teams-api-agent-report.ts
@@ -101,7 +101,13 @@ export function validateAgentReport (report: string, findings: FindingsResult): 
   for (const section of requiredSections) {
     if (!new RegExp(`^## ${section}$`, 'm').test(normalizedReport)) errors.push(`Missing required section: ${section}.`)
   }
-  if (!/\badvisory\b/i.test(report)) errors.push('Report must label recommendations as advisory.')
+  const requiredSummarySentence = 'This is an advisory report; it does not make or authorize implementation decisions.'
+  const summaryMatch = normalizedReport.match(/^## Summary\s*$(?:\n)([\s\S]*?)(?=\n## |\s*$)/m)
+  const summaryContent = summaryMatch?.[1] ?? ''
+  const firstSummaryLine = summaryContent.split('\n').map(line => line.trim()).find(line => line.length > 0)
+  if (firstSummaryLine !== requiredSummarySentence) {
+    errors.push(`Summary section must start with: "${requiredSummarySentence}".`)
+  }
 
   const knownIds = new Set(findings.findings.map(finding => finding.id))
   const referencedFindingIds = [...new Set(report.match(/\b(?:TSAPI|EXTAPI)-[A-Za-z0-9-]+\b/g) ?? [])].sort()

--- a/scripts/teams-api-drift/validate-teams-api-agent-report.ts
+++ b/scripts/teams-api-drift/validate-teams-api-agent-report.ts
@@ -1,0 +1,161 @@
+/**
+ * Validates an externally generated advisory report against deterministic findings.
+ * Rejects missing mandatory IDs, unknown IDs, malformed sections, and unattributed actions.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const defaultArtifactDirectory = 'artifacts/teams-api-drift'
+const requiredSections = [
+  'Summary',
+  'Compatibility breaks',
+  'Required adaptations',
+  'Feature-review candidates',
+  'Internal implementation opportunities',
+  'Maintainer decisions',
+  'No action',
+  'Suggested implementation issues',
+  'Validation checklist'
+]
+
+interface Finding {
+  id: string
+  classification: 'blocking' | 'required' | 'review' | 'no-action'
+}
+
+interface FindingsResult {
+  schemaVersion: 1
+  dependency: string
+  findings: Finding[]
+}
+
+export interface AgentReportValidation {
+  schemaVersion: 1
+  valid: boolean
+  referencedFindingIds: string[]
+  missingMandatoryFindingIds: string[]
+  unknownFindingIds: string[]
+  errors: string[]
+}
+
+interface Settings {
+  findings: string
+  report: string
+  output?: string
+  help: boolean
+}
+
+const help = `Usage:
+  npm run validate:teams-api-agent-report -- [--findings <file>] [--report <file>] [--output <file-or-directory>]
+
+Validates an externally generated agent report against deterministic findings.
+Blocking and required finding IDs must be present; unknown finding IDs and
+unattributed action bullets are rejected.
+`
+
+function parseSettings (args: string[]): Settings {
+  const settings: Settings = {
+    findings: join(defaultArtifactDirectory, 'findings.json'),
+    report: join(defaultArtifactDirectory, 'agent-report.md'),
+    help: false
+  }
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { ...settings, help: true }
+    if (argument === '--findings' || argument === '--report' || argument === '--output' || argument === '-o') {
+      const value = args[++index]
+      if (!value) throw new Error(`${argument} requires a file path.`)
+      if (argument === '--findings') settings.findings = value
+      else if (argument === '--report') settings.report = value
+      else settings.output = value
+      continue
+    }
+    throw new Error(`Unknown option: ${argument}`)
+  }
+  return settings
+}
+
+function readText (filePath: string): string {
+  const fullPath = resolve(filePath)
+  if (!existsSync(fullPath)) throw new Error(`File not found: ${fullPath}`)
+  return readFileSync(fullPath, 'utf8')
+}
+
+function actionSections (report: string): string[] {
+  const names = ['Compatibility breaks', 'Required adaptations', 'Feature-review candidates', 'Internal implementation opportunities', 'Maintainer decisions', 'Suggested implementation issues']
+  const normalized = report.replace(/\r\n/g, '\n')
+  return names.flatMap(name => {
+    const start = normalized.indexOf(`## ${name}\n`)
+    if (start < 0) return []
+    const contentStart = start + `## ${name}\n`.length
+    const nextHeading = normalized.indexOf('\n## ', contentStart)
+    return normalized.slice(contentStart, nextHeading < 0 ? undefined : nextHeading)
+  })
+}
+
+export function validateAgentReport (report: string, findings: FindingsResult): AgentReportValidation {
+  const errors: string[] = []
+  const normalizedReport = report.replace(/\r\n/g, '\n')
+  if (!normalizedReport.startsWith('# teams.api Impact Report\n')) errors.push('Report must start with "# teams.api Impact Report".')
+  for (const section of requiredSections) {
+    if (!new RegExp(`^## ${section}$`, 'm').test(normalizedReport)) errors.push(`Missing required section: ${section}.`)
+  }
+  if (!/\badvisory\b/i.test(report)) errors.push('Report must label recommendations as advisory.')
+
+  const knownIds = new Set(findings.findings.map(finding => finding.id))
+  const referencedFindingIds = [...new Set(report.match(/\b(?:TSAPI|EXTAPI)-[A-Za-z0-9-]+\b/g) ?? [])].sort()
+  const unknownFindingIds = referencedFindingIds.filter(id => !knownIds.has(id))
+  if (unknownFindingIds.length > 0) errors.push(`Unknown finding ID(s): ${unknownFindingIds.join(', ')}.`)
+
+  const missingMandatoryFindingIds = findings.findings
+    .filter(finding => finding.classification === 'blocking' || finding.classification === 'required')
+    .map(finding => finding.id)
+    .filter(id => !referencedFindingIds.includes(id))
+    .sort()
+  if (missingMandatoryFindingIds.length > 0) errors.push(`Missing blocking or required finding ID(s): ${missingMandatoryFindingIds.join(', ')}.`)
+
+  for (const section of actionSections(report)) {
+    for (const line of section.split(/\r?\n/).filter(line => line.startsWith('- '))) {
+      if (!/\b(?:TSAPI|EXTAPI)-[A-Za-z0-9-]+\b/.test(line) && !/^- No /i.test(line)) {
+        errors.push(`Action item is not tied to a finding ID: ${line}`)
+      }
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    valid: errors.length === 0,
+    referencedFindingIds,
+    missingMandatoryFindingIds,
+    unknownFindingIds,
+    errors
+  }
+}
+
+function outputPathFor (destination: string): string {
+  const fullPath = resolve(destination)
+  return extname(fullPath).toLowerCase() === '.json' ? fullPath : join(fullPath, 'agent-report-validation.json')
+}
+
+function main (): void {
+  const settings = parseSettings(process.argv.slice(2))
+  if (settings.help) {
+    console.log(help)
+    return
+  }
+  const findings = JSON.parse(readText(settings.findings)) as FindingsResult
+  if (findings.schemaVersion !== 1 || findings.dependency !== '@microsoft/teams.api') throw new Error('Findings must be a schemaVersion 1 result for @microsoft/teams.api.')
+  const validation = validateAgentReport(readText(settings.report), findings)
+  console.log(validation.valid ? 'Agent report validation passed.' : `Agent report validation failed: ${validation.errors.join(' ')}`)
+  if (settings.output) {
+    const outputPath = outputPathFor(settings.output)
+    mkdirSync(dirname(outputPath), { recursive: true })
+    writeFileSync(outputPath, `${JSON.stringify(validation, undefined, 2)}\n`)
+    console.log(`Wrote agent report validation to ${relative(process.cwd(), outputPath) || basename(outputPath)}`)
+  }
+  if (!validation.valid) process.exitCode = 1
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined
+if (invokedPath === fileURLToPath(import.meta.url)) main()

--- a/scripts/teams-api-drift/write-teams-api-test-summary.ts
+++ b/scripts/teams-api-drift/write-teams-api-test-summary.ts
@@ -1,0 +1,68 @@
+/**
+ * Records workflow build and verification outcomes in a deterministic JSON summary.
+ * The report renderer consumes this summary to show which compatibility checks completed.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { basename, dirname, extname, join, relative, resolve } from 'node:path'
+
+const defaultOutput = 'artifacts/teams-api-drift/test-summary.json'
+
+interface Settings {
+  output: string
+  checks: Record<string, string>
+  help: boolean
+}
+
+const help = `Usage:
+  npm run write:teams-api-test-summary -- [--build <status>] [--usage-collection <status>] [--api-extraction <status>] [--api-comparison <status>] [--contract-tests <status>] [--boundary-tests <status>] [--public-api-check <status>] [--output <file-or-directory>]
+
+Writes the deterministic build and test summary consumed by the drift report.
+`
+
+function parseSettings (args: string[]): Settings {
+  const settings: Settings = { output: defaultOutput, checks: {}, help: false }
+  const checkOptions: Record<string, string> = {
+    '--build': 'build',
+    '--usage-collection': 'usageCollection',
+    '--api-extraction': 'apiExtraction',
+    '--api-comparison': 'apiComparison',
+    '--contract-tests': 'contractTests',
+    '--boundary-tests': 'boundaryTests',
+    '--public-api-check': 'publicApiCheck'
+  }
+  for (let index = 0; index < args.length; index++) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { ...settings, help: true }
+    if (argument === '--output' || argument === '-o') {
+      const value = args[++index]
+      if (!value) throw new Error(`${argument} requires a file path.`)
+      settings.output = value
+      continue
+    }
+    const checkName = checkOptions[argument]
+    if (!checkName) throw new Error(`Unknown option: ${argument}`)
+    const status = args[++index]
+    if (!status) throw new Error(`${argument} requires a status.`)
+    settings.checks[checkName] = status
+  }
+  return settings
+}
+
+function outputPathFor (destination: string): string {
+  const fullPath = resolve(destination)
+  return extname(fullPath).toLowerCase() === '.json' ? fullPath : join(fullPath, 'test-summary.json')
+}
+
+function main (): void {
+  const settings = parseSettings(process.argv.slice(2))
+  if (settings.help) {
+    console.log(help)
+    return
+  }
+  const outputPath = outputPathFor(settings.output)
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, `${JSON.stringify({ schemaVersion: 1, checks: settings.checks }, undefined, 2)}\n`)
+  console.log(`Wrote test summary to ${relative(process.cwd(), outputPath) || basename(outputPath)}`)
+}
+
+main()


### PR DESCRIPTION
Addresses # 1191

> **NOTE: This PR depends on the new Teams extension PR # 1067**

## Description
This pull request introduces a comprehensive Teams API drift detection system for the `agents-hosting-extensions-msteams` package. The main focus is on automating compatibility checks when the `@microsoft/teams.api` dependency changes, improving visibility into API usage, and providing advisory reporting. The changes include a new GitHub Actions workflow, supporting scripts, configuration files, and updates to the package manifest.

### Detailed Changes

### Teams API Drift Detection Automation

* Added a new GitHub Actions workflow (`.github/workflows/teams-api-drift.yml`) that detects and analyzes changes to the `@microsoft/teams.api` dependency, runs compatibility checks, generates reports, and publishes results on pull requests.

### Tooling and Scripts

* Added several new npm scripts to `package.json` for comparing Teams API versions, detecting drifts, rendering reports, preparing agent context, validating reports, and contract testing.
* Introduced new dependencies required by the drift detection tooling, including `diff` and `yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R58) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L60-R69)

### Configuration and Usage Tracking

* Added a curated ownership and capabilities map (`packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml`) to classify new Teams API surface area, define adoption policies, and map source files to API areas.
* Included a usage manifest (`packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json`) that enumerates all upstream Teams API symbols consumed by the extension, their usage types, and source locations.

## Testing
These images show the workflow running and detecting differences, the AI generated report and the comment posted in the PR.
<img width="1754" height="914" alt="image" src="https://github.com/user-attachments/assets/5a0de79b-77ee-4ba2-b163-a06a938a9ec9" />

<img width="812" height="1050" alt="image" src="https://github.com/user-attachments/assets/67372d4f-2ef1-4c50-aa9c-10ec2649ee9a" />

<img width="1193" height="552" alt="image" src="https://github.com/user-attachments/assets/4ccf2bd0-7eb0-47d5-91c7-177d7a0b3ee0" />