### PR TITLE
Add observability unit tests - Copilot Studio Client

### DIFF
--- a/packages/agents-copilotstudio-client/test/copilotStudioClient.test.ts
+++ b/packages/agents-copilotstudio-client/test/copilotStudioClient.test.ts
@@ -1525,7 +1525,7 @@ describe('UserAgentHelper', function () {
 
   it('should include platform info in Node.js', function () {
     const productInfo = UserAgentHelper.getProductInfo()
-    if (typeof window === 'undefined') {
+    if (!('window' in globalThis)) {
       assert(productInfo.includes('nodejs/'))
     }
   })
@@ -1704,7 +1704,7 @@ describe('subscribeAsync', function () {
 
     const conversationId = 'test-conversation-id'
 
-    const fetchMock = mock.fn(() => Promise.resolve(mockSubscribeFetchResponse([])))
+    const fetchMock = mock.fn((url: string | URL | Request) => Promise.resolve(mockSubscribeFetchResponse([])))
     global.fetch = fetchMock as any
 
     const events: SubscribeEvent[] = []
@@ -1731,7 +1731,8 @@ describe('subscribeAsync', function () {
 
     // Verify that the fetch was called with a URL ending in /subscribe
     assert(fetchMock.mock.calls.length > 0)
-    const callUrl = fetchMock.mock.calls[0].arguments[0]
-    assert(callUrl.includes('/subscribe'), `URL should contain /subscribe: ${callUrl}`)
+    const calls = fetchMock.mock.calls as unknown as Array<{ arguments: [string | URL | Request] }>
+    const callUrl = calls[0]?.arguments[0]
+    assert(String(callUrl).includes('/subscribe'), `URL should contain /subscribe: ${String(callUrl)}`)
   })
 })

--- a/packages/agents-copilotstudio-client/test/copilotStudioClient.test.ts
+++ b/packages/agents-copilotstudio-client/test/copilotStudioClient.test.ts
@@ -14,78 +14,42 @@ import {
 import { Activity, ActivityTypes } from '@microsoft/agents-activity'
 
 describe('scopeFromSettings', function () {
-  const testCases: Array<{
-    label: string
-    cloud: PowerPlatformCloud
-    cloudBaseAddress: string
-    expectedAuthority: string
-    shouldthrow: boolean
-  }> = [
-    {
-      label: 'Should return scope for PowerPlatformCloud.Prod environment',
-      cloud: PowerPlatformCloud.Prod,
-      cloudBaseAddress: '',
-      expectedAuthority: 'https://api.powerplatform.com/.default',
-      shouldthrow: false
-    },
-    {
-      label: 'Should return scope for PowerPlatformCloud.Preprod environment',
-      cloud: PowerPlatformCloud.Preprod,
-      cloudBaseAddress: '',
-      expectedAuthority: 'https://api.preprod.powerplatform.com/.default',
-      shouldthrow: false
-    },
-    {
-      label: 'Should return scope for PowerPlatformCloud.Mooncake environment',
-      cloud: PowerPlatformCloud.Mooncake,
-      cloudBaseAddress: '',
-      expectedAuthority: 'https://api.powerplatform.partner.microsoftonline.cn/.default',
-      shouldthrow: false
-    },
-    {
-      label: 'Should return scope for PowerPlatformCloud.FirstRelease environment',
-      cloud: PowerPlatformCloud.FirstRelease,
-      cloudBaseAddress: '',
-      expectedAuthority: 'https://api.powerplatform.com/.default',
-      shouldthrow: false
-    },
-    {
-      label: 'Should return scope for PowerPlatformCloud.Other environment',
-      cloud: PowerPlatformCloud.Other,
-      cloudBaseAddress: 'fido.com',
-      expectedAuthority: 'https://fido.com/.default',
-      shouldthrow: false
-    },
-    {
-      label: 'Should throw when cloud is Unknown and no cloudBaseAddress is provided',
-      cloud: PowerPlatformCloud.Unknown,
-      cloudBaseAddress: '',
-      expectedAuthority: '',
-      shouldthrow: true
+  function createSettings (cloud: PowerPlatformCloud, cloudBaseAddress = ''): ConnectionSettings {
+    return {
+      appClientId: '123',
+      tenantId: 'test-tenant',
+      environmentId: 'A47151CF-4F34-488F-B377-EBE84E17B478',
+      cloud,
+      agentIdentifier: 'Bot01',
+      copilotAgentType: AgentType.Published,
+      customPowerPlatformCloud: cloudBaseAddress
     }
-  ]
+  }
 
-  testCases.forEach((testCase) => {
-    it(testCase.label, function () {
-      const settings: ConnectionSettings = {
-        appClientId: '123',
-        tenantId: 'test-tenant',
-        environmentId: 'A47151CF-4F34-488F-B377-EBE84E17B478',
-        cloud: testCase.cloud,
-        agentIdentifier: 'Bot01',
-        copilotAgentType: AgentType.Published,
-        customPowerPlatformCloud: testCase.cloudBaseAddress
-      }
+  it('should return scope for PowerPlatformCloud.Prod environment', function () {
+    assert.equal(CopilotStudioClient.scopeFromSettings(createSettings(PowerPlatformCloud.Prod)), 'https://api.powerplatform.com/.default')
+  })
 
-      if (testCase.shouldthrow) {
-        assert.throws(() => {
-          CopilotStudioClient.scopeFromSettings(settings)
-        }, Error)
-      } else {
-        const scope = CopilotStudioClient.scopeFromSettings(settings)
-        assert(scope === testCase.expectedAuthority)
-      }
-    })
+  it('should return scope for PowerPlatformCloud.Preprod environment', function () {
+    assert.equal(CopilotStudioClient.scopeFromSettings(createSettings(PowerPlatformCloud.Preprod)), 'https://api.preprod.powerplatform.com/.default')
+  })
+
+  it('should return scope for PowerPlatformCloud.Mooncake environment', function () {
+    assert.equal(CopilotStudioClient.scopeFromSettings(createSettings(PowerPlatformCloud.Mooncake)), 'https://api.powerplatform.partner.microsoftonline.cn/.default')
+  })
+
+  it('should return scope for PowerPlatformCloud.FirstRelease environment', function () {
+    assert.equal(CopilotStudioClient.scopeFromSettings(createSettings(PowerPlatformCloud.FirstRelease)), 'https://api.powerplatform.com/.default')
+  })
+
+  it('should return scope for PowerPlatformCloud.Other environment', function () {
+    assert.equal(CopilotStudioClient.scopeFromSettings(createSettings(PowerPlatformCloud.Other, 'fido.com')), 'https://fido.com/.default')
+  })
+
+  it('should throw when cloud is Unknown and no cloudBaseAddress is provided', function () {
+    assert.throws(() => {
+      CopilotStudioClient.scopeFromSettings(createSettings(PowerPlatformCloud.Unknown))
+    }, Error)
   })
 })
 

--- a/packages/agents-copilotstudio-client/test/observability/traces.test.ts
+++ b/packages/agents-copilotstudio-client/test/observability/traces.test.ts
@@ -1,0 +1,311 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { strict as assert } from 'assert'
+import { afterEach, describe, it } from 'node:test'
+import type { Span, TraceDefinition } from '@microsoft/agents-telemetry'
+import { Activity } from '@microsoft/agents-activity'
+import * as sinon from 'sinon'
+import { CopilotStudioClientMetrics } from '../../src/observability/metrics'
+import { CopilotStudioClientTraceDefinitions } from '../../src/observability/traces'
+import type { SubscribeEvent } from '../../src/subscribeEvent'
+
+const duration = 123
+
+interface TestSpan {
+  attributes: Record<string, unknown>
+  events: Array<{ name: string, attributes: Record<string, unknown> }>
+  setAttribute(name: string, value: unknown): void
+  setAttributes(values: Record<string, unknown>): void
+  addEvent(name: string, attributes: Record<string, unknown>): void
+}
+
+function createSpan (): TestSpan {
+  const attributes: Record<string, unknown> = {}
+  const events: Array<{ name: string, attributes: Record<string, unknown> }> = []
+
+  return {
+    attributes,
+    events,
+    setAttribute (name, value) {
+      attributes[name] = value
+    },
+    setAttributes (values) {
+      Object.assign(attributes, values)
+    },
+    addEvent (name, values) {
+      events.push({ name, attributes: values })
+    },
+  }
+}
+
+function endTrace<TRecord extends object> (
+  definition: TraceDefinition<TRecord>,
+  record: TRecord,
+  error?: unknown
+): TestSpan {
+  const span = createSpan()
+  definition.end({ span: span as unknown as Span, record, duration, error })
+  return span
+}
+
+function endTraceWithIncompleteRecord<TRecord extends object> (
+  definition: TraceDefinition<TRecord>,
+  record: Record<string, unknown>
+): TestSpan {
+  const span = createSpan()
+  definition.end({ span: span as unknown as Span, record: record as TRecord, duration })
+  return span
+}
+
+function assertMetric (metric: sinon.SinonStub, value: number, attributes: Record<string, unknown>) {
+  sinon.assert.calledOnceWithExactly(metric, value, attributes)
+}
+
+describe('Copilot Studio client trace definitions', () => {
+  afterEach(() => sinon.restore())
+
+  it('records web chat connection attributes, metrics, and activity events', () => {
+    const connections = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'webchatConnectionsCounter').value({ add: connections })
+    const span = createSpan()
+    const actions = CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: span as unknown as Span })
+    const activity = Activity.fromObject({ type: 'message', conversation: { id: 'conversation-id' } })
+
+    actions.receivedFromCopilot(activity)
+    actions.sentToWebChat(activity)
+    const endedSpan = endTrace(CopilotStudioClientTraceDefinitions.createConnection, { showTyping: true })
+
+    assert.deepEqual(span.events, [
+      { name: 'activity.received.from.copilot.studio', attributes: { 'copilot.webchat.activity.type': 'message', 'copilot.webchat.activity.conversation_id': 'conversation-id' } },
+      { name: 'activity.sent.to.webchat', attributes: { 'copilot.webchat.activity.type': 'message', 'copilot.webchat.activity.conversation_id': 'conversation-id' } },
+    ])
+    assert.deepEqual(endedSpan.attributes, { 'copilot.webchat.show_typing': true })
+    assertMetric(connections, 1, { 'copilot.webchat.show_typing': true })
+  })
+
+  it('records post request attributes, received activities, metrics, and errors', () => {
+    const received = sinon.stub()
+    const requests = sinon.stub()
+    const requestErrors = sinon.stub()
+    const streamDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'activitiesReceivedCounter').value({ add: received })
+    sinon.stub(CopilotStudioClientMetrics, 'requestsCounter').value({ add: requests })
+    sinon.stub(CopilotStudioClientMetrics, 'requestsErrorCounter').value({ add: requestErrors })
+    sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
+    const span = createSpan()
+    const actions = CopilotStudioClientTraceDefinitions.postRequest.actions!({ span: span as unknown as Span })
+    actions.receivedFromCopilot(Activity.fromObject({ type: 'message', conversation: { id: 'conversation-id' } }))
+
+    const endedSpan = endTrace(CopilotStudioClientTraceDefinitions.postRequest, {
+      url: 'https://copilot.example.com', method: 'POST'
+    }, new TypeError('request failed'))
+    const metricAttributes = {
+      operation: 'postRequestAsync',
+      'copilot.post_request.url': 'https://copilot.example.com',
+      'copilot.post_request.method': 'POST',
+    }
+
+    assert.deepEqual(span.events, [{ name: 'activity.received', attributes: { 'copilot.post_request.activity.type': 'message', 'copilot.post_request.activity.conversation_id': 'conversation-id' } }])
+    assertMetric(received, 1, { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'conversation-id' })
+    assert.deepEqual(endedSpan.attributes, { 'copilot.post_request.url': 'https://copilot.example.com', 'copilot.post_request.method': 'POST' })
+    assertMetric(requests, 1, metricAttributes)
+    assertMetric(streamDuration, duration, metricAttributes)
+    assertMetric(requestErrors, 1, { ...metricAttributes, 'error.type': 'TypeError' })
+  })
+
+  it('does not record request errors on success and classifies non-Error failures', () => {
+    const requests = sinon.stub()
+    const requestErrors = sinon.stub()
+    const streamDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'requestsCounter').value({ add: requests })
+    sinon.stub(CopilotStudioClientMetrics, 'requestsErrorCounter').value({ add: requestErrors })
+    sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
+    const successAttributes = { operation: 'postRequestAsync', 'copilot.post_request.url': 'https://copilot.example.com', 'copilot.post_request.method': 'GET' }
+
+    endTrace(CopilotStudioClientTraceDefinitions.postRequest, { url: 'https://copilot.example.com', method: 'GET' })
+    sinon.assert.notCalled(requestErrors)
+
+    endTrace(CopilotStudioClientTraceDefinitions.postRequest, { url: 'https://copilot.example.com', method: 'GET' }, 'request failed')
+    sinon.assert.calledTwice(requests)
+    sinon.assert.calledTwice(streamDuration)
+    assertMetric(requestErrors, 1, { ...successAttributes, 'error.type': 'string' })
+  })
+
+  it('records start conversation attributes and metrics for both request modes', () => {
+    const started = sinon.stub()
+    const requestDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'conversationsStartedCounter').value({ add: started })
+    sinon.stub(CopilotStudioClientMetrics, 'requestDuration').value({ record: requestDuration })
+
+    const emitStartSpan = endTrace(CopilotStudioClientTraceDefinitions.startConversation, { shouldEmitStartEvent: true })
+    const requestSpan = endTrace(CopilotStudioClientTraceDefinitions.startConversation, { shouldEmitStartEvent: false })
+
+    assert.deepEqual(emitStartSpan.attributes, { 'copilot.emit_start_event': true })
+    assert.deepEqual(requestSpan.attributes, { 'copilot.request': true })
+    sinon.assert.calledWithExactly(started, 1, { operation: 'startConversationStreaming', 'copilot.emit_start_event': true })
+    sinon.assert.calledWithExactly(started, 1, { operation: 'startConversationStreaming', 'copilot.request': true })
+    sinon.assert.calledWithExactly(requestDuration, duration, { operation: 'startConversationStreaming', 'copilot.emit_start_event': true })
+    sinon.assert.calledWithExactly(requestDuration, duration, { operation: 'startConversationStreaming', 'copilot.request': true })
+  })
+
+  it('records send activity attributes and metrics', () => {
+    const sent = sinon.stub()
+    const requestDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'activitiesSentCounter').value({ add: sent })
+    sinon.stub(CopilotStudioClientMetrics, 'requestDuration').value({ record: requestDuration })
+    const span = endTrace(CopilotStudioClientTraceDefinitions.sendActivity, {
+      activity: Activity.fromObject({ type: 'message', conversation: { id: 'conversation-id' } })
+    })
+    const attributes = { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'conversation-id' }
+    const metricAttributes = { operation: 'sendActivityStreaming', ...attributes }
+
+    assert.deepEqual(span.attributes, attributes)
+    assertMetric(sent, 1, attributes)
+    assertMetric(requestDuration, duration, metricAttributes)
+  })
+
+  it('records execute streaming attributes and metrics', () => {
+    const executed = sinon.stub()
+    const requestDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'executeStreamingCounter').value({ add: executed })
+    sinon.stub(CopilotStudioClientMetrics, 'requestDuration').value({ record: requestDuration })
+    const span = endTrace(CopilotStudioClientTraceDefinitions.executeStreaming, {
+      activity: Activity.fromObject({ type: 'event' }), conversationId: 'conversation-id'
+    })
+    const attributes = { 'copilot.activity.type': 'event', 'copilot.activity.conversation_id': 'conversation-id' }
+
+    assert.deepEqual(span.attributes, attributes)
+    assertMetric(executed, 1, attributes)
+    assertMetric(requestDuration, duration, { operation: 'executeStreaming', ...attributes })
+  })
+
+  it('records subscription attributes, received events, and metrics', () => {
+    const events = sinon.stub()
+    const subscriptions = sinon.stub()
+    const streamDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'subscribeEventCounter').value({ add: events })
+    sinon.stub(CopilotStudioClientMetrics, 'subscribeAsyncCounter').value({ add: subscriptions })
+    sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
+    const span = createSpan()
+    const actions = CopilotStudioClientTraceDefinitions.subscribeAsync.actions!({ span: span as unknown as Span })
+    const event: SubscribeEvent = { eventId: 'event-id', activity: Activity.fromObject({ type: 'message' }) }
+    actions.eventReceivedFromCopilot(event)
+
+    const endedSpan = endTrace(CopilotStudioClientTraceDefinitions.subscribeAsync, {
+      conversationId: 'conversation-id', lastReceivedEventId: 'previous-event-id'
+    })
+    const spanAttributes = {
+      'copilot.subscribe_async.conversation_id': 'conversation-id',
+      'copilot.subscribe_async.last_received_event_id': 'previous-event-id',
+    }
+    const metricAttributes = {
+      operation: 'subscribeAsync',
+      'copilot.conversation_id': 'conversation-id',
+      'copilot.last_received_event_id': 'previous-event-id',
+    }
+
+    assert.deepEqual(span.events, [{ name: 'event.received', attributes: { 'copilot.subscribe_async.event.id': 'event-id', 'copilot.subscribe_async.event.activity.type': 'message' } }])
+    assertMetric(events, 1, { 'copilot.subscribe_async.event.id': 'event-id', 'copilot.subscribe_async.event.activity.type': 'message' })
+    assert.deepEqual(endedSpan.attributes, spanAttributes)
+    assertMetric(subscriptions, 1, metricAttributes)
+    assertMetric(streamDuration, duration, metricAttributes)
+  })
+
+  it('uses unknown for missing optional trace values', () => {
+    const connections = sinon.stub()
+    const received = sinon.stub()
+    const sent = sinon.stub()
+    const executed = sinon.stub()
+    const events = sinon.stub()
+    const subscriptions = sinon.stub()
+    const requests = sinon.stub()
+    const streamDuration = sinon.stub()
+    const requestDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'webchatConnectionsCounter').value({ add: connections })
+    sinon.stub(CopilotStudioClientMetrics, 'activitiesReceivedCounter').value({ add: received })
+    sinon.stub(CopilotStudioClientMetrics, 'activitiesSentCounter').value({ add: sent })
+    sinon.stub(CopilotStudioClientMetrics, 'executeStreamingCounter').value({ add: executed })
+    sinon.stub(CopilotStudioClientMetrics, 'subscribeEventCounter').value({ add: events })
+    sinon.stub(CopilotStudioClientMetrics, 'subscribeAsyncCounter').value({ add: subscriptions })
+    sinon.stub(CopilotStudioClientMetrics, 'requestsCounter').value({ add: requests })
+    sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
+    sinon.stub(CopilotStudioClientMetrics, 'requestDuration').value({ record: requestDuration })
+    const activity = Activity.fromObject({ type: 'message' })
+
+    const connectionSpan = createSpan()
+    CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: connectionSpan as unknown as Span }).receivedFromCopilot(activity)
+    const requestSpan = createSpan()
+    CopilotStudioClientTraceDefinitions.postRequest.actions!({ span: requestSpan as unknown as Span }).receivedFromCopilot(activity)
+    const subscriptionSpan = createSpan()
+    CopilotStudioClientTraceDefinitions.subscribeAsync.actions!({ span: subscriptionSpan as unknown as Span }).eventReceivedFromCopilot({ activity })
+
+    assert.deepEqual(connectionSpan.events[0].attributes, { 'copilot.webchat.activity.type': 'message', 'copilot.webchat.activity.conversation_id': 'unknown' })
+    assert.deepEqual(requestSpan.events[0].attributes, { 'copilot.post_request.activity.type': 'message', 'copilot.post_request.activity.conversation_id': 'unknown' })
+    assert.deepEqual(subscriptionSpan.events[0].attributes, { 'copilot.subscribe_async.event.id': 'unknown', 'copilot.subscribe_async.event.activity.type': 'message' })
+    assertMetric(received, 1, { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+    assertMetric(events, 1, { 'copilot.subscribe_async.event.id': 'unknown', 'copilot.subscribe_async.event.activity.type': 'message' })
+
+    const connection = endTraceWithIncompleteRecord(CopilotStudioClientTraceDefinitions.createConnection, { showTyping: undefined })
+    const request = endTraceWithIncompleteRecord(CopilotStudioClientTraceDefinitions.postRequest, { url: undefined, method: undefined })
+    const sentActivity = endTrace(CopilotStudioClientTraceDefinitions.sendActivity, { activity })
+    const execution = endTraceWithIncompleteRecord(CopilotStudioClientTraceDefinitions.executeStreaming, { activity, conversationId: undefined })
+    const subscription = endTraceWithIncompleteRecord(CopilotStudioClientTraceDefinitions.subscribeAsync, { conversationId: undefined, lastReceivedEventId: undefined })
+
+    assert.deepEqual(connection.attributes, { 'copilot.webchat.show_typing': 'unknown' })
+    assert.deepEqual(request.attributes, { 'copilot.post_request.url': 'unknown', 'copilot.post_request.method': 'unknown' })
+    assert.deepEqual(sentActivity.attributes, { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+    assert.deepEqual(execution.attributes, { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+    assert.deepEqual(subscription.attributes, { 'copilot.subscribe_async.conversation_id': 'unknown', 'copilot.subscribe_async.last_received_event_id': 'unknown' })
+    assertMetric(connections, 1, { 'copilot.webchat.show_typing': 'unknown' })
+    assertMetric(requests, 1, { operation: 'postRequestAsync', 'copilot.post_request.url': 'unknown', 'copilot.post_request.method': 'unknown' })
+    assertMetric(sent, 1, { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+    assertMetric(executed, 1, { 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+    assertMetric(subscriptions, 1, { operation: 'subscribeAsync', 'copilot.conversation_id': 'unknown', 'copilot.last_received_event_id': 'unknown' })
+    sinon.assert.calledWithExactly(streamDuration, duration, { operation: 'postRequestAsync', 'copilot.post_request.url': 'unknown', 'copilot.post_request.method': 'unknown' })
+    sinon.assert.calledWithExactly(streamDuration, duration, { operation: 'subscribeAsync', 'copilot.conversation_id': 'unknown', 'copilot.last_received_event_id': 'unknown' })
+    sinon.assert.calledWithExactly(requestDuration, duration, { operation: 'sendActivityStreaming', 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+    sinon.assert.calledWithExactly(requestDuration, duration, { operation: 'executeStreaming', 'copilot.activity.type': 'message', 'copilot.activity.conversation_id': 'unknown' })
+  })
+
+  it('preserves trace defaults and records sent web chat activities without a conversation', () => {
+    const connections = sinon.stub()
+    const requests = sinon.stub()
+    const sent = sinon.stub()
+    const executed = sinon.stub()
+    const subscriptions = sinon.stub()
+    const streamDuration = sinon.stub()
+    const requestDuration = sinon.stub()
+    sinon.stub(CopilotStudioClientMetrics, 'webchatConnectionsCounter').value({ add: connections })
+    sinon.stub(CopilotStudioClientMetrics, 'requestsCounter').value({ add: requests })
+    sinon.stub(CopilotStudioClientMetrics, 'activitiesSentCounter').value({ add: sent })
+    sinon.stub(CopilotStudioClientMetrics, 'executeStreamingCounter').value({ add: executed })
+    sinon.stub(CopilotStudioClientMetrics, 'subscribeAsyncCounter').value({ add: subscriptions })
+    sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
+    sinon.stub(CopilotStudioClientMetrics, 'requestDuration').value({ record: requestDuration })
+
+    const connection = endTrace(CopilotStudioClientTraceDefinitions.createConnection, CopilotStudioClientTraceDefinitions.createConnection.record)
+    const request = endTrace(CopilotStudioClientTraceDefinitions.postRequest, CopilotStudioClientTraceDefinitions.postRequest.record)
+    const activity = endTrace(CopilotStudioClientTraceDefinitions.sendActivity, CopilotStudioClientTraceDefinitions.sendActivity.record)
+    const execution = endTrace(CopilotStudioClientTraceDefinitions.executeStreaming, CopilotStudioClientTraceDefinitions.executeStreaming.record)
+    const subscription = endTrace(CopilotStudioClientTraceDefinitions.subscribeAsync, CopilotStudioClientTraceDefinitions.subscribeAsync.record)
+    const actionSpan = createSpan()
+    CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: actionSpan as unknown as Span }).sentToWebChat(Activity.fromObject({ type: 'message' }))
+
+    assert.deepEqual(connection.attributes, { 'copilot.webchat.show_typing': false })
+    assert.deepEqual(request.attributes, { 'copilot.post_request.url': '', 'copilot.post_request.method': '' })
+    assert.deepEqual(activity.attributes, { 'copilot.activity.type': 'unknown', 'copilot.activity.conversation_id': 'unknown' })
+    assert.deepEqual(execution.attributes, { 'copilot.activity.type': 'unknown', 'copilot.activity.conversation_id': 'unknown' })
+    assert.deepEqual(subscription.attributes, { 'copilot.subscribe_async.conversation_id': 'unknown', 'copilot.subscribe_async.last_received_event_id': 'unknown' })
+    assert.deepEqual(actionSpan.events, [{ name: 'activity.sent.to.webchat', attributes: { 'copilot.webchat.activity.type': 'message', 'copilot.webchat.activity.conversation_id': 'unknown' } }])
+    assertMetric(connections, 1, { 'copilot.webchat.show_typing': false })
+    assertMetric(requests, 1, { operation: 'postRequestAsync', 'copilot.post_request.url': '', 'copilot.post_request.method': '' })
+    assertMetric(sent, 1, { 'copilot.activity.type': 'unknown', 'copilot.activity.conversation_id': 'unknown' })
+    assertMetric(executed, 1, { 'copilot.activity.type': 'unknown', 'copilot.activity.conversation_id': 'unknown' })
+    assertMetric(subscriptions, 1, { operation: 'subscribeAsync', 'copilot.conversation_id': 'unknown', 'copilot.last_received_event_id': 'unknown' })
+    sinon.assert.calledWithExactly(streamDuration, duration, { operation: 'postRequestAsync', 'copilot.post_request.url': '', 'copilot.post_request.method': '' })
+    sinon.assert.calledWithExactly(streamDuration, duration, { operation: 'subscribeAsync', 'copilot.conversation_id': 'unknown', 'copilot.last_received_event_id': 'unknown' })
+    sinon.assert.calledWithExactly(requestDuration, duration, { operation: 'sendActivityStreaming', 'copilot.activity.type': 'unknown', 'copilot.activity.conversation_id': 'unknown' })
+    sinon.assert.calledWithExactly(requestDuration, duration, { operation: 'executeStreaming', 'copilot.activity.type': 'unknown', 'copilot.activity.conversation_id': 'unknown' })
+  })
+})

--- a/packages/agents-copilotstudio-client/test/observability/traces.test.ts
+++ b/packages/agents-copilotstudio-client/test/observability/traces.test.ts
@@ -3,7 +3,8 @@
 
 import { strict as assert } from 'assert'
 import { afterEach, describe, it } from 'node:test'
-import type { Span, TraceDefinition } from '@microsoft/agents-telemetry'
+import type { Span } from '@opentelemetry/api'
+import type { TraceDefinition } from '@microsoft/agents-telemetry'
 import { Activity } from '@microsoft/agents-activity'
 import * as sinon from 'sinon'
 import { CopilotStudioClientMetrics } from '../../src/observability/metrics'
@@ -39,8 +40,8 @@ function createSpan (): TestSpan {
   }
 }
 
-function endTrace<TRecord extends object> (
-  definition: TraceDefinition<TRecord>,
+function endTrace<TRecord extends object, TActions extends object> (
+  definition: TraceDefinition<TRecord, TActions>,
   record: TRecord,
   error?: unknown
 ): TestSpan {
@@ -49,8 +50,8 @@ function endTrace<TRecord extends object> (
   return span
 }
 
-function endTraceWithIncompleteRecord<TRecord extends object> (
-  definition: TraceDefinition<TRecord>,
+function endTraceWithIncompleteRecord<TRecord extends object, TActions extends object> (
+  definition: TraceDefinition<TRecord, TActions>,
   record: Record<string, unknown>
 ): TestSpan {
   const span = createSpan()

--- a/packages/agents-copilotstudio-client/test/observability/traces.test.ts
+++ b/packages/agents-copilotstudio-client/test/observability/traces.test.ts
@@ -3,7 +3,6 @@
 
 import { strict as assert } from 'assert'
 import { afterEach, describe, it } from 'node:test'
-import type { Span } from '@opentelemetry/api'
 import type { TraceDefinition } from '@microsoft/agents-telemetry'
 import { Activity } from '@microsoft/agents-activity'
 import * as sinon from 'sinon'
@@ -16,9 +15,17 @@ const duration = 123
 interface TestSpan {
   attributes: Record<string, unknown>
   events: Array<{ name: string, attributes: Record<string, unknown> }>
-  setAttribute(name: string, value: unknown): void
-  setAttributes(values: Record<string, unknown>): void
-  addEvent(name: string, attributes: Record<string, unknown>): void
+  spanContext(): { traceId: string, spanId: string, traceFlags: number }
+  setAttribute(name: string, value: unknown): this
+  setAttributes(values: Record<string, unknown>): this
+  addEvent(name: string, attributes?: unknown, startTime?: unknown): this
+  addLink(link: unknown): this
+  addLinks(links: unknown[]): this
+  setStatus(status: unknown): this
+  updateName(name: string): this
+  end(endTime?: unknown): void
+  isRecording(): boolean
+  recordException(exception: unknown, time?: unknown): void
 }
 
 function createSpan (): TestSpan {
@@ -28,15 +35,38 @@ function createSpan (): TestSpan {
   return {
     attributes,
     events,
+    spanContext () {
+      return { traceId: '', spanId: '', traceFlags: 0 }
+    },
     setAttribute (name, value) {
       attributes[name] = value
+      return this
     },
     setAttributes (values) {
       Object.assign(attributes, values)
+      return this
     },
     addEvent (name, values) {
-      events.push({ name, attributes: values })
+      events.push({ name, attributes: (values ?? {}) as Record<string, unknown> })
+      return this
     },
+    addLink () {
+      return this
+    },
+    addLinks () {
+      return this
+    },
+    setStatus () {
+      return this
+    },
+    updateName () {
+      return this
+    },
+    end () {},
+    isRecording () {
+      return true
+    },
+    recordException () {},
   }
 }
 
@@ -46,7 +76,7 @@ function endTrace<TRecord extends object, TActions extends object> (
   error?: unknown
 ): TestSpan {
   const span = createSpan()
-  definition.end({ span: span as unknown as Span, record, duration, error })
+  definition.end({ span: span as unknown as TestSpan, record, duration, error })
   return span
 }
 
@@ -55,7 +85,7 @@ function endTraceWithIncompleteRecord<TRecord extends object, TActions extends o
   record: Record<string, unknown>
 ): TestSpan {
   const span = createSpan()
-  definition.end({ span: span as unknown as Span, record: record as TRecord, duration })
+  definition.end({ span: span as unknown as TestSpan, record: record as TRecord, duration })
   return span
 }
 
@@ -70,7 +100,7 @@ describe('Copilot Studio client trace definitions', () => {
     const connections = sinon.stub()
     sinon.stub(CopilotStudioClientMetrics, 'webchatConnectionsCounter').value({ add: connections })
     const span = createSpan()
-    const actions = CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: span as unknown as Span })
+    const actions = CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: span as unknown as TestSpan })
     const activity = Activity.fromObject({ type: 'message', conversation: { id: 'conversation-id' } })
 
     actions.receivedFromCopilot(activity)
@@ -95,7 +125,7 @@ describe('Copilot Studio client trace definitions', () => {
     sinon.stub(CopilotStudioClientMetrics, 'requestsErrorCounter').value({ add: requestErrors })
     sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
     const span = createSpan()
-    const actions = CopilotStudioClientTraceDefinitions.postRequest.actions!({ span: span as unknown as Span })
+    const actions = CopilotStudioClientTraceDefinitions.postRequest.actions!({ span: span as unknown as TestSpan })
     actions.receivedFromCopilot(Activity.fromObject({ type: 'message', conversation: { id: 'conversation-id' } }))
 
     const endedSpan = endTrace(CopilotStudioClientTraceDefinitions.postRequest, {
@@ -189,7 +219,7 @@ describe('Copilot Studio client trace definitions', () => {
     sinon.stub(CopilotStudioClientMetrics, 'subscribeAsyncCounter').value({ add: subscriptions })
     sinon.stub(CopilotStudioClientMetrics, 'streamDuration').value({ record: streamDuration })
     const span = createSpan()
-    const actions = CopilotStudioClientTraceDefinitions.subscribeAsync.actions!({ span: span as unknown as Span })
+    const actions = CopilotStudioClientTraceDefinitions.subscribeAsync.actions!({ span: span as unknown as TestSpan })
     const event: SubscribeEvent = { eventId: 'event-id', activity: Activity.fromObject({ type: 'message' }) }
     actions.eventReceivedFromCopilot(event)
 
@@ -235,11 +265,11 @@ describe('Copilot Studio client trace definitions', () => {
     const activity = Activity.fromObject({ type: 'message' })
 
     const connectionSpan = createSpan()
-    CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: connectionSpan as unknown as Span }).receivedFromCopilot(activity)
+    CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: connectionSpan as unknown as TestSpan }).receivedFromCopilot(activity)
     const requestSpan = createSpan()
-    CopilotStudioClientTraceDefinitions.postRequest.actions!({ span: requestSpan as unknown as Span }).receivedFromCopilot(activity)
+    CopilotStudioClientTraceDefinitions.postRequest.actions!({ span: requestSpan as unknown as TestSpan }).receivedFromCopilot(activity)
     const subscriptionSpan = createSpan()
-    CopilotStudioClientTraceDefinitions.subscribeAsync.actions!({ span: subscriptionSpan as unknown as Span }).eventReceivedFromCopilot({ activity })
+    CopilotStudioClientTraceDefinitions.subscribeAsync.actions!({ span: subscriptionSpan as unknown as TestSpan }).eventReceivedFromCopilot({ activity })
 
     assert.deepEqual(connectionSpan.events[0].attributes, { 'copilot.webchat.activity.type': 'message', 'copilot.webchat.activity.conversation_id': 'unknown' })
     assert.deepEqual(requestSpan.events[0].attributes, { 'copilot.post_request.activity.type': 'message', 'copilot.post_request.activity.conversation_id': 'unknown' })
@@ -291,7 +321,7 @@ describe('Copilot Studio client trace definitions', () => {
     const execution = endTrace(CopilotStudioClientTraceDefinitions.executeStreaming, CopilotStudioClientTraceDefinitions.executeStreaming.record)
     const subscription = endTrace(CopilotStudioClientTraceDefinitions.subscribeAsync, CopilotStudioClientTraceDefinitions.subscribeAsync.record)
     const actionSpan = createSpan()
-    CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: actionSpan as unknown as Span }).sentToWebChat(Activity.fromObject({ type: 'message' }))
+    CopilotStudioClientTraceDefinitions.createConnection.actions!({ span: actionSpan as unknown as TestSpan }).sentToWebChat(Activity.fromObject({ type: 'message' }))
 
     assert.deepEqual(connection.attributes, { 'copilot.webchat.show_typing': false })
     assert.deepEqual(request.attributes, { 'copilot.post_request.url': '', 'copilot.post_request.method': '' })

--- a/packages/agents-copilotstudio-client/tsconfig.json
+++ b/packages/agents-copilotstudio-client/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.json",
     "include": [
       "src/**/*",
+      "test/**/*",
       "package.json"
     ],
     "compilerOptions": {


### PR DESCRIPTION
Addresses # 1215

## Description

Adds exhaustive unit coverage for Copilot Studio client OTel trace definitions.

### Changes

- Adds `test/observability/traces.test.ts`
- Validates all trace definitions and action callbacks
- Verifies span attributes, events, metric counters, and duration histograms
- Covers normal values, defaults, missing optional values, success, and error paths

## Testing
This is validated by the CI workflow, but the following image shows the test extension showing the new tests.
<img width="948" height="612" alt="image" src="https://github.com/user-attachments/assets/b7ca9c61-98f2-4cd7-9f40-528997a8cf7a" />
