### PR TITLE
Add observability unit tests - Cosmos & Blobs

### DIFF
--- a/packages/agents-hosting-storage-blob/test/observability/traces.test.ts
+++ b/packages/agents-hosting-storage-blob/test/observability/traces.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { strict as assert } from 'assert'
+import { afterEach, describe, it } from 'node:test'
+import type { Span, TraceDefinition } from '@microsoft/agents-telemetry'
+import * as sinon from 'sinon'
+import { BlobsStorageMetrics } from '../../src/observability/metrics'
+import { BlobsStorageTraceDefinitions } from '../../src/observability/traces'
+
+const duration = 123
+
+interface TestSpan {
+  attributes: Record<string, unknown>
+  setAttributes(values: Record<string, unknown>): void
+}
+
+function createSpan (): TestSpan {
+  const attributes: Record<string, unknown> = {}
+  return { attributes, setAttributes: values => Object.assign(attributes, values) }
+}
+
+function endTrace<TRecord extends object> (definition: TraceDefinition<TRecord>, record: TRecord): TestSpan {
+  const span = createSpan()
+  definition.end({ span: span as unknown as Span, record, duration })
+  return span
+}
+
+function endTraceWithIncompleteRecord<TRecord extends object> (definition: TraceDefinition<TRecord>): TestSpan {
+  const span = createSpan()
+  definition.end({ span: span as unknown as Span, record: { keyCount: undefined } as TRecord, duration })
+  return span
+}
+
+describe('Blob storage trace definitions', () => {
+  afterEach(() => sinon.restore())
+
+  function assertStorageOperation (definition: TraceDefinition<{ keyCount: number }>, operation: string) {
+    const operationDuration = sinon.stub()
+    sinon.stub(BlobsStorageMetrics, 'storageOperationDuration').value({ record: operationDuration })
+    const expectedAttributes = { 'storage.operation': operation, 'storage.key.count': 3 }
+
+    const span = endTrace(definition, { keyCount: 3 })
+    assert.deepEqual(span.attributes, expectedAttributes)
+    sinon.assert.calledWithExactly(operationDuration, duration, expectedAttributes)
+
+    const defaultSpan = endTrace(definition, definition.record)
+    const zeroKeyCountAttributes = { 'storage.operation': operation, 'storage.key.count': 0 }
+    assert.deepEqual(defaultSpan.attributes, zeroKeyCountAttributes)
+    assert.deepEqual(operationDuration.getCall(1).args, [duration, zeroKeyCountAttributes])
+
+    const missingSpan = endTraceWithIncompleteRecord(definition)
+    assert.deepEqual(missingSpan.attributes, zeroKeyCountAttributes)
+    assert.deepEqual(operationDuration.getCall(2).args, [duration, zeroKeyCountAttributes])
+    sinon.assert.callCount(operationDuration, 3)
+  }
+
+  it('records read attributes, duration metric, defaults, and missing key counts', () => {
+    assertStorageOperation(BlobsStorageTraceDefinitions.read, 'read')
+  })
+
+  it('records write attributes, duration metric, defaults, and missing key counts', () => {
+    assertStorageOperation(BlobsStorageTraceDefinitions.write, 'write')
+  })
+
+  it('records delete attributes, duration metric, defaults, and missing key counts', () => {
+    assertStorageOperation(BlobsStorageTraceDefinitions.delete, 'delete')
+  })
+})

--- a/packages/agents-hosting-storage-blob/test/observability/traces.test.ts
+++ b/packages/agents-hosting-storage-blob/test/observability/traces.test.ts
@@ -3,7 +3,7 @@
 
 import { strict as assert } from 'assert'
 import { afterEach, describe, it } from 'node:test'
-import type { Span, TraceDefinition } from '@microsoft/agents-telemetry'
+import type { TraceDefinition } from '@microsoft/agents-telemetry'
 import * as sinon from 'sinon'
 import { BlobsStorageMetrics } from '../../src/observability/metrics'
 import { BlobsStorageTraceDefinitions } from '../../src/observability/traces'
@@ -12,30 +12,53 @@ const duration = 123
 
 interface TestSpan {
   attributes: Record<string, unknown>
-  setAttributes(values: Record<string, unknown>): void
+  spanContext(): { traceId: string, spanId: string, traceFlags: number }
+  setAttribute(name: string, value: unknown): this
+  setAttributes(values: Record<string, unknown>): this
+  addEvent(name: string, attributes?: unknown, startTime?: unknown): this
+  addLink(link: unknown): this
+  addLinks(links: unknown[]): this
+  setStatus(status: unknown): this
+  updateName(name: string): this
+  end(endTime?: unknown): void
+  isRecording(): boolean
+  recordException(exception: unknown, time?: unknown): void
 }
 
 function createSpan (): TestSpan {
   const attributes: Record<string, unknown> = {}
-  return { attributes, setAttributes: values => Object.assign(attributes, values) }
+  return {
+    attributes,
+    spanContext: () => ({ traceId: '', spanId: '', traceFlags: 0 }),
+    setAttribute (name, value) { attributes[name] = value; return this },
+    setAttributes (values) { Object.assign(attributes, values); return this },
+    addEvent () { return this },
+    addLink () { return this },
+    addLinks () { return this },
+    setStatus () { return this },
+    updateName () { return this },
+    end () {},
+    isRecording: () => true,
+    recordException () {},
+  }
 }
 
-function endTrace<TRecord extends object> (definition: TraceDefinition<TRecord>, record: TRecord): TestSpan {
+function endTrace<TRecord extends object, TActions extends object> (definition: TraceDefinition<TRecord, TActions>, record: TRecord): TestSpan {
   const span = createSpan()
-  definition.end({ span: span as unknown as Span, record, duration })
+  definition.end({ span: span as unknown as TestSpan, record, duration })
   return span
 }
 
-function endTraceWithIncompleteRecord<TRecord extends object> (definition: TraceDefinition<TRecord>): TestSpan {
+function endTraceWithIncompleteRecord<TRecord extends object, TActions extends object> (definition: TraceDefinition<TRecord, TActions>): TestSpan {
   const span = createSpan()
-  definition.end({ span: span as unknown as Span, record: { keyCount: undefined } as TRecord, duration })
+  definition.end({ span: span as unknown as TestSpan, record: { keyCount: undefined } as TRecord, duration })
   return span
 }
 
 describe('Blob storage trace definitions', () => {
   afterEach(() => sinon.restore())
 
-  function assertStorageOperation (definition: TraceDefinition<{ keyCount: number }>, operation: string) {
+  function assertStorageOperation<TActions extends object> (definition: TraceDefinition<{ keyCount: number }, TActions>, operation: string) {
     const operationDuration = sinon.stub()
     sinon.stub(BlobsStorageMetrics, 'storageOperationDuration').value({ record: operationDuration })
     const expectedAttributes = { 'storage.operation': operation, 'storage.key.count': 3 }

--- a/packages/agents-hosting-storage-blob/tsconfig.json
+++ b/packages/agents-hosting-storage-blob/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": [
       "src/**/*",
+      "test/**/*",
       "package.json"
     ],
   "compilerOptions": {

--- a/packages/agents-hosting-storage-cosmos/test/observability/traces.test.ts
+++ b/packages/agents-hosting-storage-cosmos/test/observability/traces.test.ts
@@ -3,7 +3,7 @@
 
 import { strict as assert } from 'assert'
 import { afterEach, describe, it } from 'node:test'
-import type { Span, TraceDefinition } from '@microsoft/agents-telemetry'
+import type { TraceDefinition } from '@microsoft/agents-telemetry'
 import * as sinon from 'sinon'
 import { CosmosStorageMetrics } from '../../src/observability/metrics'
 import { CosmosStorageTraceDefinitions } from '../../src/observability/traces'
@@ -12,30 +12,53 @@ const duration = 123
 
 interface TestSpan {
   attributes: Record<string, unknown>
-  setAttributes(values: Record<string, unknown>): void
+  spanContext(): { traceId: string, spanId: string, traceFlags: number }
+  setAttribute(name: string, value: unknown): this
+  setAttributes(values: Record<string, unknown>): this
+  addEvent(name: string, attributes?: unknown, startTime?: unknown): this
+  addLink(link: unknown): this
+  addLinks(links: unknown[]): this
+  setStatus(status: unknown): this
+  updateName(name: string): this
+  end(endTime?: unknown): void
+  isRecording(): boolean
+  recordException(exception: unknown, time?: unknown): void
 }
 
 function createSpan (): TestSpan {
   const attributes: Record<string, unknown> = {}
-  return { attributes, setAttributes: values => Object.assign(attributes, values) }
+  return {
+    attributes,
+    spanContext: () => ({ traceId: '', spanId: '', traceFlags: 0 }),
+    setAttribute (name, value) { attributes[name] = value; return this },
+    setAttributes (values) { Object.assign(attributes, values); return this },
+    addEvent () { return this },
+    addLink () { return this },
+    addLinks () { return this },
+    setStatus () { return this },
+    updateName () { return this },
+    end () {},
+    isRecording: () => true,
+    recordException () {},
+  }
 }
 
-function endTrace<TRecord extends object> (definition: TraceDefinition<TRecord>, record: TRecord): TestSpan {
+function endTrace<TRecord extends object, TActions extends object> (definition: TraceDefinition<TRecord, TActions>, record: TRecord): TestSpan {
   const span = createSpan()
-  definition.end({ span: span as unknown as Span, record, duration })
+  definition.end({ span: span as unknown as TestSpan, record, duration })
   return span
 }
 
-function endTraceWithIncompleteRecord<TRecord extends object> (definition: TraceDefinition<TRecord>): TestSpan {
+function endTraceWithIncompleteRecord<TRecord extends object, TActions extends object> (definition: TraceDefinition<TRecord, TActions>): TestSpan {
   const span = createSpan()
-  definition.end({ span: span as unknown as Span, record: { keyCount: undefined } as TRecord, duration })
+  definition.end({ span: span as unknown as TestSpan, record: { keyCount: undefined } as TRecord, duration })
   return span
 }
 
 describe('Cosmos storage trace definitions', () => {
   afterEach(() => sinon.restore())
 
-  function assertStorageOperation (definition: TraceDefinition<{ keyCount: number }>, operation: string) {
+  function assertStorageOperation<TActions extends object> (definition: TraceDefinition<{ keyCount: number }, TActions>, operation: string) {
     const operationDuration = sinon.stub()
     sinon.stub(CosmosStorageMetrics, 'storageOperationDuration').value({ record: operationDuration })
     const expectedAttributes = { 'storage.operation': operation, 'storage.key.count': 3 }

--- a/packages/agents-hosting-storage-cosmos/test/observability/traces.test.ts
+++ b/packages/agents-hosting-storage-cosmos/test/observability/traces.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { strict as assert } from 'assert'
+import { afterEach, describe, it } from 'node:test'
+import type { Span, TraceDefinition } from '@microsoft/agents-telemetry'
+import * as sinon from 'sinon'
+import { CosmosStorageMetrics } from '../../src/observability/metrics'
+import { CosmosStorageTraceDefinitions } from '../../src/observability/traces'
+
+const duration = 123
+
+interface TestSpan {
+  attributes: Record<string, unknown>
+  setAttributes(values: Record<string, unknown>): void
+}
+
+function createSpan (): TestSpan {
+  const attributes: Record<string, unknown> = {}
+  return { attributes, setAttributes: values => Object.assign(attributes, values) }
+}
+
+function endTrace<TRecord extends object> (definition: TraceDefinition<TRecord>, record: TRecord): TestSpan {
+  const span = createSpan()
+  definition.end({ span: span as unknown as Span, record, duration })
+  return span
+}
+
+function endTraceWithIncompleteRecord<TRecord extends object> (definition: TraceDefinition<TRecord>): TestSpan {
+  const span = createSpan()
+  definition.end({ span: span as unknown as Span, record: { keyCount: undefined } as TRecord, duration })
+  return span
+}
+
+describe('Cosmos storage trace definitions', () => {
+  afterEach(() => sinon.restore())
+
+  function assertStorageOperation (definition: TraceDefinition<{ keyCount: number }>, operation: string) {
+    const operationDuration = sinon.stub()
+    sinon.stub(CosmosStorageMetrics, 'storageOperationDuration').value({ record: operationDuration })
+    const expectedAttributes = { 'storage.operation': operation, 'storage.key.count': 3 }
+
+    const span = endTrace(definition, { keyCount: 3 })
+    assert.deepEqual(span.attributes, expectedAttributes)
+    sinon.assert.calledWithExactly(operationDuration, duration, expectedAttributes)
+
+    const defaultSpan = endTrace(definition, definition.record)
+    const zeroKeyCountAttributes = { 'storage.operation': operation, 'storage.key.count': 0 }
+    assert.deepEqual(defaultSpan.attributes, zeroKeyCountAttributes)
+    assert.deepEqual(operationDuration.getCall(1).args, [duration, zeroKeyCountAttributes])
+
+    const missingSpan = endTraceWithIncompleteRecord(definition)
+    assert.deepEqual(missingSpan.attributes, zeroKeyCountAttributes)
+    assert.deepEqual(operationDuration.getCall(2).args, [duration, zeroKeyCountAttributes])
+    sinon.assert.callCount(operationDuration, 3)
+  }
+
+  it('records read attributes, duration metric, defaults, and missing key counts', () => {
+    assertStorageOperation(CosmosStorageTraceDefinitions.read, 'read')
+  })
+
+  it('records write attributes, duration metric, defaults, and missing key counts', () => {
+    assertStorageOperation(CosmosStorageTraceDefinitions.write, 'write')
+  })
+
+  it('records delete attributes, duration metric, defaults, and missing key counts', () => {
+    assertStorageOperation(CosmosStorageTraceDefinitions.delete, 'delete')
+  })
+})

--- a/packages/agents-hosting-storage-cosmos/tsconfig.json
+++ b/packages/agents-hosting-storage-cosmos/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "include": [
       "src/**/*",
+      "test/**/*",
       "package.json"
     ],
   "compilerOptions": {


### PR DESCRIPTION
Addresses # 1215

## Description

Adds OTel trace-definition unit tests for Cosmos and Blob storage.

### Changes

- Adds explicit tests for `read`, `write`, and `delete` traces in both packages
- Validates span attributes and storage-operation duration metrics
- Covers normal key counts, default records, and missing key-count fallbacks
- Uses explicit `it(...)` cases for Node Test Explorer discovery

## Testing
This is validated by the CI workflow, but the following image shows the test extension showing the new tests.
<img width="895" height="637" alt="image" src="https://github.com/user-attachments/assets/7c8058f9-804b-4c0d-8477-8f116467031d" />
