### PR TITLE
[#1211] Add activity.name tag to AgentApplication instrumentation

### DIFF
--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -26,7 +26,8 @@ export const AgentApplicationTraceDefinitions = {
       span.setAttributes({
         'route.authorized': record.authorized,
         'route.matched': record.routeMatched,
-        ...attributes
+        ...attributes,
+        ...{ 'activity.name': activity.name ?? 'unknown' }
       })
 
       HostingMetrics.turnsTotalCounter.add(1, attributes)

--- a/packages/agents-hosting/test/hosting/observability/traces.test.ts
+++ b/packages/agents-hosting/test/hosting/observability/traces.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { Activity } from '@microsoft/agents-activity'
+import { AgentApplicationTraceDefinitions } from '../../../src/observability/traces'
+
+describe('AgentApplicationTraceDefinitions.run', () => {
+  it('should add a named activity to the turn span', () => {
+    const attributes = endRunTrace(Activity.fromObject({
+      type: 'event',
+      name: 'application/vnd.contoso.order',
+      channelId: 'msteams',
+    }))
+
+    assert.equal(attributes['activity.name'], 'application/vnd.contoso.order')
+  })
+
+  it('should omit activity.name when the activity has no name', () => {
+    const attributes = endRunTrace(Activity.fromObject({ type: 'message' }))
+
+    assert.equal(attributes['activity.name'], 'unknown')
+  })
+})
+
+function endRunTrace (activity: Activity): Record<string, unknown> {
+  let attributes: Record<string, unknown> = {}
+
+  AgentApplicationTraceDefinitions.run.end({
+    span: {
+      setAttributes: (values: Record<string, unknown>) => { attributes = values }
+    } as any,
+    record: {
+      authorized: true,
+      activity,
+      routeMatched: true,
+    },
+    duration: 0,
+  })
+
+  return attributes
+}

--- a/packages/agents-hosting/test/hosting/observability/traces.test.ts
+++ b/packages/agents-hosting/test/hosting/observability/traces.test.ts
@@ -17,7 +17,7 @@ describe('AgentApplicationTraceDefinitions.run', () => {
     assert.equal(attributes['activity.name'], 'application/vnd.contoso.order')
   })
 
-  it('should omit activity.name when the activity has no name', () => {
+  it('should set activity.name to unknown when the activity has no name', () => {
     const attributes = endRunTrace(Activity.fromObject({ type: 'message' }))
 
     assert.equal(attributes['activity.name'], 'unknown')


### PR DESCRIPTION
Fixes # 1211

## Description
This pull request enhances observability in the agent hosting platform by ensuring that the activity name is always included in trace attributes, even when the activity lacks a name. It also adds comprehensive tests to verify this behavior.

**Observability improvements:**

* Updated `AgentApplicationTraceDefinitions.run` to always include the `activity.name` attribute in trace spans, defaulting to `'unknown'` if the activity has no name.

**Testing:**

* Added a new test suite in `traces.test.ts` to verify that `activity.name` is set correctly in trace attributes, both when the activity has a name and when it does not.

## Testing
This image shows the activity.name attribute set in the _agent.app.run_ trace.
<img width="2406" height="1052" alt="image" src="https://github.com/user-attachments/assets/493e0fe2-11bc-4ff6-b4b5-f895f9a3ae1c" />
