### PR TITLE
[#1237] Add shared OutboundHostValidator anti-SSRF control

### DIFF
--- a/compat/baseline/agents-hosting.api.md
+++ b/compat/baseline/agents-hosting.api.md
@@ -366,7 +366,7 @@ export interface AttachmentData {
 
 // @public
 export class AttachmentDownloader<TState extends TurnState = TurnState> implements InputFileDownloader<TState> {
-    constructor(stateKey?: string);
+    constructor(stateKey?: string, outboundHostValidator?: OutboundUrlPolicy);
     downloadAndStoreFiles(context: TurnContext, state: TState): Promise<void>;
     downloadFiles(context: TurnContext): Promise<InputFile[]>;
 }
@@ -542,7 +542,7 @@ export function clearJwksClients(): void;
 
 // @public (undocumented)
 export class CloudAdapter extends BaseAdapter {
-    constructor(authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient, options?: CloudAdapterOptions);
+    constructor(authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient, options?: CloudAdapterOptions, outboundHostValidator?: OutboundUrlPolicy);
     // (undocumented)
     protected _agentName?: string;
     // (undocumented)
@@ -577,6 +577,7 @@ export class CloudAdapter extends BaseAdapter {
 // @public
 export interface CloudAdapterOptions {
     emitStackTrace?: boolean;
+    // @deprecated
     validateServiceUrl?: boolean;
 }
 
@@ -799,6 +800,9 @@ export class CreateConversationOptionsBuilder {
 }
 
 // @public
+export function createOutboundHostValidator(options?: OutboundHostValidatorOptions): OutboundHostValidator;
+
+// @public
 export interface CustomKey {
     channelId: string;
     conversationId: string;
@@ -992,11 +996,14 @@ export interface InvokeResponse<T = any> {
 export const loadAuthConfigFromEnv: (cnxName?: string) => AuthConfiguration;
 
 // @public
+export function loadOutboundHostValidatorOptionsFromEnv(): OutboundHostValidatorOptions;
+
+// @public
 export const loadPrevAuthConfigFromEnv: () => AuthConfiguration;
 
 // @public
 export class M365AttachmentDownloader<TState extends TurnState = TurnState> implements InputFileDownloader<TState> {
-    constructor(stateKey?: string);
+    constructor(stateKey?: string, outboundHostValidator?: OutboundUrlPolicy);
     downloadAndStoreFiles(context: TurnContext, state: TState): Promise<void>;
     downloadFiles(context: TurnContext): Promise<InputFile[]>;
 }
@@ -1154,6 +1161,30 @@ export interface OAuthCard {
     text: string;
     tokenExchangeResource: TokenExchangeResource;
     tokenPostResource: TokenPostResource;
+}
+
+// @public
+export class OutboundHostValidator implements OutboundUrlPolicy {
+    constructor(options?: OutboundHostValidatorOptions);
+    // (undocumented)
+    readonly enabled: boolean;
+    // (undocumented)
+    isAllowed(input: string | URL | null | undefined): boolean;
+}
+
+// @public
+export interface OutboundHostValidatorOptions {
+    enabled?: boolean;
+    hosts?: readonly string[];
+    includeDefaultMicrosoftHosts?: boolean;
+}
+
+// @public
+export interface OutboundUrlPolicy {
+    // (undocumented)
+    readonly enabled: boolean;
+    // (undocumented)
+    isAllowed(url: string | URL | null | undefined): boolean;
 }
 
 // @public

--- a/packages/agents-hosting/README.md
+++ b/packages/agents-hosting/README.md
@@ -41,7 +41,12 @@ OutboundHostValidator__Hosts=contoso.com,fabrikam.com
 ```
 
 Indexed host variables such as `OutboundHostValidator__Hosts__0=contoso.com` are
-also supported. A host entry matches both the exact host and its subdomains.
+also supported. A host entry matches both the exact host and its subdomains, and
+is normalized (scheme/port/path stripped; a leading `*.` is accepted and ignored).
+
+When enforcement is enabled, `CloudAdapter` rejects inbound activities whose
+`serviceUrl` host is not allowlisted, and it also rejects `serviceurl` claim
+mismatches (equivalent to `CloudAdapterOptions.validateServiceUrl=true`).
 
 For explicit configuration, reuse the same immutable policy in the adapter and
 attachment downloaders:

--- a/packages/agents-hosting/README.md
+++ b/packages/agents-hosting/README.md
@@ -28,6 +28,48 @@ exposes framework-agnostic primitives that the
 Most consumers should keep using `startServer`/`createAgentRequestHandler` from the
 Express or Fastify packages; reach for these APIs when adapting another framework.
 
+## Outbound request host validation
+
+`OutboundHostValidator` provides an opt-in allowlist for server-side requests made
+to activity service URLs and attachment URLs. Enforcement is disabled by default.
+It can be configured with environment variables:
+
+```dotenv
+OutboundHostValidator__Enabled=true
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=contoso.com,fabrikam.com
+```
+
+Indexed host variables such as `OutboundHostValidator__Hosts__0=contoso.com` are
+also supported. A host entry matches both the exact host and its subdomains.
+
+For explicit configuration, reuse the same immutable policy in the adapter and
+attachment downloaders:
+
+```ts
+import {
+  AgentApplication,
+  AttachmentDownloader,
+  CloudAdapter,
+  OutboundHostValidator
+} from '@microsoft/agents-hosting'
+
+const outboundHostValidator = new OutboundHostValidator({
+  enabled: true,
+  hosts: ['contoso.com']
+})
+
+const adapter = new CloudAdapter(undefined, undefined, undefined, undefined, outboundHostValidator)
+
+const agent = new AgentApplication({
+  adapter,
+  fileDownloaders: [new AttachmentDownloader('inputFiles', outboundHostValidator)]
+})
+```
+
+The validator checks the URL supplied to the downloader. Redirects retain native
+`fetch` behavior.
+
 ## Example Usage based on the AgentApplication object
 
 ```ts

--- a/packages/agents-hosting/src/app/attachmentDownloader.ts
+++ b/packages/agents-hosting/src/app/attachmentDownloader.ts
@@ -11,6 +11,7 @@ import { Attachment } from '@microsoft/agents-activity'
 import { AuthProvider } from '../auth/authProvider'
 import { debug } from '@microsoft/agents-telemetry'
 import { loadAuthConfigFromEnv, MsalTokenProvider } from '../auth'
+import { createOutboundHostValidator, OutboundUrlPolicy } from '../outboundHostValidator'
 
 const logger = debug('agents:attachmentDownloader')
 
@@ -27,16 +28,19 @@ const logger = debug('agents:attachmentDownloader')
 export class AttachmentDownloader<TState extends TurnState = TurnState> implements InputFileDownloader<TState> {
   private _httpClient: HttpClient
   private _stateKey: string
+  private readonly _hostValidator: OutboundUrlPolicy
 
   /**
    * Creates an instance of AttachmentDownloader.
    * This class is responsible for downloading input files from attachments.
    *
    * @param stateKey The key to store files in state. Defaults to 'inputFiles'.
+   * @param outboundHostValidator Optional shared policy used to validate outbound attachment URLs.
    */
-  public constructor (stateKey: string = 'inputFiles') {
+  public constructor (stateKey: string = 'inputFiles', outboundHostValidator?: OutboundUrlPolicy) {
     this._httpClient = new HttpClient()
     this._stateKey = stateKey
+    this._hostValidator = outboundHostValidator ?? createOutboundHostValidator()
   }
 
   /**
@@ -90,6 +94,8 @@ export class AttachmentDownloader<TState extends TurnState = TurnState> implemen
       if (accessToken.length > 0) {
         headers.Authorization = `Bearer ${accessToken}`
       }
+      if (!this._hostValidator.isAllowed(attachment.contentUrl)) return undefined
+
       const response = await this._httpClient.get(attachment.contentUrl, {
         headers,
         responseType: 'arraybuffer'

--- a/packages/agents-hosting/src/app/teamsAttachmentDownloader.ts
+++ b/packages/agents-hosting/src/app/teamsAttachmentDownloader.ts
@@ -11,6 +11,7 @@ import { TurnContext } from '../turnContext'
 import { TurnState } from './turnState'
 import { HttpClient } from '../httpClient'
 import { z } from 'zod'
+import { createOutboundHostValidator, OutboundUrlPolicy } from '../outboundHostValidator'
 
 const logger = debug('agents:M365AttachmentDownloader')
 
@@ -20,10 +21,12 @@ const logger = debug('agents:M365AttachmentDownloader')
 export class M365AttachmentDownloader<TState extends TurnState = TurnState> implements InputFileDownloader<TState> {
   private _httpClient: HttpClient
   private _stateKey: string
+  private readonly _hostValidator: OutboundUrlPolicy
 
-  public constructor (stateKey: string = 'inputFiles') {
+  public constructor (stateKey: string = 'inputFiles', outboundHostValidator?: OutboundUrlPolicy) {
     this._httpClient = new HttpClient()
     this._stateKey = stateKey
+    this._hostValidator = outboundHostValidator ?? createOutboundHostValidator()
   }
 
   /**
@@ -69,6 +72,8 @@ export class M365AttachmentDownloader<TState extends TurnState = TurnState> impl
         const contentSchema = z.object({ downloadUrl: z.string().url() })
         const parsed = contentSchema.safeParse(attachment.content)
         const downloadUrl = parsed.success ? parsed.data.downloadUrl : attachment.contentUrl
+        if (!this._hostValidator.isAllowed(downloadUrl)) return undefined
+
         const response = await this._httpClient.get(downloadUrl, { responseType: 'arraybuffer' })
 
         const content = Buffer.from(response.data as ArrayBuffer)

--- a/packages/agents-hosting/src/cloudAdapter.ts
+++ b/packages/agents-hosting/src/cloudAdapter.ts
@@ -32,6 +32,7 @@ import { parseBooleanEnv, suggestClosest } from './utils/env'
 import { trace } from '@microsoft/agents-telemetry'
 import { AdapterTraceDefinitions } from './observability'
 import { applyAgenticHeaders } from './getProductInfo'
+import { createOutboundHostValidator, OutboundUrlPolicy } from './outboundHostValidator'
 
 const logger = debug('agents:cloud-adapter')
 
@@ -80,6 +81,9 @@ export interface CloudAdapterOptions {
    * for one service URL tries to send activities targeting a different one.
    *
    * Env var: `CloudAdapterOptions__validateServiceUrl`.
+   *
+   * @deprecated Configure {@link OutboundUrlPolicy} instead. This option
+   * remains available for backward compatibility with claim-only validation.
    */
   validateServiceUrl?: boolean
 }
@@ -246,6 +250,7 @@ export class CloudAdapter extends BaseAdapter {
   connectionManager: Connections
 
   private readonly _options: Required<CloudAdapterOptions>
+  private readonly _hostValidator: OutboundUrlPolicy
 
   /**
    * Creates an instance of CloudAdapter.
@@ -253,12 +258,16 @@ export class CloudAdapter extends BaseAdapter {
    * @param authProvider - No longer used.
    * @param userTokenClient - No longer used.
    * @param options - Optional runtime behavior overrides. See {@link CloudAdapterOptions}.
+   * @param outboundHostValidator - Optional policy for validating outbound `Activity.serviceUrl` hosts.
+   * When omitted, the policy is loaded from `OutboundHostValidator__*` environment variables
+   * and remains disabled by default.
    */
-  constructor (authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient, options?: CloudAdapterOptions) {
+  constructor (authConfig?: AuthConfiguration, authProvider?: AuthProvider, userTokenClient?: UserTokenClient, options?: CloudAdapterOptions, outboundHostValidator?: OutboundUrlPolicy) {
     super()
     this.authConfig = authConfig = getAuthConfigWithDefaults(authConfig)
     this.connectionManager = new MsalConnectionManager(undefined, undefined, authConfig)
     this._options = resolveCloudAdapterOptions(options)
+    this._hostValidator = outboundHostValidator ?? createOutboundHostValidator()
 
     // Install a CloudAdapter-aware default `onTurnError` that honors
     // `emitStackTrace`. The base class default only logs the message; we
@@ -321,6 +330,8 @@ export class CloudAdapter extends BaseAdapter {
     identity: JwtPayload,
     headers?: HeaderPropagationCollection
   ): Promise<ConnectorClient> {
+    this.ensureOutboundServiceUrlAllowed(serviceUrl)
+
     return trace(AdapterTraceDefinitions.createConnectorClient, async ({ record }) => {
       record({ serviceUrl, scopes: [scope] })
 
@@ -349,6 +360,8 @@ export class CloudAdapter extends BaseAdapter {
     identity: JwtPayload,
     activity: Activity,
     headers?: HeaderPropagationCollection) {
+    this.ensureOutboundServiceUrlAllowed(activity.serviceUrl)
+
     return trace(AdapterTraceDefinitions.createConnectorClient, async ({ record }) => {
       if (!identity?.aud) {
         // anonymous
@@ -692,6 +705,8 @@ export class CloudAdapter extends BaseAdapter {
    * should be rejected with a 400.
    */
   private validateServiceUrl (identity: JwtPayload | undefined, activity: Activity): boolean {
+    if (!this.isOutboundServiceUrlAllowed(activity.serviceUrl)) return false
+
     if (!identity) return true
     if (!activity.serviceUrl) return true
 
@@ -709,12 +724,29 @@ export class CloudAdapter extends BaseAdapter {
 
     const safeClaim = sanitizeForLog(claimValue)
     const safeServiceUrl = sanitizeForLog(activity.serviceUrl)
-    if (this._options.validateServiceUrl) {
+    if (this._hostValidator.enabled || this._options.validateServiceUrl) {
       logger.error(`Invalid service URL Claim='${safeClaim}', ServiceUrl='${safeServiceUrl}'`)
       return false
     }
     logger.warn(`Invalid service URL Claim='${safeClaim}', ServiceUrl='${safeServiceUrl}'`)
     return true
+  }
+
+  /**
+   * Applies the shared outbound host policy.
+   */
+  private isOutboundServiceUrlAllowed (serviceUrl: string | undefined): boolean {
+    if (!this._hostValidator.enabled || !serviceUrl || this._hostValidator.isAllowed(serviceUrl)) return true
+
+    logger.warn(`ServiceUrl host is not in the configured allowed hosts. ServiceUrl='${sanitizeForLog(serviceUrl)}'`)
+    return false
+  }
+
+  /** Ensures connector-client creation cannot bypass the outbound host policy. */
+  private ensureOutboundServiceUrlAllowed (serviceUrl: string | undefined): void {
+    if (!this.isOutboundServiceUrlAllowed(serviceUrl)) {
+      throw ExceptionHelper.generateException(Error, Errors.OutboundServiceUrlNotAllowed)
+    }
   }
 
   /**

--- a/packages/agents-hosting/src/errorHelper.ts
+++ b/packages/agents-hosting/src/errorHelper.ts
@@ -157,6 +157,14 @@ export const Errors: { [key: string]: AgentErrorDefinition } = {
   },
 
   /**
+    * Error thrown when the outbound service URL is denied by the configured host policy.
+    */
+  OutboundServiceUrlNotAllowed: {
+    code: -120175,
+    description: 'serviceUrl host is not in the configured allowed hosts.'
+  },
+
+  /**
      * Error thrown when conversationParameters must be defined.
      */
   ConversationParametersRequired: {

--- a/packages/agents-hosting/src/index.ts
+++ b/packages/agents-hosting/src/index.ts
@@ -32,5 +32,6 @@ export * from './storage/storage'
 export * from './headerPropagation'
 export * from './interfaces'
 export * from './httpClient'
+export * from './outboundHostValidator'
 
 export * from './agent-client'

--- a/packages/agents-hosting/src/outboundHostValidator.ts
+++ b/packages/agents-hosting/src/outboundHostValidator.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { parseBooleanEnv } from './utils/env'
+
+/** Hosts used by Microsoft channel callbacks and hosted attachments. */
+const DEFAULT_MICROSOFT_HOSTS = Object.freeze([
+  'botframework.com',
+  'smba.trafficmanager.net',
+  'teams.microsoft.com',
+  'teams.microsoft.us',
+  'graph.microsoft.com',
+  'sharepoint.com',
+  'svc.ms',
+  'blob.core.windows.net'
+])
+
+const OUTBOUND_HOST_VALIDATOR_ENV_PREFIX = 'OutboundHostValidator__'
+const OUTBOUND_HOST_VALIDATOR_ENV_PREFIX_UPPER = OUTBOUND_HOST_VALIDATOR_ENV_PREFIX.toUpperCase()
+
+/** Configuration for the shared outbound-host allowlist. */
+export interface OutboundHostValidatorOptions {
+  /** Enables allowlist enforcement. Defaults to `false`. */
+  enabled?: boolean
+
+  /**
+   * Indicates whether the built-in list of Microsoft first-party hosts
+   * (Bot Connector, Graph, SharePoint, Azure Blob/AMS) is included when enforcement is enabled.
+   * Defaults to `true`.
+   */
+  includeDefaultMicrosoftHosts?: boolean
+
+  /** Additional exact hosts or host suffixes to allow.
+   * An entry matches a request host when the host equals the entry or is a subdomain of it (e.g. <c>contoso.com</c> matches <c>contoso.com</c> and <c>files.contoso.com</c>).
+   * A leading <c>*.</c> is accepted and ignored (treated as a suffix).
+  */
+  hosts?: readonly string[]
+}
+
+/** A policy that decides whether an outbound URL is safe to request. */
+export interface OutboundUrlPolicy {
+  readonly enabled: boolean
+  isAllowed(url: string | URL | null | undefined): boolean
+}
+
+/**
+ * Shared allowlist policy for server-side outbound requests.
+ *
+ * A configured suffix matches both the exact host and its subdomains. The
+ * policy is disabled by default to preserve existing SDK behavior.
+ */
+export class OutboundHostValidator implements OutboundUrlPolicy {
+  public readonly enabled: boolean
+  private readonly suffixes: ReadonlySet<string>
+
+  public constructor (options: OutboundHostValidatorOptions = {}) {
+    this.enabled = options.enabled ?? false
+
+    const suffixes = new Set<string>()
+    if (options.includeDefaultMicrosoftHosts ?? true) {
+      for (const host of DEFAULT_MICROSOFT_HOSTS) suffixes.add(host)
+    }
+
+    for (const host of options.hosts ?? []) {
+      const normalized = normalizeConfiguredHost(host)
+      if (normalized) suffixes.add(normalized)
+    }
+
+    this.suffixes = suffixes
+  }
+
+  public isAllowed (input: string | URL | null | undefined): boolean {
+    if (!this.enabled) return true
+
+    const host = getUrlHost(input)
+    if (!host) return false
+
+    for (const suffix of this.suffixes) {
+      if (host === suffix || host.endsWith(`.${suffix}`)) return true
+    }
+
+    return false
+  }
+}
+
+/**
+ * Loads validator options from environment variables compatible with the
+ * .NET `OutboundHostValidator` configuration section.
+ *
+ * Hosts can be supplied either as a comma-separated `Hosts` value or as
+ * indexed values such as `Hosts__0`, `Hosts__1`, and so on.
+ */
+export function loadOutboundHostValidatorOptionsFromEnv (): OutboundHostValidatorOptions {
+  const result: OutboundHostValidatorOptions = {}
+  const indexedHosts = new Map<number, string>()
+  const hosts: string[] = []
+
+  for (const [envKey, rawValue] of Object.entries(process.env)) {
+    const upperKey = envKey.toUpperCase()
+    if (!upperKey.startsWith(OUTBOUND_HOST_VALIDATOR_ENV_PREFIX_UPPER)) continue
+
+    const property = envKey.substring(OUTBOUND_HOST_VALIDATOR_ENV_PREFIX.length)
+    const upperProperty = property.toUpperCase()
+
+    if (upperProperty === 'ENABLED') {
+      const value = parseBooleanEnv(rawValue)
+      if (value !== undefined) result.enabled = value
+    } else if (upperProperty === 'INCLUDEDEFAULTMICROSOFTHOSTS') {
+      const value = parseBooleanEnv(rawValue)
+      if (value !== undefined) result.includeDefaultMicrosoftHosts = value
+    } else if (upperProperty === 'HOSTS' && rawValue) {
+      hosts.push(...rawValue.split(',').map(host => host.trim()).filter(Boolean))
+    } else {
+      const match = /^HOSTS__(\d+)$/i.exec(property)
+      if (match && rawValue?.trim()) indexedHosts.set(Number(match[1]), rawValue.trim())
+    }
+  }
+
+  for (const [, host] of [...indexedHosts.entries()].sort(([left], [right]) => left - right)) {
+    hosts.push(host)
+  }
+  if (hosts.length > 0) result.hosts = hosts
+
+  return result
+}
+
+/** Creates the default validator, with explicit settings overriding the environment. */
+export function createOutboundHostValidator (options?: OutboundHostValidatorOptions): OutboundHostValidator {
+  const fromEnv = loadOutboundHostValidatorOptionsFromEnv()
+  return new OutboundHostValidator({
+    enabled: options?.enabled ?? fromEnv.enabled,
+    includeDefaultMicrosoftHosts: options?.includeDefaultMicrosoftHosts ?? fromEnv.includeDefaultMicrosoftHosts,
+    hosts: options?.hosts ?? fromEnv.hosts
+  })
+}
+
+function getUrlHost (input: string | URL | null | undefined): string | undefined {
+  if (!input) return undefined
+
+  try {
+    const url = input instanceof URL ? input : new URL(input)
+    return normalizeHostname(url.hostname)
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeConfiguredHost (input: string): string | undefined {
+  let candidate = input?.trim()
+  if (!candidate) return undefined
+  if (candidate.startsWith('*.')) candidate = candidate.slice(2)
+
+  try {
+    const absolute = new URL(candidate)
+    if (absolute.hostname) return normalizeHostname(absolute.hostname)
+  } catch {
+    // A bare host, host:port, or host/path is handled below.
+  }
+
+  try {
+    return normalizeHostname(new URL(`http://${candidate}`).hostname)
+  } catch {
+    return undefined
+  }
+}
+
+function normalizeHostname (host: string): string | undefined {
+  const normalized = host.trim().toLowerCase().replace(/\.$/, '')
+  return normalized || undefined
+}

--- a/packages/agents-hosting/src/outboundHostValidator.ts
+++ b/packages/agents-hosting/src/outboundHostValidator.ts
@@ -33,9 +33,9 @@ export interface OutboundHostValidatorOptions {
   includeDefaultMicrosoftHosts?: boolean
 
   /** Additional exact hosts or host suffixes to allow.
-   * An entry matches a request host when the host equals the entry or is a subdomain of it (e.g. <c>contoso.com</c> matches <c>contoso.com</c> and <c>files.contoso.com</c>).
-   * A leading <c>*.</c> is accepted and ignored (treated as a suffix).
-  */
+   * An entry matches a request host when the host equals the entry or is a subdomain of it (e.g. `contoso.com` matches `contoso.com` and `files.contoso.com`).
+   * A leading `*.` is accepted and ignored (treated as a suffix). Ports and paths are ignored if provided.
+   */
   hosts?: readonly string[]
 }
 

--- a/packages/agents-hosting/test/hosting/adapter/cloudAdapter.options.test.ts
+++ b/packages/agents-hosting/test/hosting/adapter/cloudAdapter.options.test.ts
@@ -4,12 +4,14 @@
 import { strict as assert } from 'assert'
 import { afterEach, describe, it } from 'node:test'
 import sinon from 'sinon'
-import { Activity, ActivityTypes } from '@microsoft/agents-activity'
+import { Activity, ActivityTypes, ConversationParameters, ConversationReference } from '@microsoft/agents-activity'
 import {
   AuthConfiguration,
   CloudAdapter,
   CloudAdapterOptions,
   MsalConnectionManager,
+  OutboundUrlPolicy,
+  OutboundHostValidator,
   Request,
   TurnContext,
   UserTokenClient
@@ -35,12 +37,12 @@ describe('CloudAdapter options (PR #838 parity)', () => {
 
   // --- Test scaffolding ----------------------------------------------------
 
-  function buildAdapter (options?: CloudAdapterOptions) {
+  function buildAdapter (options?: CloudAdapterOptions, outboundHostValidator?: OutboundUrlPolicy) {
     const mockConnectorClient = sinon.createStubInstance(ConnectorClient)
     const mockConnectionManager = sinon.createStubInstance(MsalConnectionManager)
     const mockUserTokenClient = sinon.createStubInstance(UserTokenClient)
 
-    const adapter = new CloudAdapter(authentication, undefined, undefined, options)
+    const adapter = new CloudAdapter(authentication, undefined, undefined, options, outboundHostValidator)
     const adapterAny = adapter as any
     adapterAny.connectionManager = mockConnectionManager
     sinon.stub(adapterAny, 'createConnectorClient').returns(mockConnectorClient)
@@ -303,6 +305,114 @@ describe('CloudAdapter options (PR #838 parity)', () => {
         if (prev === undefined) delete process.env.CloudAdapterOptions__VALIDATESERVICEURL
         else process.env.CloudAdapterOptions__VALIDATESERVICEURL = prev
       }
+    })
+  })
+
+  describe('outboundHostValidator', () => {
+    it('rejects a disallowed ServiceUrl even when there is no serviceurl claim', async () => {
+      const adapter = buildAdapter(undefined, new OutboundHostValidator({ enabled: true }))
+      const activity = makeActivity(ActivityTypes.Message, 'https://evil.example.com/relay/')
+      stubFromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      const res = buildRes()
+
+      await adapter.process(buildReq({ aud: 'clientId' } as any), res as Response, async () => {})
+
+      sinon.assert.calledWith((res as any).status, 400)
+    })
+
+    it('allows a built-in Microsoft ServiceUrl', async () => {
+      const adapter = buildAdapter(undefined, new OutboundHostValidator({ enabled: true }))
+      const activity = makeActivity(ActivityTypes.Message, 'https://smba.trafficmanager.net/teams/')
+      stubFromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      const res = buildRes()
+
+      await adapter.process(buildReq({ aud: 'clientId' } as any), res as Response, async () => {})
+
+      sinon.assert.neverCalledWith((res as any).status, 400)
+    })
+
+    it('allows a configured ServiceUrl host', async () => {
+      const adapter = buildAdapter(undefined, new OutboundHostValidator({ enabled: true, hosts: ['contoso.com'] }))
+      const activity = makeActivity(ActivityTypes.Message, 'https://callback.contoso.com/api/')
+      stubFromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      const res = buildRes()
+
+      await adapter.process(buildReq({ aud: 'clientId' } as any), res as Response, async () => {})
+
+      sinon.assert.neverCalledWith((res as any).status, 400)
+    })
+
+    it('preserves existing behavior when the validator is disabled', async () => {
+      const adapter = buildAdapter(undefined, new OutboundHostValidator({ enabled: false }))
+      const activity = makeActivity(ActivityTypes.Message, 'https://evil.example.com/relay/')
+      stubFromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      const res = buildRes()
+
+      await adapter.process(buildReq({ aud: 'clientId' } as any), res as Response, async () => {})
+
+      sinon.assert.neverCalledWith((res as any).status, 400)
+    })
+
+    it('enforces serviceurl claim matching when the validator is enabled', async () => {
+      const adapter = buildAdapter(undefined, new OutboundHostValidator({ enabled: true }))
+      const activity = makeActivity(ActivityTypes.Message, 'https://smba.trafficmanager.net/teams/')
+      stubFromObject = sinon.stub(Activity, 'fromObject').returns(activity)
+      const res = buildRes()
+
+      await adapter.process(buildReq({ serviceurl: 'https://graph.microsoft.com/callback/' } as any), res as Response, async () => {})
+
+      sinon.assert.calledWith((res as any).status, 400)
+    })
+
+    it('rejects a disallowed continuation ServiceUrl before creating a connector client', async () => {
+      const adapter = new CloudAdapter(
+        authentication,
+        undefined,
+        undefined,
+        undefined,
+        new OutboundHostValidator({ enabled: true })
+      )
+      const reference: ConversationReference = {
+        activityId: 'activity-id',
+        user: { id: 'user-id' },
+        agent: { id: 'agent-id' },
+        conversation: { id: 'conversation-id' },
+        channelId: 'msteams',
+        serviceUrl: 'https://evil.example.com/relay/'
+      }
+
+      await assert.rejects(
+        adapter.continueConversation('clientId', reference, async () => {}),
+        /serviceUrl host is not in the configured allowed hosts/
+      )
+    })
+
+    it('rejects a disallowed create-conversation ServiceUrl before creating a connector client', async () => {
+      const adapter = new CloudAdapter(
+        authentication,
+        undefined,
+        undefined,
+        undefined,
+        new OutboundHostValidator({ enabled: true })
+      )
+      const parameters: ConversationParameters = {
+        members: [{ id: 'user-id' }],
+        isGroup: false,
+        activity: new Activity(ActivityTypes.Message),
+        channelData: undefined
+      }
+
+      await assert.rejects(
+        adapter.createConversationAsync(
+          'agentAppId',
+          'msteams',
+          'https://evil.example.com/relay/',
+          'audience',
+          parameters,
+          async () => {}
+        ),
+        /serviceUrl host is not in the configured allowed hosts/
+      )
     })
   })
 

--- a/packages/agents-hosting/test/hosting/app/attachmentDownloader.test.ts
+++ b/packages/agents-hosting/test/hosting/app/attachmentDownloader.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { strict as assert } from 'node:assert'
+import { afterEach, describe, it } from 'node:test'
+import sinon from 'sinon'
+import {
+  AttachmentDownloader,
+  M365AttachmentDownloader,
+  OutboundHostValidator
+} from '../../../src'
+
+describe('attachment downloader outbound host validation', () => {
+  afterEach(() => sinon.restore())
+
+  it('skips a disallowed generic attachment without issuing a request', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch')
+    const downloader = new AttachmentDownloader(
+      'inputFiles',
+      new OutboundHostValidator({ enabled: true })
+    )
+
+    const result = await (downloader as any).downloadFile({
+      contentType: 'application/octet-stream',
+      contentUrl: 'https://evil.example.com/file'
+    }, 'secret-token')
+
+    assert.equal(result, undefined)
+    sinon.assert.notCalled(fetchStub)
+  })
+
+  it('downloads an attachment from an allowed host using native fetch redirect handling', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response('contents', {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' }
+    }))
+    const downloader = new AttachmentDownloader(
+      'inputFiles',
+      new OutboundHostValidator({ enabled: true, hosts: ['files.contoso.com'] })
+    )
+
+    const result = await (downloader as any).downloadFile({
+      contentType: 'application/octet-stream',
+      contentUrl: 'https://files.contoso.com/file'
+    }, 'secret-token')
+
+    assert.equal(result.content.toString(), 'contents')
+    assert.equal(fetchStub.firstCall.args[1]?.redirect, undefined)
+  })
+
+  it('validates the actual M365 downloadUrl instead of contentUrl', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch')
+    const downloader = new M365AttachmentDownloader(
+      'inputFiles',
+      new OutboundHostValidator({ enabled: true })
+    )
+
+    const result = await (downloader as any).downloadFile({
+      contentType: 'application/octet-stream',
+      contentUrl: 'https://graph.microsoft.com/attachment',
+      content: { downloadUrl: 'https://evil.example.com/token-target' }
+    })
+
+    assert.equal(result, undefined)
+    sinon.assert.notCalled(fetchStub)
+  })
+
+  it('preserves existing download behavior when validation is disabled', async () => {
+    const fetchStub = sinon.stub(globalThis, 'fetch').resolves(new Response('contents', {
+      status: 200,
+      headers: { 'content-type': 'application/octet-stream' }
+    }))
+    const downloader = new M365AttachmentDownloader(
+      'inputFiles',
+      new OutboundHostValidator({ enabled: false })
+    )
+
+    const result = await (downloader as any).downloadFile({
+      contentType: 'application/octet-stream',
+      contentUrl: 'https://evil.example.com/attachment',
+      content: { downloadUrl: 'https://evil.example.com/file' }
+    })
+
+    assert.equal(result.content.toString(), 'contents')
+    sinon.assert.calledOnce(fetchStub)
+    assert.equal(fetchStub.firstCall.args[1]?.redirect, undefined)
+  })
+})

--- a/packages/agents-hosting/test/hosting/outboundHostValidator.test.ts
+++ b/packages/agents-hosting/test/hosting/outboundHostValidator.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { strict as assert } from 'node:assert'
+import { afterEach, describe, it } from 'node:test'
+import {
+  createOutboundHostValidator,
+  loadOutboundHostValidatorOptionsFromEnv,
+  OutboundHostValidator
+} from '../../src'
+
+describe('OutboundHostValidator', () => {
+  const changedEnvironmentKeys = new Map<string, string | undefined>()
+
+  function setEnvironment (key: string, value: string): void {
+    if (!changedEnvironmentKeys.has(key)) changedEnvironmentKeys.set(key, process.env[key])
+    process.env[key] = value
+  }
+
+  afterEach(() => {
+    for (const [key, value] of changedEnvironmentKeys) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    changedEnvironmentKeys.clear()
+  })
+
+  function assertDisabledValidatorAllows (url: string | null): void {
+    const validator = new OutboundHostValidator({ enabled: false })
+    assert.equal(validator.enabled, false)
+    assert.equal(validator.isAllowed(url), true)
+  }
+
+  function assertDefaultMicrosoftHostAllowed (url: string): void {
+    assert.equal(new OutboundHostValidator({ enabled: true }).isAllowed(url), true)
+  }
+
+  function assertUnknownOrInvalidHostDenied (url: string): void {
+    assert.equal(new OutboundHostValidator({ enabled: true }).isAllowed(url), false)
+  }
+
+  function assertHostNormalization (configuredHost: string): void {
+    const validator = new OutboundHostValidator({ enabled: true, hosts: [configuredHost] })
+    assert.equal(validator.isAllowed('https://contoso.com/api'), true)
+    assert.equal(validator.isAllowed('https://files.contoso.com/api'), true)
+    assert.equal(validator.isAllowed('https://notcontoso.com/api'), false)
+    assert.equal(validator.isAllowed('https://contoso.com.evil.example/api'), false)
+  }
+
+  it('allows an external URL when enforcement is disabled', () => {
+    assertDisabledValidatorAllows('https://evil.example.com/relay')
+  })
+
+  it('allows a link-local IP address when enforcement is disabled', () => {
+    assertDisabledValidatorAllows('https://169.254.169.254/latest/meta-data')
+  })
+
+  it('allows localhost when enforcement is disabled', () => {
+    assertDisabledValidatorAllows('http://localhost/admin')
+  })
+
+  it('allows an invalid URL when enforcement is disabled', () => {
+    assertDisabledValidatorAllows('not-a-uri')
+  })
+
+  it('allows an absent URL when enforcement is disabled', () => {
+    assertDisabledValidatorAllows(null)
+  })
+
+  it('allows the default SMBA host', () => {
+    assertDefaultMicrosoftHostAllowed('https://smba.trafficmanager.net/teams/')
+  })
+
+  it('allows the default Microsoft Graph host', () => {
+    assertDefaultMicrosoftHostAllowed('https://graph.microsoft.com/v1.0/me')
+  })
+
+  it('allows the default SharePoint host', () => {
+    assertDefaultMicrosoftHostAllowed('https://contoso.sharepoint.com/file')
+  })
+
+  it('allows the default svc.ms host', () => {
+    assertDefaultMicrosoftHostAllowed('https://foo.svc.ms/download')
+  })
+
+  it('allows the default Azure Blob Storage host', () => {
+    assertDefaultMicrosoftHostAllowed('https://account.blob.core.windows.net/container/blob')
+  })
+
+  it('allows the default Bot Framework host', () => {
+    assertDefaultMicrosoftHostAllowed('https://webchat.botframework.com/callback')
+  })
+
+  it('denies an unknown external host', () => {
+    assertUnknownOrInvalidHostDenied('https://evil.example.com/relay')
+  })
+
+  it('denies a link-local IP address', () => {
+    assertUnknownOrInvalidHostDenied('https://169.254.169.254/latest/meta-data')
+  })
+
+  it('denies an internal hostname', () => {
+    assertUnknownOrInvalidHostDenied('https://internal-test.local:8443/secret')
+  })
+
+  it('denies localhost', () => {
+    assertUnknownOrInvalidHostDenied('http://localhost/admin')
+  })
+
+  it('denies a non-allowlisted trafficmanager.net host', () => {
+    assertUnknownOrInvalidHostDenied('https://evil.trafficmanager.net/relay')
+  })
+
+  it('denies an invalid URL', () => {
+    assertUnknownOrInvalidHostDenied('not-a-uri')
+  })
+
+  it('denies a relative URL', () => {
+    assertUnknownOrInvalidHostDenied('/relative/path')
+  })
+
+  it('normalizes a full host URL', () => {
+    assertHostNormalization('https://contoso.com')
+  })
+
+  it('normalizes a full host URL with a path', () => {
+    assertHostNormalization('https://contoso.com/some/path')
+  })
+
+  it('normalizes a host with a port', () => {
+    assertHostNormalization('contoso.com:8443')
+  })
+
+  it('normalizes a host with a path', () => {
+    assertHostNormalization('contoso.com/path')
+  })
+
+  it('normalizes a wildcard host', () => {
+    assertHostNormalization('*.contoso.com')
+  })
+
+  it('can exclude the default Microsoft hosts', () => {
+    const validator = new OutboundHostValidator({
+      enabled: true,
+      includeDefaultMicrosoftHosts: false,
+      hosts: ['contoso.com']
+    })
+
+    assert.equal(validator.isAllowed('https://graph.microsoft.com/v1.0/me'), false)
+    assert.equal(validator.isAllowed('https://contoso.com/x'), true)
+  })
+
+  it('loads scalar and indexed settings from environment variables case-insensitively', () => {
+    setEnvironment('OUTBOUNDHOSTVALIDATOR__ENABLED', 'true')
+    setEnvironment('OutboundHostValidator__IncludeDefaultMicrosoftHosts', 'false')
+    setEnvironment('OutboundHostValidator__Hosts__1', 'fabrikam.com')
+    setEnvironment('OutboundHostValidator__Hosts__0', 'contoso.com')
+
+    const options = loadOutboundHostValidatorOptionsFromEnv()
+    assert.deepEqual(options, {
+      enabled: true,
+      includeDefaultMicrosoftHosts: false,
+      hosts: ['contoso.com', 'fabrikam.com']
+    })
+
+    const validator = createOutboundHostValidator()
+    assert.equal(validator.isAllowed('https://api.contoso.com'), true)
+    assert.equal(validator.isAllowed('https://graph.microsoft.com'), false)
+  })
+})

--- a/test-agents/agentic-ai/env.TEMPLATE
+++ b/test-agents/agentic-ai/env.TEMPLATE
@@ -7,5 +7,10 @@ connections__serviceConnection__settings__tenantId=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 agentic_type=agentic
 agentic_scopes=https://graph.microsoft.com/.default

--- a/test-agents/application-style/env.TEMPLATE
+++ b/test-agents/application-style/env.TEMPLATE
@@ -6,6 +6,11 @@ connections__serviceConnection__settings__tenantId=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 BLOB_STORAGE_CONNECTION_STRING=
 BLOB_CONTAINER_ID=
 COSMOS_ENDPOINT=                        # e.g., https://your-account.documents.azure.com:443/

--- a/test-agents/copilotstudio-console/env.TEMPLATE
+++ b/test-agents/copilotstudio-console/env.TEMPLATE
@@ -21,3 +21,8 @@ enableDiagnostics=false # Enable diagnostic logging for debugging (true/false). 
 locale=en-US # Set conversation locale (e.g., en-US, fr-FR, es-ES). Default is en-US.
 
 DEBUG=copilot-studio:*
+
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=

--- a/test-agents/custom-dialogs/env.TEMPLATE
+++ b/test-agents/custom-dialogs/env.TEMPLATE
@@ -5,3 +5,8 @@ connections__serviceConnection__settings__tenantId=
 
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
+
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=

--- a/test-agents/empty-agent/env.TEMPLATE
+++ b/test-agents/empty-agent/env.TEMPLATE
@@ -7,3 +7,8 @@ connections__serviceConnection__settings__FICClientId=
 
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
+
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=

--- a/test-agents/fastify-empty-agent/env.TEMPLATE
+++ b/test-agents/fastify-empty-agent/env.TEMPLATE
@@ -7,3 +7,8 @@ connections__serviceConnection__settings__FICClientId=
 
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
+
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=

--- a/test-agents/multi-turn-prompt/env.TEMPLATE
+++ b/test-agents/multi-turn-prompt/env.TEMPLATE
@@ -5,3 +5,8 @@ connections__serviceConnection__settings__tenantId=
 
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
+
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=

--- a/test-agents/named-pipe-agent/env.TEMPLATE
+++ b/test-agents/named-pipe-agent/env.TEMPLATE
@@ -1,2 +1,7 @@
 # Named pipe name (default: bfv4.pipes)
 PIPE_NAME=bfv4.pipes
+
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=

--- a/test-agents/proactive-agent/env.TEMPLATE
+++ b/test-agents/proactive-agent/env.TEMPLATE
@@ -8,6 +8,11 @@ connections__serviceConnection__settings__FICClientId=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 # Comma-separated list of app IDs permitted to call the proactive endpoints.
 # Leave empty to allow all callers (development only).
 ALLOWED_CALLERS=

--- a/test-agents/root-agent/env.TEMPLATE
+++ b/test-agents/root-agent/env.TEMPLATE
@@ -6,6 +6,11 @@ connections__serviceConnection__settings__tenantId=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 Agent1_endpoint=http://localhost:39783/api/messages
 Agent1_clientId=<targetbot_clientid>
 Agent1_serviceUrl=http://localhost:3978/api/agentresponse

--- a/test-agents/sidecar-auth/env.TEMPLATE
+++ b/test-agents/sidecar-auth/env.TEMPLATE
@@ -31,6 +31,11 @@ connections__serviceConnection__settings__sidecarBaseUrl=http://localhost:5178
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 # Alternatively, point the SDK at the sidecar with a single environment variable
 # (takes precedence over sidecarBaseUrl above):
 # SIDECAR_URL=http://localhost:5178

--- a/test-agents/slack-agent/env.TEMPLATE
+++ b/test-agents/slack-agent/env.TEMPLATE
@@ -6,5 +6,10 @@ connections__serviceConnection__settings__tenantId=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 # Optional: fallback token for local testing without ABS injecting ApiToken
 # SLACK_TOKEN=xoxb-your-bot-token

--- a/test-agents/state-agent/env.TEMPLATE
+++ b/test-agents/state-agent/env.TEMPLATE
@@ -6,6 +6,11 @@ connections__serviceConnection__settings__tenantId=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 BLOB_STORAGE_CONNECTION_STRING=
 BLOB_CONTAINER_ID=
 COSMOS_ENDPOINT=                        # e.g., https://your-account.documents.azure.com:443/

--- a/test-agents/web-chat/env.TEMPLATE
+++ b/test-agents/web-chat/env.TEMPLATE
@@ -7,4 +7,9 @@ connections__serviceConnection__settings__connectionName=
 connectionsMap__0__connection=serviceConnection
 connectionsMap__0__serviceUrl=*
 
+# Outbound host validation. Disabled by default.
+OutboundHostValidator__Enabled=false
+OutboundHostValidator__IncludeDefaultMicrosoftHosts=true
+OutboundHostValidator__Hosts=
+
 agentName=MultiFeatureAgent


### PR DESCRIPTION
Fixes # 1237

## Description
This pull request introduces a new outbound host validation policy to the `@microsoft/agents-hosting` package, enabling opt-in allowlisting for outbound requests to activity service URLs and attachment URLs. 
The changes add the `OutboundHostValidator` class and related interfaces, update the `CloudAdapter` and attachment downloaders to support host validation, and provide environment variable-based configuration. Backward compatibility is maintained for existing service URL validation options.

**Outbound Host Validation Policy:**

* Introduced the `OutboundHostValidator` class, the `OutboundUrlPolicy` interface, and related options, allowing developers to specify allowed hosts for outbound requests via code or environment variables. A utility function `createOutboundHostValidator` and environment loader `loadOutboundHostValidatorOptionsFromEnv` were also added. (`[[1]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R1166-R1189)`, `[[2]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R802-R804)`, `[[3]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R998-R1006)`, `[[4]](diffhunk://#diff-04308ebde6873c0dc13b6a0f83a62c4160edad10fa4f566d253d261a52b865caR35)`)
* Updated the documentation (`README.md`) to describe how to configure and use the outbound host validator with code examples and environment variable support. (`[packages/agents-hosting/README.mdR31-R72](diffhunk://#diff-5ffc0110cb5cf0d529f521308cd261cfff8ecb7e3bdd64353404c279891d07a2R31-R72)`)

**Integration with Core Components:**

* Updated the `CloudAdapter` constructor to accept an optional `OutboundUrlPolicy` and enforce outbound host validation for connector client creation and activity updates. Added internal checks and error handling for disallowed service URLs, and deprecated the old `validateServiceUrl` option in favor of the new policy. (`[[1]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1L545-R545)`, `[[2]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R35)`, `[[3]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R84-R86)`, `[[4]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R253-R270)`, `[[5]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R333-R334)`, `[[6]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R363-R364)`, `[[7]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R708-R709)`, `[[8]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420L712-R751)`)
* Extended the `AttachmentDownloader` and `M365AttachmentDownloader` classes to accept an optional outbound host validator and enforce host validation before file downloads. (`[[1]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1L369-R369)`, `[[2]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R998-R1006)`, `[[3]](diffhunk://#diff-02ad1e16f1706b49019394ebb1e1e38b6e7957e5e9a17160ff16147d84b90b8dR14)`, `[[4]](diffhunk://#diff-02ad1e16f1706b49019394ebb1e1e38b6e7957e5e9a17160ff16147d84b90b8dR31-R43)`, `[[5]](diffhunk://#diff-02ad1e16f1706b49019394ebb1e1e38b6e7957e5e9a17160ff16147d84b90b8dR97-R98)`, `[[6]](diffhunk://#diff-a6f70e5a744d76a6a581acdc02ee6eb998e574bf4349d1c3f352325a16e321deR14)`, `[[7]](diffhunk://#diff-a6f70e5a744d76a6a581acdc02ee6eb998e574bf4349d1c3f352325a16e321deR24-R29)`, `[[8]](diffhunk://#diff-a6f70e5a744d76a6a581acdc02ee6eb998e574bf4349d1c3f352325a16e321deR75-R76)`)

**Error Handling:**

* Added a new error definition `OutboundServiceUrlNotAllowed` to provide consistent error reporting when outbound service URLs are not allowed by the configured policy. (`[packages/agents-hosting/src/errorHelper.tsR159-R166](diffhunk://#diff-a99d0b88336dd114b0573b8c64cca81a0e18eef6206caead4f18258cff0b7d94R159-R166)`)

**Backward Compatibility:**

* Marked the old `validateServiceUrl` option as deprecated but still available for claim-only validation, ensuring a smooth transition to the new outbound host policy. (`[[1]](diffhunk://#diff-eeda38696bc38a513b5b5545af7c7340abd13c44be2cd73c0881902ac64e85a1R580)`, `[[2]](diffhunk://#diff-0c14fd717680b2a2fcf5072417547179c0964b6f49aa89b7bf8717268fb0f420R84-R86)`)

## Testing
These images show the tests we did with the samples.

Warning logged by the empty-agent when the validator is configured:
<img width="1939" height="73" alt="image" src="https://github.com/user-attachments/assets/a6b6ee90-33cd-4431-b1ac-3bb88867046b" />

Proactive scenarios working with default values for the outbound validator options:
<img width="1978" height="831" alt="image" src="https://github.com/user-attachments/assets/ad96d293-c16b-4377-99aa-3460e46db4b7" />

Error thrown when calling createConversation with a host that is not in the allowedList:
<img width="1938" height="551" alt="image" src="https://github.com/user-attachments/assets/d96ea6d1-cfa0-445e-bed0-3e1847902d29" />

