### PR TITLE
Add Observability in agents-hosting-extensions-slack project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8301,7 +8301,8 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/agents-activity": "file:../agents-activity",
-        "@microsoft/agents-hosting": "file:../agents-hosting"
+        "@microsoft/agents-hosting": "file:../agents-hosting",
+        "@microsoft/agents-telemetry": "file:../agents-telemetry"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/agents-hosting-extensions-slack/package.json
+++ b/packages/agents-hosting-extensions-slack/package.json
@@ -20,7 +20,8 @@
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "@microsoft/agents-hosting": "file:../agents-hosting",
-    "@microsoft/agents-activity": "file:../agents-activity"
+    "@microsoft/agents-activity": "file:../agents-activity",
+    "@microsoft/agents-telemetry": "file:../agents-telemetry"
   },
   "license": "MIT",
   "files": [

--- a/packages/agents-hosting-extensions-slack/src/api/slackApi.ts
+++ b/packages/agents-hosting-extensions-slack/src/api/slackApi.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 import { ExceptionHelper } from '@microsoft/agents-activity'
+import { trace } from '@microsoft/agents-telemetry'
 import { Errors } from '../errorHelper.js'
+import { SlackTraceDefinitions } from '../observability/index.js'
 import type { SlackResponse } from './slackResponse.js'
 
 /**
@@ -37,34 +39,40 @@ export class SlackApi {
    * @throws When the HTTP request fails or the API returns `ok: false`.
    */
   async call (method: string, options?: Record<string, unknown>): Promise<SlackResponse> {
-    const body = options
-      ? JSON.stringify(options, (_key, value) => (value === null || value === undefined ? undefined : value))
-      : undefined
+    return trace(SlackTraceDefinitions.apiCall, async ({ record }) => {
+      record({ method })
 
-    let response: Response
-    try {
-      response = await fetch(`https://slack.com/api/${method}`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this._token}`,
-          'Content-Type': 'application/json',
-        },
-        body,
-      })
-    } catch (err) {
-      throw ExceptionHelper.generateException(Error, Errors.SlackApiHttpError, err instanceof Error ? err : undefined, { status: 'network error' })
-    }
+      const body = options
+        ? JSON.stringify(options, (_key, value) => (value === null || value === undefined ? undefined : value))
+        : undefined
 
-    if (!response.ok) {
-      throw ExceptionHelper.generateException(Error, Errors.SlackApiHttpError, undefined, { status: String(response.status) })
-    }
+      let response: Response
+      try {
+        response = await fetch(`https://slack.com/api/${method}`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this._token}`,
+            'Content-Type': 'application/json',
+          },
+          body,
+        })
+      } catch (err) {
+        throw ExceptionHelper.generateException(Error, Errors.SlackApiHttpError, err instanceof Error ? err : undefined, { status: 'network error' })
+      }
 
-    const data = await response.json() as SlackResponse
+      record({ httpStatusCode: String(response.status) })
+      if (!response.ok) {
+        throw ExceptionHelper.generateException(Error, Errors.SlackApiHttpError, undefined, { status: String(response.status) })
+      }
 
-    if (!data.ok) {
-      throw ExceptionHelper.generateException(Error, Errors.SlackApiError, undefined, { error: data.error ?? 'unknown' })
-    }
+      const data = await response.json() as SlackResponse
 
-    return data
+      if (!data.ok) {
+        record({ slackErrorCode: data.error ?? 'unknown' })
+        throw ExceptionHelper.generateException(Error, Errors.SlackApiError, undefined, { error: data.error ?? 'unknown' })
+      }
+
+      return data
+    })
   }
 }

--- a/packages/agents-hosting-extensions-slack/src/observability/index.ts
+++ b/packages/agents-hosting-extensions-slack/src/observability/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export * from './metrics.js'
+export * from './traces.js'

--- a/packages/agents-hosting-extensions-slack/src/observability/metrics.ts
+++ b/packages/agents-hosting-extensions-slack/src/observability/metrics.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { metric, MetricNames } from '@microsoft/agents-telemetry'
+
+export const SlackMetrics = {
+  apiRequestsCounter: metric.counter(MetricNames.SLACK_API_REQUESTS, {
+    unit: 'request',
+    description: 'Total number of outbound Slack Web API requests'
+  }),
+
+  apiRequestDuration: metric.histogram(MetricNames.SLACK_API_REQUEST_DURATION, {
+    unit: 'ms',
+    description: 'Duration of outbound Slack Web API requests in milliseconds'
+  })
+}

--- a/packages/agents-hosting-extensions-slack/src/observability/traces.ts
+++ b/packages/agents-hosting-extensions-slack/src/observability/traces.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { SpanNames, trace } from '@microsoft/agents-telemetry'
+import { SlackMetrics } from './metrics.js'
+
+export const SlackTraceDefinitions = {
+  apiCall: trace.define({
+    name: SpanNames.SLACK_API_CALL,
+    record: {
+      method: '',
+      httpStatusCode: 'unknown',
+      slackErrorCode: '',
+    },
+    end ({ span, record, duration, error }) {
+      const attributes = {
+        'slack.api.method': record.method || 'unknown',
+        'http.method': 'POST',
+        'http.status_code': record.httpStatusCode,
+      }
+
+      span.setAttributes({
+        ...attributes,
+        'server.address': 'slack.com',
+      })
+
+      if (record.slackErrorCode) {
+        span.setAttribute('slack.api.error_code', record.slackErrorCode)
+      }
+
+      const metricAttributes = {
+        ...attributes,
+        'operation.success': error === undefined,
+      }
+
+      SlackMetrics.apiRequestsCounter.add(1, metricAttributes)
+      SlackMetrics.apiRequestDuration.record(duration, metricAttributes)
+    }
+  })
+}

--- a/packages/agents-telemetry/src/observability/constants.ts
+++ b/packages/agents-telemetry/src/observability/constants.ts
@@ -112,6 +112,9 @@ export const SpanNames = {
   NAMED_PIPE_CONNECT: 'agents.named_pipe.connect',
   NAMED_PIPE_DISPATCH: 'agents.named_pipe.dispatch',
   NAMED_PIPE_SEND: 'agents.named_pipe.send',
+
+  // Slack
+  SLACK_API_CALL: 'agents.slack.api.call',
 } as const
 
 /**
@@ -179,4 +182,8 @@ export const MetricNames = {
   NAMED_PIPE_DISPATCH_ERRORS: 'agents.named_pipe.dispatch.error.count',
   NAMED_PIPE_SENDS: 'agents.named_pipe.send.count',
   NAMED_PIPE_SEND_DURATION: 'agents.named_pipe.send.duration',
+
+  // Slack
+  SLACK_API_REQUESTS: 'agents.slack.api.request.count',
+  SLACK_API_REQUEST_DURATION: 'agents.slack.api.request.duration',
 } as const


### PR DESCRIPTION
Fixes # 1216

## Description

Adds OpenTelemetry instrumentation for outbound Slack Web API calls in _agents-hosting-extensions-slack_.

_SlackApi.call_ now emits an _agents.slack.api.call_ span for each Slack API request. The span records the API method, HTTP status, Slack host, and Slack API error code when applicable. It captures failures through the shared telemetry error handling without exposing tokens, request payloads, or conversation identifiers.

Adds Slack request-count and request-duration metrics, labelled by API method, HTTP status, and operation success. Stable Slack span and metric names were added to _agents-telemetry_.

## Testing
The following image shows the slack-agent sample working correctly with OTel.
<img width="2014" height="1477" alt="image" src="https://github.com/user-attachments/assets/b8d9ce07-0e85-4aee-a585-f17cb9ad8a91" />