### PR TITLE
Add teams metadata validation to repo:doctor script

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -6,6 +6,10 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
+- checkout: self
+  fetchDepth: 0
+  displayName: 'Checkout repository with full history'
+
 - task: UseNode@1
   inputs:
     version: '24.x'

--- a/packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
+++ b/packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
@@ -2,6 +2,9 @@
 # This package consumes selected Teams API types and clients; it is not a wrapper
 # for the full upstream package. Direct compatibility findings take precedence
 # over these advisory adoption policies.
+
+# For capability metadata maintenance and sourceReview acknowledgments, see:
+# scripts/teams-api-drift/README.md#source-review-acknowledgments
 schemaVersion: 1
 
 dependency:

--- a/packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
+++ b/packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml
@@ -22,8 +22,8 @@ capabilities:
     description: "Parses Teams channel data and provides Teams-specific activity helpers."
     owners:
       - "src/activity-extensions/**"
+      - "src/teamsActivity.ts"
       - "src/teamsActivityExtensions.ts"
-      - "src/teamsModelExtensions.ts"
     upstreamAreas:
       - "models.channel-data"
       - "activities"
@@ -62,6 +62,7 @@ capabilities:
     description: "Handles message extension invokes, query parsing, actions, and responses."
     owners:
       - "src/messageExtensions/**"
+      - "src/teamsModelExtensions.ts"
     upstreamAreas:
       - "models.messaging-extension"
       - "models.app-based-link-query"
@@ -72,6 +73,7 @@ capabilities:
     description: "Handles Teams task module fetch and submit invokes."
     owners:
       - "src/taskModules/**"
+      - "src/teamsModelExtensions.ts"
     upstreamAreas:
       - "models.task-module"
       - "activities.invoke"

--- a/packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
+++ b/packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json
@@ -1,6 +1,6 @@
 {
   "dependency": "@microsoft/teams.api",
-  "declaredVersion": "2.0.13",
+  "declaredVersion": "2.0.14",
   "sourceRoot": "src",
   "usages": [
     {
@@ -13,6 +13,7 @@
     {
       "upstreamSymbol": "Client",
       "usage": "type-reference",
+      "exposure": "publicly-exposed",
       "files": [
         "src/teamsAgentExtension.ts",
         "src/teamsApiClientExtensions.ts",
@@ -22,6 +23,7 @@
     {
       "upstreamSymbol": "AppBasedLinkQuery",
       "usage": "request-model",
+      "exposure": "publicly-exposed",
       "propertiesValidated": [
         "state",
         "url"
@@ -33,6 +35,7 @@
     {
       "upstreamSymbol": "ChannelData",
       "usage": "parsed-model",
+      "exposure": "publicly-exposed",
       "propertiesRead": [
         "channel",
         "eventType",
@@ -44,12 +47,14 @@
         "src/channels/teamsChannel.ts",
         "src/messages/message.ts",
         "src/teams/teamsTeam.ts",
+        "src/teamsActivity.ts",
         "src/teamsActivityExtensions.ts"
       ]
     },
     {
       "upstreamSymbol": "ChannelInfo",
       "usage": "event-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/channels/teamsChannel.ts"
       ]
@@ -57,6 +62,7 @@
     {
       "upstreamSymbol": "ConfigResponse",
       "usage": "response-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/config/config.ts"
       ]
@@ -64,6 +70,7 @@
     {
       "upstreamSymbol": "FileConsentCardResponse",
       "usage": "request-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/fileConsents/fileConsent.ts"
       ]
@@ -71,6 +78,7 @@
     {
       "upstreamSymbol": "MeetingDetails",
       "usage": "event-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/meetings/meeting.ts"
       ]
@@ -78,6 +86,7 @@
     {
       "upstreamSymbol": "MessagingExtensionAction",
       "usage": "request-model",
+      "exposure": "publicly-exposed",
       "propertiesRead": [
         "botActivityPreview",
         "data"
@@ -90,6 +99,7 @@
     {
       "upstreamSymbol": "MessagingExtensionActionResponse",
       "usage": "response-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/messageExtensions/messageExtension.ts"
       ]
@@ -97,6 +107,7 @@
     {
       "upstreamSymbol": "MessagingExtensionQuery",
       "usage": "request-model",
+      "exposure": "publicly-exposed",
       "propertiesValidated": [
         "commandId",
         "parameters",
@@ -115,6 +126,7 @@
     {
       "upstreamSymbol": "MessagingExtensionResponse",
       "usage": "response-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/messageExtensions/messageExtension.ts"
       ]
@@ -122,6 +134,7 @@
     {
       "upstreamSymbol": "O365ConnectorCardActionQuery",
       "usage": "request-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/messages/message.ts"
       ]
@@ -129,6 +142,7 @@
     {
       "upstreamSymbol": "OnBehalfOf",
       "usage": "return-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/teamsActivityExtensions.ts"
       ]
@@ -136,6 +150,7 @@
     {
       "upstreamSymbol": "TaskModuleRequest",
       "usage": "request-model",
+      "exposure": "publicly-exposed",
       "propertiesRead": [
         "data"
       ],
@@ -147,6 +162,7 @@
     {
       "upstreamSymbol": "TaskModuleResponse",
       "usage": "response-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/taskModules/taskModule.ts"
       ]
@@ -154,6 +170,7 @@
     {
       "upstreamSymbol": "TeamInfo",
       "usage": "event-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/teams/teamsTeam.ts"
       ]
@@ -161,6 +178,7 @@
     {
       "upstreamSymbol": "TeamsChannelAccount",
       "usage": "nested-event-model",
+      "exposure": "publicly-exposed",
       "files": [
         "src/meetings/meeting.ts"
       ]

--- a/scripts/repo-doctor.mjs
+++ b/scripts/repo-doctor.mjs
@@ -5,6 +5,8 @@ import path from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 import { fileURLToPath } from 'node:url'
 
+import { checkTeamsApiMetadata } from './teams-api-drift/validate-teams-api-metadata.mjs'
+
 const ignoredDirectories = new Set(['.git', 'node_modules', 'dist', 'coverage'])
 const ignoredDocumentPrefixes = ['compat/', 'packages/agents-hosting-dialogs/vendor/']
 const workspaceRoots = ['packages', 'test-agents']
@@ -285,6 +287,26 @@ export const ruleDefinitions = {
     why: 'Keeps public API compatibility checks complete and attributable.',
     fix: 'Regenerate the API report so its header matches the package name.',
   },
+  'compat/teams-api-usage-manifest-stale': {
+    what: 'Teams API usage metadata matches concrete dependency consumption.',
+    why: 'Keeps direct Teams API compatibility findings and affected source files accurate.',
+    fix: 'Update teams-api-usage-manifest.json to match the current Teams extension source.',
+  },
+  'compat/teams-api-usage-review-missing': {
+    what: 'Ambiguous Teams API usage changes receive an explicit metadata review.',
+    why: 'Keeps dynamic and manually classified Teams API usage from drifting silently.',
+    fix: 'Update the usage manifest, or change its sourceReview with a specific non-impact reason.',
+  },
+  'compat/teams-api-capabilities-stale': {
+    what: 'Teams capability ownership and upstream areas match the extension structure.',
+    why: 'Keeps additive Teams API changes assigned to the correct feature and adoption policy.',
+    fix: 'Update teams-capabilities.yaml to match current feature ownership and upstream areas.',
+  },
+  'compat/teams-api-capabilities-review-missing': {
+    what: 'Ambiguous Teams capability changes receive an explicit metadata review.',
+    why: 'Keeps feature ownership and adoption-policy decisions from drifting silently.',
+    fix: 'Update the capabilities map, or change its sourceReview with a specific non-impact reason.',
+  },
   'runtime/toolchain-mismatch': {
     what: 'Configured Node versions match the .nvmrc major.',
     why: 'Keeps local, CI, container, and type-level runtime support aligned.',
@@ -324,8 +346,9 @@ const ruleCategories = {
 /**
  * Runs the repository consistency checks without modifying the checkout.
  * @param {string} root
+ * @param {{ baseRef?: string }} [options]
  */
-export function checkRepository (root) {
+export function checkRepository (root, options = {}) {
   const normalizedRoot = path.resolve(root)
   const rootManifestFile = 'package.json'
   const rootManifestText = readRequiredText(normalizedRoot, rootManifestFile)
@@ -384,6 +407,7 @@ export function checkRepository (root) {
   checkDocumentationImports(normalizedRoot, documents, packages, findings)
   checkRelativeDocumentationLinks(normalizedRoot, documents, findings)
   checkCompatibilityBaselines(normalizedRoot, packages, findings)
+  findings.push(...checkTeamsApiMetadata(normalizedRoot, { baseRef: options.baseRef }))
   checkRuntimeConfiguration(normalizedRoot, rootManifest, findings)
 
   findings.sort((left, right) => left.path.localeCompare(right.path) ||
@@ -408,6 +432,7 @@ export function checkRepository (root) {
 /** @param {string[]} argv */
 export function parseArguments (argv) {
   let root = process.cwd()
+  let baseRef
   let rules = false
   const ruleIds = []
   for (let index = 0; index < argv.length; index += 1) {
@@ -423,12 +448,17 @@ export function parseArguments (argv) {
       if (!root) throw new DoctorConfigurationError('scripts/repo-doctor.mjs', '--root requires a path.')
       continue
     }
+    if (argument === '--base-ref') {
+      baseRef = argv[++index]
+      if (!baseRef) throw new DoctorConfigurationError('scripts/repo-doctor.mjs', '--base-ref requires a Git ref.')
+      continue
+    }
     throw new DoctorConfigurationError('scripts/repo-doctor.mjs', `Unknown argument: ${argument}`)
   }
   for (const ruleId of ruleIds) {
     if (!Object.hasOwn(ruleDefinitions, ruleId)) throw new DoctorConfigurationError('scripts/repo-doctor.mjs', `Unknown rule ID: ${ruleId}`)
   }
-  return { help: false, rules, ruleIds, root }
+  return { help: false, rules, ruleIds, root, ...(baseRef ? { baseRef } : {}) }
 }
 
 /**
@@ -495,15 +525,16 @@ function runCli () {
   try {
     const options = parseArguments(process.argv.slice(2))
     if (options.help) {
-      console.log('Usage: npm run repo:doctor -- [--root <path>] [--rules [<rule-id>...]]')
+      console.log('Usage: npm run repo:doctor -- [--root <path>] [--base-ref <git-ref>] [--rules [<rule-id>...]]')
       console.log('  --rules  List every rule, or selected rule IDs, with their purpose and typical resolution.')
+      console.log('  --base-ref  Compare Teams API metadata reviews with the merge base of this Git ref.')
       return
     }
     if (options.rules) {
       console.log(formatRuleGuide({ ruleIds: options.ruleIds }))
       return
     }
-    const report = checkRepository(options.root)
+    const report = checkRepository(options.root, { baseRef: options.baseRef })
     console.log(formatReport(report))
     process.exitCode = report.status === 'fail' ? 1 : 0
   } catch (error) {

--- a/scripts/repo-doctor.mjs
+++ b/scripts/repo-doctor.mjs
@@ -295,7 +295,7 @@ export const ruleDefinitions = {
   'compat/teams-api-usage-review-missing': {
     what: 'Ambiguous Teams API usage changes receive an explicit metadata review.',
     why: 'Keeps dynamic and manually classified Teams API usage from drifting silently.',
-    fix: 'Update the usage manifest, or change its sourceReview with a specific non-impact reason.',
+    fix: 'Update the usage manifest, or follow scripts/teams-api-drift/README.md#source-review-acknowledgments.',
   },
   'compat/teams-api-capabilities-stale': {
     what: 'Teams capability ownership and upstream areas match the extension structure.',
@@ -305,7 +305,7 @@ export const ruleDefinitions = {
   'compat/teams-api-capabilities-review-missing': {
     what: 'Ambiguous Teams capability changes receive an explicit metadata review.',
     why: 'Keeps feature ownership and adoption-policy decisions from drifting silently.',
-    fix: 'Update the capabilities map, or change its sourceReview with a specific non-impact reason.',
+    fix: 'Update the capabilities map, or follow scripts/teams-api-drift/README.md#source-review-acknowledgments.',
   },
   'runtime/toolchain-mismatch': {
     what: 'Configured Node versions match the .nvmrc major.',

--- a/scripts/teams-api-drift/README.md
+++ b/scripts/teams-api-drift/README.md
@@ -1,0 +1,111 @@
+# Teams API drift metadata
+
+The Teams API drift checks use two independent metadata documents for
+`packages/agents-hosting-extensions-msteams`:
+
+- [`teams-api-usage-manifest.json`](../../packages/agents-hosting-extensions-msteams/teams-api-usage-manifest.json)
+  records concrete consumption of
+  `@microsoft/teams.api`. Each usage identifies an upstream symbol, its source
+  files, how it is used, any statically known members, and whether the type is
+  exposed through the package's public API.
+- [`config/teams-capabilities.yaml`](../../packages/agents-hosting-extensions-msteams/config/teams-capabilities.yaml)
+  maps source ownership to Teams feature
+  areas. Each capability records its owner paths, upstream API areas, and the
+  adoption policy used to classify upstream additions. Descriptions provide
+  additional context for maintainers and automated review.
+
+Repo Doctor validates the current contents of both documents. When Git history
+is available, it also checks whether relevant source changes received a
+document-specific metadata review.
+
+## Which document should change?
+
+Update `teams-api-usage-manifest.json` when a source change affects a concrete
+Teams API usage fact, including:
+
+- adding or removing a direct import from `@microsoft/teams.api`;
+- moving a usage to another source file or adding another file that uses it;
+- reading, writing, calling, or validating a different upstream member;
+- exposing an upstream type through the package's public exports, or making a
+  previously public type internal; or
+- changing the declared `@microsoft/teams.api` dependency version.
+
+Update `teams-capabilities.yaml` when a source change affects feature ownership
+or compatibility policy, including:
+
+- adding, deleting, renaming, or moving source paths covered by a capability;
+- changing which capability owns a source path;
+- changing the Teams API areas imported by a capability-owned file; or
+- changing a capability's `upstreamAreas` or `adoptionPolicy`.
+
+An ordinary internal refactor can still require review when static analysis
+cannot prove that metadata is unaffected. Examples include dynamic property
+access and schema-based validation. In that case, use the acknowledgment for
+the document named by the Repo Doctor finding.
+
+## Source review acknowledgments
+
+Use `sourceReview` only after checking the relevant source change and
+confirming that the document's substantive metadata remains accurate. An
+acknowledgment does not suppress provable errors such as a missing import,
+missing file, stale dependency version, invalid owner pattern, missing static
+member, or incorrect public exposure.
+
+The acknowledgment is document-specific. A capability acknowledgment cannot
+satisfy a usage-manifest review, and a usage acknowledgment cannot satisfy a
+capability review.
+
+For `teams-api-usage-manifest.json`, add or update this top-level property:
+
+```json
+{
+  "usages": [],
+  "sourceReview": {
+    "outcome": "no-usage-metadata-change",
+    "reason": "Explain specifically why the changed source does not alter Teams API usage metadata."
+  }
+}
+```
+
+Keep the existing `usages` entries; the empty array above only shows where the
+top-level property belongs.
+
+For `config/teams-capabilities.yaml`, add or update this top-level section:
+
+```yaml
+sourceReview:
+  outcome: "no-capability-metadata-change"
+  reason: "Explain specifically why the changed source does not alter capability ownership or upstream areas."
+```
+
+The record must differ from the version at the Git base. If `sourceReview`
+already exists, update its reason for the current change; copying or retaining
+an unchanged acknowledgment does not pass. The reason must be non-empty and
+specific to the source change.
+
+The acknowledgment must also be at least as recent as the source change. In a
+commit series, commit it with or after the relevant source change. While
+testing local working-tree changes, edit the corresponding metadata document
+in the working tree as well. Whitespace-only metadata changes do not count.
+
+Prefer updating the substantive metadata whenever the change can be described
+accurately. The acknowledgment is for a reviewed non-impact conclusion, not a
+general waiver.
+
+## Run the checks
+
+From the repository root, run:
+
+```shell
+npm run repo:doctor
+```
+
+To compare explicitly against a pull request target while testing locally:
+
+```shell
+npm run repo:doctor -- --base-ref main
+```
+
+Repo Doctor includes committed, staged, unstaged, and untracked changes. If it
+is run outside a Git checkout, current-state validation still runs, but the
+change-review rules are skipped.

--- a/scripts/teams-api-drift/validate-teams-api-metadata.mjs
+++ b/scripts/teams-api-drift/validate-teams-api-metadata.mjs
@@ -1,0 +1,518 @@
+// @ts-check
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
+
+import typescript from 'typescript'
+import { parse as parseYaml } from 'yaml'
+
+const ts = typescript
+const dependency = '@microsoft/teams.api'
+const packagePath = 'packages/agents-hosting-extensions-msteams'
+const manifestPath = `${packagePath}/teams-api-usage-manifest.json`
+const capabilitiesPath = `${packagePath}/config/teams-capabilities.yaml`
+const packageManifestPath = `${packagePath}/package.json`
+const sourcePrefix = `${packagePath}/src/`
+
+/** @typedef {{ upstreamSymbol: string, usage: string, usageKinds?: string[], exposure?: string, methodsCalled?: string[], propertiesRead?: string[], propertiesValidated?: string[], propertiesWritten?: string[], files: string[] }} Usage */
+/** @typedef {{ dependency: string, declaredVersion?: string, sourceRoot?: string, usages: Usage[], sourceReview?: { outcome?: string, reason?: string } }} UsageManifest */
+/** @typedef {{ description?: string, owners: string[], upstreamAreas: string[], adoptionPolicy: string }} Capability */
+/** @typedef {{ schemaVersion: number, dependency: { package: string }, capabilities: Record<string, Capability>, sourceReview?: { outcome?: string, reason?: string } }} CapabilitiesDocument */
+/** @typedef {{ symbol: string, localName: string, typeOnly: boolean, file: string, line: number }} TeamsImport */
+/** @typedef {{ ruleId: 'compat/teams-api-usage-manifest-stale' | 'compat/teams-api-usage-review-missing' | 'compat/teams-api-capabilities-stale' | 'compat/teams-api-capabilities-review-missing', path: string, message: string, fix: string, line: number, column: number, subject?: string }} MetadataFinding */
+
+/**
+ * Validates the Teams API drift metadata without modifying the checkout.
+ * @param {string} root
+ * @param {{ baseRef?: string }} [options]
+ * @returns {MetadataFinding[]}
+ */
+export function checkTeamsApiMetadata (root, options = {}) {
+  const normalizedRoot = path.resolve(root)
+  if (!fs.existsSync(path.join(normalizedRoot, packageManifestPath))) return []
+
+  /** @type {MetadataFinding[]} */
+  const findings = []
+  const packageManifest = readJsonFile(normalizedRoot, packageManifestPath, findings, 'usage')
+  const manifest = readJsonFile(normalizedRoot, manifestPath, findings, 'usage')
+  const capabilities = readYamlFile(normalizedRoot, capabilitiesPath, findings)
+  if (!packageManifest || !manifest || !capabilities) return findings
+
+  validateDocumentShapes(manifest, capabilities, findings)
+  if (!Array.isArray(manifest.usages) || !isCapabilitiesRecord(capabilities.capabilities)) return findings
+
+  const sourceFiles = walkSourceFiles(normalizedRoot)
+  const imports = sourceFiles.flatMap(file => collectTeamsImports(file, fs.readFileSync(path.join(normalizedRoot, packagePath, file), 'utf8')))
+  validateManifestState(normalizedRoot, packageManifest, manifest, sourceFiles, imports, findings)
+  validateCapabilityState(sourceFiles, imports, capabilities, findings)
+  const program = createTeamsProgram(normalizedRoot)
+  if (program) {
+    validatePublicExposure(normalizedRoot, manifest, findings, program)
+    validateStaticMembers(normalizedRoot, manifest, findings, program)
+  }
+
+  const git = collectGitChanges(normalizedRoot, options.baseRef)
+  if (git) validateChangeReviews(normalizedRoot, git, manifest, capabilities, imports, findings)
+
+  return findings
+}
+
+function validateDocumentShapes (manifest, capabilities, findings) {
+  if (manifest.dependency !== dependency || !Array.isArray(manifest.usages)) {
+    add(findings, 'usage-stale', manifestPath, `Usage manifest must describe ${dependency} and contain a usages array.`, `Set dependency to "${dependency}" and restore the usages array.`)
+  }
+  if (capabilities.schemaVersion !== 1 || capabilities.dependency?.package !== dependency || !isCapabilitiesRecord(capabilities.capabilities)) {
+    add(findings, 'capabilities-stale', capabilitiesPath, `Capabilities metadata must be a schemaVersion 1 map for ${dependency}.`, `Restore schemaVersion, dependency.package, and the capabilities map for ${dependency}.`)
+  }
+  validateReview(manifest.sourceReview, 'no-usage-metadata-change', manifestPath, 'usage', findings)
+  validateReview(capabilities.sourceReview, 'no-capability-metadata-change', capabilitiesPath, 'capabilities', findings)
+}
+
+function validateReview (review, expectedOutcome, file, kind, findings) {
+  if (review === undefined) return
+  if (!review || review.outcome !== expectedOutcome || typeof review.reason !== 'string' || review.reason.trim() === '') {
+    add(findings, `${kind}-stale`, file, `sourceReview must use outcome "${expectedOutcome}" and include a non-empty reason.`, 'Correct sourceReview or remove it when the document contains a substantive metadata update.')
+  }
+}
+
+function validateManifestState (root, packageManifest, manifest, sourceFiles, imports, findings) {
+  const declaredRange = packageManifest.dependencies?.[dependency]
+  const declaredVersion = typeof declaredRange === 'string' ? declaredRange.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0] : undefined
+  if (!declaredVersion || manifest.declaredVersion !== declaredVersion) {
+    add(findings, 'usage-stale', manifestPath, `declaredVersion must match package.json (${declaredVersion ?? 'missing dependency version'}).`, `Set declaredVersion to ${JSON.stringify(declaredVersion ?? '<package dependency version>')}.`)
+  }
+  if (manifest.sourceRoot !== 'src') {
+    add(findings, 'usage-stale', manifestPath, 'sourceRoot must be "src" for Teams extension source paths.', 'Set sourceRoot to "src".')
+  }
+
+  const sourceSet = new Set(sourceFiles)
+  for (const usage of manifest.usages) {
+    if (!usage || typeof usage.upstreamSymbol !== 'string' || typeof usage.usage !== 'string' || !Array.isArray(usage.files)) {
+      add(findings, 'usage-stale', manifestPath, 'Every usage must include upstreamSymbol, usage, and a files array.', 'Repair the malformed usage entry.')
+      continue
+    }
+    for (const file of usage.files) {
+      if (typeof file !== 'string' || !file.startsWith('src/') || !sourceSet.has(normalize(file))) {
+        add(findings, 'usage-stale', manifestPath, `Usage ${usage.upstreamSymbol} references missing or unsafe source file ${JSON.stringify(file)}.`, 'Remove the stale path or replace it with an existing file under src/.', usage.upstreamSymbol)
+      }
+    }
+  }
+
+  for (const imported of imports) {
+    const covered = manifest.usages.some(usage => usage.upstreamSymbol === imported.symbol && usage.files?.some(file => normalize(file) === imported.file))
+    if (!covered) {
+      add(findings, 'usage-stale', `${packagePath}/${imported.file}`, `Direct ${dependency} import ${imported.symbol} is absent from the usage manifest for this file.`, `Add ${imported.symbol} and ${imported.file} to ${manifestPath}.`, imported.symbol, imported.line)
+    }
+  }
+}
+
+function validateCapabilityState (sourceFiles, imports, capabilities, findings) {
+  for (const [name, capability] of Object.entries(capabilities.capabilities)) {
+    if (!Array.isArray(capability.owners) || !Array.isArray(capability.upstreamAreas) || typeof capability.adoptionPolicy !== 'string') {
+      add(findings, 'capabilities-stale', capabilitiesPath, `Capability ${name} must include owners, upstreamAreas, and adoptionPolicy.`, `Repair the ${name} capability metadata.`, name)
+      continue
+    }
+    for (const owner of capability.owners) {
+      if (typeof owner !== 'string' || !sourceFiles.some(file => matchesOwner(owner, file))) {
+        add(findings, 'capabilities-stale', capabilitiesPath, `Capability ${name} owner pattern ${JSON.stringify(owner)} matches no source files.`, `Update or remove the stale owner pattern from ${name}.`, name)
+      }
+    }
+  }
+
+  for (const imported of imports) {
+    const areas = upstreamAreasFor(imported.symbol)
+    if (areas.length === 0) continue
+    const owners = capabilitiesForFile(capabilities, imported.file)
+    if (owners.length === 0) {
+      add(findings, 'capabilities-stale', `${packagePath}/${imported.file}`, `${imported.symbol} maps to ${areas.join(', ')} but this source file has no capability owner.`, `Add ${imported.file} to the appropriate capability owners in ${capabilitiesPath}.`, imported.symbol, imported.line)
+      continue
+    }
+    if (!owners.some(([, capability]) => capability.upstreamAreas.some(area => areas.some(candidate => candidate === area || candidate.startsWith(`${area}.`))))) {
+      add(findings, 'capabilities-stale', `${packagePath}/${imported.file}`, `${imported.symbol} maps to ${areas.join(', ')}, which is absent from this file's owning capabilities.`, `Add the appropriate upstream area to ${owners.map(([name]) => name).join(' or ')} in ${capabilitiesPath}.`, imported.symbol, imported.line)
+    }
+  }
+}
+
+function createTeamsProgram (root) {
+  const configPath = path.join(root, packagePath, 'tsconfig.json')
+  const config = ts.readConfigFile(configPath, ts.sys.readFile)
+  if (config.error) return undefined
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath), { noEmit: true }, configPath)
+  return ts.createProgram({ rootNames: parsed.fileNames, options: parsed.options })
+}
+
+function validatePublicExposure (root, manifest, findings, program) {
+  const checker = program.getTypeChecker()
+  const entrypoint = program.getSourceFile(path.join(root, packagePath, 'src/index.ts'))
+  const moduleSymbol = entrypoint && checker.getSymbolAtLocation(entrypoint)
+  if (!entrypoint || !moduleSymbol) return
+
+  /** @type {Map<string, Set<string>>} */
+  const exposed = new Map()
+  const exportedSymbols = new Set(checker.getExportsOfModule(moduleSymbol).map(exported => exported.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(exported) : exported))
+  for (const symbol of exportedSymbols) {
+    for (const declaration of symbol.declarations ?? []) {
+      const sourceFile = declaration.getSourceFile()
+      if (!normalize(sourceFile.fileName).includes(`/${packagePath}/src/`)) continue
+      const relativeFile = normalize(path.relative(path.join(root, packagePath), sourceFile.fileName))
+      visitPublicTypes(declaration, checker, exportedSymbols, upstreamSymbol => {
+        const files = exposed.get(upstreamSymbol) ?? new Set()
+        files.add(relativeFile)
+        exposed.set(upstreamSymbol, files)
+      })
+    }
+  }
+
+  for (const [upstreamSymbol, files] of exposed) {
+    const usages = manifest.usages.filter(usage => usage.upstreamSymbol === upstreamSymbol)
+    if (usages.length === 0) continue
+    if (!usages.some(usage => usage.exposure === 'publicly-exposed' || usage.exposure === 're-exported')) {
+      add(findings, 'usage-stale', manifestPath, `${upstreamSymbol} appears in the package public API but is not marked publicly exposed.`, `Set exposure to "publicly-exposed" on the ${upstreamSymbol} usage entry.`, upstreamSymbol)
+    }
+    for (const file of files) {
+      if (!usages.some(usage => usage.files.some(candidate => normalize(candidate) === file))) {
+        add(findings, 'usage-stale', `${packagePath}/${file}`, `Public ${upstreamSymbol} exposure is absent from the usage manifest for this file.`, `Add ${file} to the publicly exposed ${upstreamSymbol} usage entry.`, upstreamSymbol)
+      }
+    }
+  }
+  for (const usage of manifest.usages) {
+    if ((usage.exposure === 'publicly-exposed' || usage.exposure === 're-exported') && !exposed.has(usage.upstreamSymbol)) {
+      add(findings, 'usage-stale', manifestPath, `${usage.upstreamSymbol} is marked ${usage.exposure} but no longer appears in the package public API.`, `Update or remove the stale exposure for ${usage.upstreamSymbol}.`, usage.upstreamSymbol)
+    }
+  }
+}
+
+function visitPublicTypes (declaration, checker, exportedSymbols, onUpstreamSymbol) {
+  const visitedSymbols = new Set()
+  function visit (node) {
+    if (ts.isBlock(node) || ts.isExpressionStatement(node) || ts.isImportDeclaration(node)) return
+    if (ts.isClassElement(node) && hasModifier(node, ts.SyntaxKind.PrivateKeyword)) return
+    if (ts.isTypeReferenceNode(node)) {
+      const identifier = ts.isIdentifier(node.typeName) ? node.typeName : node.typeName.right
+      const symbol = checker.getSymbolAtLocation(identifier)
+      const target = symbol && (symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol)
+      if (target && comesFromTeamsApi(target)) onUpstreamSymbol(target.getName())
+      else if (target && !exportedSymbols.has(target) && !visitedSymbols.has(target) && (target.declarations ?? []).some(candidate => normalize(candidate.getSourceFile().fileName).includes(`/${packagePath}/src/`))) {
+        visitedSymbols.add(target)
+        for (const candidate of target.declarations ?? []) visit(candidate)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(declaration)
+}
+
+function validateStaticMembers (root, manifest, findings, program) {
+  const checker = program.getTypeChecker()
+  /** @type {Set<string>} */
+  const reported = new Set()
+
+  for (const sourceFile of program.getSourceFiles()) {
+    const normalizedFile = normalize(sourceFile.fileName)
+    if (!normalizedFile.includes(`/${packagePath}/src/`)) continue
+    const relativeFile = normalize(path.relative(path.join(root, packagePath), sourceFile.fileName))
+    function visit (node) {
+      if (ts.isPropertyAccessExpression(node)) {
+        const access = propertyAccess(node, checker)
+        if (access) {
+          const usages = manifest.usages.filter(usage => usage.upstreamSymbol === access.symbol && usage.files.some(file => normalize(file) === relativeFile))
+          if (usages.length > 0) {
+            const declared = access.kind === 'method'
+              ? usages.flatMap(usage => usage.methodsCalled ?? [])
+              : usages.flatMap(usage => [...(usage.propertiesRead ?? []), ...(usage.propertiesWritten ?? []), ...(usage.propertiesValidated ?? [])])
+            const covered = declared.some(candidate => candidate === access.path || candidate.replace(/\[\]/g, '').split('.')[0] === access.path.split('.')[0])
+            const key = `${relativeFile}:${access.symbol}:${access.kind}:${access.path}`
+            if (!covered && !reported.has(key)) {
+              reported.add(key)
+              const field = access.kind === 'method' ? 'methodsCalled' : access.kind === 'write' ? 'propertiesWritten' : 'propertiesRead'
+              add(findings, 'usage-stale', `${packagePath}/${relativeFile}`, `${access.symbol}.${access.path} is statically ${access.kind === 'method' ? 'called' : access.kind === 'write' ? 'written' : 'read'} but absent from the usage manifest.`, `Add ${JSON.stringify(access.path)} to ${field} for ${access.symbol}.`, access.symbol, sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1)
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sourceFile)
+  }
+}
+
+function propertyAccess (node, checker) {
+  const segments = [node.name.text]
+  let expression = node.expression
+  while (ts.isPropertyAccessExpression(expression)) {
+    segments.unshift(expression.name.text)
+    expression = expression.expression
+  }
+  const type = checker.getTypeAtLocation(expression)
+  const symbol = upstreamTypeSymbol(type)
+  if (!symbol) return undefined
+  const parent = node.parent
+  const method = ts.isCallExpression(parent) && parent.expression === node
+  if (method && segments.length > 1) return undefined
+  const write = ts.isBinaryExpression(parent) && parent.left === node && parent.operatorToken.kind >= ts.SyntaxKind.FirstAssignment && parent.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+  return { symbol, path: segments.join('.'), kind: method ? 'method' : write ? 'write' : 'read' }
+}
+
+function upstreamTypeSymbol (type) {
+  if (type.isUnionOrIntersection?.()) {
+    for (const member of type.types) {
+      const symbol = upstreamTypeSymbol(member)
+      if (symbol) return symbol
+    }
+    return undefined
+  }
+  const symbol = type.aliasSymbol ?? type.symbol
+  return symbol && comesFromTeamsApi(symbol) ? symbol.getName() : undefined
+}
+
+function comesFromTeamsApi (symbol) {
+  return (symbol.declarations ?? []).some(declaration => {
+    const file = normalize(declaration.getSourceFile().fileName)
+    return file.includes('/node_modules/@microsoft/teams.api/')
+  })
+}
+
+function validateChangeReviews (root, git, manifest, capabilities, currentImports, findings) {
+  const baseManifest = readGitJson(root, git.base, manifestPath)
+  const baseCapabilities = readGitYaml(root, git.base, capabilitiesPath)
+  if (!baseManifest || !baseCapabilities) return
+
+  const currentUsageFiles = usageFiles(manifest)
+  const baseUsageFiles = usageFiles(baseManifest)
+  const currentImportFiles = new Set(currentImports.map(item => item.file))
+  const changedSourceFiles = [...git.changedFiles]
+    .filter(file => file.startsWith(sourcePrefix))
+    .map(file => normalize(path.relative(packagePath, file)))
+
+  const usageRelevant = changedSourceFiles.filter(file => currentUsageFiles.has(file) || baseUsageFiles.has(file) || currentImportFiles.has(file) || gitFileImportsTeamsApi(root, git.base, `${packagePath}/${file}`))
+  const removedImportsStillRecorded = changedSourceFiles.flatMap(file => {
+    const currentSymbols = new Set(currentImports.filter(item => item.file === file).map(item => item.symbol))
+    const baseText = readGitFile(root, git.base, `${packagePath}/${file}`)
+    if (baseText === undefined) return []
+    return collectTeamsImports(file, baseText)
+      .filter(item => !currentSymbols.has(item.symbol) && manifest.usages.some(usage => usage.upstreamSymbol === item.symbol && usage.files.some(candidate => normalize(candidate) === file)))
+      .map(item => `${item.symbol} in ${file}`)
+  })
+  const usageReviewFresh = metadataChangeIsFresh(root, git, usageRelevant.map(file => `${packagePath}/${file}`), manifestPath)
+  const explicitUsageReview = reviewChanged(baseManifest.sourceReview, manifest.sourceReview, 'no-usage-metadata-change') && usageReviewFresh
+  let usageReviewReported = false
+  if (removedImportsStillRecorded.length > 0 && !explicitUsageReview) {
+    usageReviewReported = true
+    add(findings, 'usage-review', manifestPath, `Removed direct Teams API import(s) remain recorded in the usage manifest: ${removedImportsStillRecorded.join(', ')}.`, 'Update the affected usage entries, or change sourceReview with outcome "no-usage-metadata-change" and explain why the indirect usage remains.')
+  }
+  if (!usageReviewReported && usageRelevant.length > 0 && (!metadataReviewed(baseManifest, manifest, 'usages', 'no-usage-metadata-change') || !usageReviewFresh)) {
+    add(findings, 'usage-review', manifestPath, `${usageRelevant.length} Teams API usage-related source file(s) changed without a usage-manifest update or non-impact review.`, `Update usages in ${manifestPath}, or change sourceReview with outcome "no-usage-metadata-change" and a specific reason.`, usageRelevant.slice(0, 4).join(', '))
+  }
+
+  const capabilityChanges = changedSourceFiles.map(file => {
+    const currentExists = fs.existsSync(path.join(root, packagePath, file))
+    const baseExists = gitFileExists(root, git.base, `${packagePath}/${file}`)
+    const currentOwners = currentExists ? capabilitiesForFile(capabilities, file).map(([name]) => name).sort() : []
+    const baseOwners = baseExists ? capabilitiesForFile(baseCapabilities, file).map(([name]) => name).sort() : []
+    const currentSymbols = currentImports.filter(item => item.file === file).map(item => item.symbol).sort()
+    const baseText = readGitFile(root, git.base, `${packagePath}/${file}`)
+    const baseSymbols = baseText === undefined ? [] : collectTeamsImports(file, baseText).map(item => item.symbol).sort()
+    return {
+      file,
+      currentExists,
+      baseExists,
+      currentOwners,
+      baseOwners,
+      importChanged: (currentOwners.length > 0 || baseOwners.length > 0) && !isDeepStrictEqual(currentSymbols, baseSymbols)
+    }
+  }).filter(change => change.currentExists !== change.baseExists || !isDeepStrictEqual(change.currentOwners, change.baseOwners) || change.importChanged)
+  const capabilityRelevant = capabilityChanges.map(change => change.file)
+  const capabilityReviewFresh = metadataChangeIsFresh(root, git, capabilityRelevant.map(file => `${packagePath}/${file}`), capabilitiesPath)
+  const explicitCapabilityReview = reviewChanged(baseCapabilities.sourceReview, capabilities.sourceReview, 'no-capability-metadata-change') && capabilityReviewFresh
+  const targetedCapabilitiesUpdate = capabilityReviewFresh && capabilityChanges.every(change => capabilityChangeAddressed(change, baseCapabilities, capabilities))
+  if (capabilityRelevant.length > 0 && !explicitCapabilityReview && !targetedCapabilitiesUpdate) {
+    add(findings, 'capabilities-review', capabilitiesPath, `${capabilityRelevant.length} capability ownership or upstream-area source change(s) lack a targeted capabilities update or non-impact review.`, `Add or remove owner patterns for the affected paths in ${capabilitiesPath}, or change sourceReview with outcome "no-capability-metadata-change" and a specific reason.`, capabilityRelevant.slice(0, 4).join(', '))
+  }
+}
+
+function capabilityChangeAddressed (change, before, after) {
+  if (!change.baseExists && change.currentExists) {
+    return ownerPatternsForFile(after, change.file).some(pattern => !ownerPatternsForFile(before, change.file).includes(pattern))
+  }
+  if (change.baseExists && !change.currentExists) {
+    return ownerPatternsForFile(before, change.file).some(pattern => !ownerPatternsForFile(after, change.file).includes(pattern))
+  }
+  if (!isDeepStrictEqual(change.currentOwners, change.baseOwners)) return true
+  if (!change.importChanged) return false
+  return [...new Set([...change.currentOwners, ...change.baseOwners])].some(name => {
+    const beforeCapability = before.capabilities?.[name]
+    const afterCapability = after.capabilities?.[name]
+    return !isDeepStrictEqual(beforeCapability?.owners, afterCapability?.owners) || !isDeepStrictEqual(beforeCapability?.upstreamAreas, afterCapability?.upstreamAreas)
+  })
+}
+
+function ownerPatternsForFile (document, file) {
+  return Object.values(document.capabilities ?? {}).flatMap(capability => (capability.owners ?? []).filter(owner => matchesOwner(owner, file))).sort()
+}
+
+function metadataReviewed (before, after, substantiveField, expectedOutcome) {
+  if (!isDeepStrictEqual(before[substantiveField], after[substantiveField])) return true
+  return reviewChanged(before.sourceReview, after.sourceReview, expectedOutcome)
+}
+
+function reviewChanged (beforeReview, afterReview, expectedOutcome) {
+  return !isDeepStrictEqual(beforeReview, afterReview) && afterReview?.outcome === expectedOutcome && typeof afterReview.reason === 'string' && afterReview.reason.trim() !== ''
+}
+
+function metadataChangeIsFresh (root, git, sourceFiles, metadataFile) {
+  const normalizedSources = sourceFiles.map(normalize)
+  const metadata = normalize(metadataFile)
+  if (normalizedSources.some(file => git.workingFiles.has(file))) return git.workingFiles.has(metadata)
+  if (git.workingFiles.has(metadata)) return true
+  const sourceCommit = latestCommitFor(root, git.base, normalizedSources)
+  const metadataCommit = latestCommitFor(root, git.base, [metadata])
+  return Boolean(sourceCommit && metadataCommit && (sourceCommit === metadataCommit || gitSucceeds(root, ['merge-base', '--is-ancestor', sourceCommit, metadataCommit])))
+}
+
+function latestCommitFor (root, base, files) {
+  return gitText(root, ['log', '-1', '--format=%H', `${base}..HEAD`, '--', ...files])?.trim()
+}
+
+function collectGitChanges (root, explicitBaseRef) {
+  if (!gitSucceeds(root, ['rev-parse', '--is-inside-work-tree'])) return undefined
+  const baseRef = resolveBaseRef(root, explicitBaseRef)
+  const base = gitText(root, ['merge-base', 'HEAD', baseRef])?.trim()
+  if (!base) {
+    if (explicitBaseRef) throw new Error(`Unable to resolve Git base ref ${explicitBaseRef}.`)
+    return undefined
+  }
+  const committedFiles = new Set(gitNullList(root, ['diff', '--name-only', '--no-renames', '-z', base, 'HEAD']).map(normalize))
+  const workingFiles = new Set([
+    ...gitNullList(root, ['diff', '--name-only', '--no-renames', '-z', 'HEAD']),
+    ...gitNullList(root, ['ls-files', '--others', '--exclude-standard', '-z'])
+  ].map(normalize))
+  return { base, committedFiles, workingFiles, changedFiles: new Set([...committedFiles, ...workingFiles]) }
+}
+
+function resolveBaseRef (root, explicit) {
+  const candidates = []
+  if (explicit) candidates.push(explicit)
+  else if (process.env.GITHUB_BASE_REF) candidates.push(`origin/${process.env.GITHUB_BASE_REF}`, process.env.GITHUB_BASE_REF)
+  else if (process.env.SYSTEM_PULLREQUEST_TARGETBRANCH) {
+    const branch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH.replace(/^refs\/heads\//, '')
+    candidates.push(`origin/${branch}`, branch, process.env.SYSTEM_PULLREQUEST_TARGETBRANCH)
+  }
+  if (!explicit) candidates.push('origin/main', 'upstream/main', 'main', 'HEAD')
+  return candidates.find(candidate => gitSucceeds(root, ['rev-parse', '--verify', `${candidate}^{commit}`])) ?? explicit ?? 'HEAD'
+}
+
+function gitText (root, args) {
+  try {
+    return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] })
+  } catch {
+    return undefined
+  }
+}
+
+function gitSucceeds (root, args) { return gitText(root, args) !== undefined }
+function gitNullList (root, args) { return (gitText(root, args) ?? '').split('\0').filter(Boolean) }
+function readGitFile (root, base, file) { return gitText(root, ['show', `${base}:${normalize(file)}`]) }
+function gitFileExists (root, base, file) { return readGitFile(root, base, file) !== undefined }
+function gitFileImportsTeamsApi (root, base, file) { const text = readGitFile(root, base, file) ?? ''; return text.includes(`from '${dependency}'`) || text.includes(`from "${dependency}"`) }
+function readGitJson (root, base, file) { const text = readGitFile(root, base, file); try { return text === undefined ? undefined : JSON.parse(text) } catch { return undefined } }
+function readGitYaml (root, base, file) { const text = readGitFile(root, base, file); try { return text === undefined ? undefined : parseYaml(text) } catch { return undefined } }
+
+function readJsonFile (root, file, findings, kind) {
+  if (!fs.existsSync(path.join(root, file))) {
+    add(findings, `${kind}-stale`, file, 'Required Teams API metadata file is missing.', `Restore ${file}.`)
+    return undefined
+  }
+  try { return JSON.parse(fs.readFileSync(path.join(root, file), 'utf8')) } catch (error) {
+    add(findings, `${kind}-stale`, file, `Unable to parse JSON: ${error instanceof Error ? error.message : String(error)}`, `Correct the JSON syntax in ${file}.`)
+    return undefined
+  }
+}
+
+function readYamlFile (root, file, findings) {
+  if (!fs.existsSync(path.join(root, file))) {
+    add(findings, 'capabilities-stale', file, 'Required Teams API capabilities file is missing.', `Restore ${file}.`)
+    return undefined
+  }
+  try { return parseYaml(fs.readFileSync(path.join(root, file), 'utf8')) } catch (error) {
+    add(findings, 'capabilities-stale', file, `Unable to parse YAML: ${error instanceof Error ? error.message : String(error)}`, `Correct the YAML syntax in ${file}.`)
+    return undefined
+  }
+}
+
+function collectTeamsImports (file, text) {
+  const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  /** @type {TeamsImport[]} */
+  const imports = []
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier) || statement.moduleSpecifier.text !== dependency) continue
+    const clause = statement.importClause
+    if (!clause?.namedBindings || !ts.isNamedImports(clause.namedBindings)) continue
+    for (const specifier of clause.namedBindings.elements) {
+      imports.push({
+        symbol: specifier.propertyName?.text ?? specifier.name.text,
+        localName: specifier.name.text,
+        typeOnly: clause.isTypeOnly || specifier.isTypeOnly,
+        file: normalize(file),
+        line: source.getLineAndCharacterOfPosition(specifier.getStart(source)).line + 1
+      })
+    }
+  }
+  return imports
+}
+
+function walkSourceFiles (root) {
+  const sourceRoot = path.join(root, packagePath, 'src')
+  if (!fs.existsSync(sourceRoot)) return []
+  const files = []
+  function visit (directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const target = path.join(directory, entry.name)
+      if (entry.isDirectory()) visit(target)
+      else if (entry.isFile() && entry.name.endsWith('.ts')) files.push(normalize(path.relative(path.join(root, packagePath), target)))
+    }
+  }
+  visit(sourceRoot)
+  return files.sort()
+}
+
+function capabilitiesForFile (document, file) {
+  return Object.entries(document.capabilities ?? {}).filter(([, capability]) => Array.isArray(capability.owners) && capability.owners.some(owner => matchesOwner(owner, file)))
+}
+
+function matchesOwner (pattern, file) {
+  if (typeof pattern !== 'string') return false
+  const expression = '^' + normalize(pattern).split(/(\*\*|\*)/).map(part => part === '**' ? '.*' : part === '*' ? '[^/]*' : escapeRegExp(part)).join('') + '$'
+  return new RegExp(expression).test(normalize(file))
+}
+
+function upstreamAreasFor (symbol) {
+  if (symbol === 'Client') return ['clients']
+  if (symbol.endsWith('Client')) return [`clients.${symbol.slice(0, -'Client'.length).toLowerCase()}`]
+  if (symbol === 'ChannelData') return ['models.channel-data']
+  if (symbol === 'ChannelInfo') return ['models.channel-data.channel-info']
+  if (symbol === 'TeamInfo') return ['models.channel-data.team-info']
+  if (symbol.startsWith('Meeting')) return ['models.meeting']
+  if (symbol.startsWith('MessagingExtension')) return ['models.messaging-extension']
+  if (symbol.startsWith('TaskModule')) return ['models.task-module']
+  if (symbol.startsWith('File')) return ['models.file']
+  if (symbol.startsWith('Config')) return ['models.config']
+  return []
+}
+
+function usageFiles (manifest) { return new Set((manifest.usages ?? []).flatMap(usage => usage.files ?? []).map(normalize)) }
+function isCapabilitiesRecord (value) { return value && typeof value === 'object' && !Array.isArray(value) }
+function hasModifier (node, kind) { return Boolean(ts.getModifiers(node)?.some(modifier => modifier.kind === kind)) }
+function normalize (value) { return String(value).replaceAll('\\', '/').replace(/^\.\//, '') }
+function escapeRegExp (value) { return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') }
+
+function add (findings, kind, file, message, fix, subject, line = 0) {
+  const ruleId = {
+    'usage-stale': 'compat/teams-api-usage-manifest-stale',
+    'usage-review': 'compat/teams-api-usage-review-missing',
+    'capabilities-stale': 'compat/teams-api-capabilities-stale',
+    'capabilities-review': 'compat/teams-api-capabilities-review-missing'
+  }[kind]
+  findings.push({ ruleId, path: normalize(file), message, fix, line, column: line > 0 ? 1 : 0, ...(subject ? { subject } : {}) })
+}

--- a/scripts/teams-api-drift/validate-teams-api-metadata.mjs
+++ b/scripts/teams-api-drift/validate-teams-api-metadata.mjs
@@ -15,6 +15,7 @@ const manifestPath = `${packagePath}/teams-api-usage-manifest.json`
 const capabilitiesPath = `${packagePath}/config/teams-capabilities.yaml`
 const packageManifestPath = `${packagePath}/package.json`
 const sourcePrefix = `${packagePath}/src/`
+const sourceReviewGuide = 'scripts/teams-api-drift/README.md#source-review-acknowledgments'
 
 /** @typedef {{ upstreamSymbol: string, usage: string, usageKinds?: string[], exposure?: string, methodsCalled?: string[], propertiesRead?: string[], propertiesValidated?: string[], propertiesWritten?: string[], files: string[] }} Usage */
 /** @typedef {{ dependency: string, declaredVersion?: string, sourceRoot?: string, usages: Usage[], sourceReview?: { outcome?: string, reason?: string } }} UsageManifest */
@@ -73,7 +74,7 @@ function validateDocumentShapes (manifest, capabilities, findings) {
 function validateReview (review, expectedOutcome, file, kind, findings) {
   if (review === undefined) return
   if (!review || review.outcome !== expectedOutcome || typeof review.reason !== 'string' || review.reason.trim() === '') {
-    add(findings, `${kind}-stale`, file, `sourceReview must use outcome "${expectedOutcome}" and include a non-empty reason.`, 'Correct sourceReview or remove it when the document contains a substantive metadata update.')
+    add(findings, `${kind}-stale`, file, `sourceReview must use outcome "${expectedOutcome}" and include a non-empty reason.`, `Correct sourceReview or remove it when the document contains a substantive metadata update. See ${sourceReviewGuide}.`)
   }
 }
 
@@ -300,10 +301,10 @@ function validateChangeReviews (root, git, manifest, capabilities, currentImport
   let usageReviewReported = false
   if (removedImportsStillRecorded.length > 0 && !explicitUsageReview) {
     usageReviewReported = true
-    add(findings, 'usage-review', manifestPath, `Removed direct Teams API import(s) remain recorded in the usage manifest: ${removedImportsStillRecorded.join(', ')}.`, 'Update the affected usage entries, or change sourceReview with outcome "no-usage-metadata-change" and explain why the indirect usage remains.')
+    add(findings, 'usage-review', manifestPath, `Removed direct Teams API import(s) remain recorded in the usage manifest: ${removedImportsStillRecorded.join(', ')}.`, `Update the affected usage entries, or follow ${sourceReviewGuide} and explain why the indirect usage remains.`)
   }
   if (!usageReviewReported && usageRelevant.length > 0 && (!metadataReviewed(baseManifest, manifest, 'usages', 'no-usage-metadata-change') || !usageReviewFresh)) {
-    add(findings, 'usage-review', manifestPath, `${usageRelevant.length} Teams API usage-related source file(s) changed without a usage-manifest update or non-impact review.`, `Update usages in ${manifestPath}, or change sourceReview with outcome "no-usage-metadata-change" and a specific reason.`, usageRelevant.slice(0, 4).join(', '))
+    add(findings, 'usage-review', manifestPath, `${usageRelevant.length} Teams API usage-related source file(s) changed without a usage-manifest update or non-impact review.`, `Update usages in ${manifestPath}, or follow ${sourceReviewGuide}.`, usageRelevant.slice(0, 4).join(', '))
   }
 
   const capabilityChanges = changedSourceFiles.map(file => {
@@ -328,7 +329,7 @@ function validateChangeReviews (root, git, manifest, capabilities, currentImport
   const explicitCapabilityReview = reviewChanged(baseCapabilities.sourceReview, capabilities.sourceReview, 'no-capability-metadata-change') && capabilityReviewFresh
   const targetedCapabilitiesUpdate = capabilityReviewFresh && capabilityChanges.every(change => capabilityChangeAddressed(change, baseCapabilities, capabilities))
   if (capabilityRelevant.length > 0 && !explicitCapabilityReview && !targetedCapabilitiesUpdate) {
-    add(findings, 'capabilities-review', capabilitiesPath, `${capabilityRelevant.length} capability ownership or upstream-area source change(s) lack a targeted capabilities update or non-impact review.`, `Add or remove owner patterns for the affected paths in ${capabilitiesPath}, or change sourceReview with outcome "no-capability-metadata-change" and a specific reason.`, capabilityRelevant.slice(0, 4).join(', '))
+    add(findings, 'capabilities-review', capabilitiesPath, `${capabilityRelevant.length} capability ownership or upstream-area source change(s) lack a targeted capabilities update or non-impact review.`, `Add or remove owner patterns for the affected paths in ${capabilitiesPath}, or follow ${sourceReviewGuide}.`, capabilityRelevant.slice(0, 4).join(', '))
   }
 }
 

--- a/scripts/test/repo-doctor.test.mjs
+++ b/scripts/test/repo-doctor.test.mjs
@@ -347,10 +347,12 @@ describe('repo:doctor', () => {
 
   it('parses supported CLI arguments', () => {
     assert.deepEqual(parseArguments(['--root', 'fixture']), { help: false, rules: false, ruleIds: [], root: 'fixture' })
+    assert.deepEqual(parseArguments(['--base-ref', 'origin/release/v1.3']), { help: false, rules: false, ruleIds: [], root: process.cwd(), baseRef: 'origin/release/v1.3' })
     assert.deepEqual(parseArguments(['--rules']), { help: false, rules: true, ruleIds: [], root: process.cwd() })
     assert.deepEqual(parseArguments(['--rules', 'package/private', 'docs/relative-link-missing']), { help: false, rules: true, ruleIds: ['package/private', 'docs/relative-link-missing'], root: process.cwd() })
     assert.throws(() => parseArguments(['--rules', 'missing/rule']), /Unknown rule ID/)
     assert.throws(() => parseArguments(['--format', 'json']), /Unknown argument/)
+    assert.throws(() => parseArguments(['--base-ref']), /requires a Git ref/)
     assert.throws(() => parseArguments(['--wat']), /Unknown argument/)
   })
 

--- a/scripts/test/teams-api-metadata.test.mjs
+++ b/scripts/test/teams-api-metadata.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+
+import { checkTeamsApiMetadata } from '../teams-api-drift/validate-teams-api-metadata.mjs'
+
+const packagePath = 'packages/agents-hosting-extensions-msteams'
+const roots = []
+
+function fixture ({ git = false } = {}) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'teams-api-metadata-'))
+  roots.push(root)
+  const write = (file, value) => {
+    mkdirSync(path.dirname(path.join(root, file)), { recursive: true })
+    writeFileSync(path.join(root, file), value)
+  }
+  const read = file => readFileSync(path.join(root, file), 'utf8')
+  const readJson = file => JSON.parse(read(file))
+  const writeJson = (file, value) => write(file, `${JSON.stringify(value, undefined, 2)}\n`)
+  const runGit = (...args) => {
+    const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' })
+    assert.equal(result.status, 0, result.stderr)
+  }
+
+  writeJson(`${packagePath}/package.json`, {
+    name: '@microsoft/agents-hosting-extensions-msteams',
+    type: 'module',
+    dependencies: { '@microsoft/teams.api': '2.0.14' }
+  })
+  writeJson(`${packagePath}/tsconfig.json`, {
+    compilerOptions: { module: 'node16', moduleResolution: 'node16', strict: true, skipLibCheck: true },
+    include: ['src/**/*.ts']
+  })
+  writeJson('node_modules/@microsoft/teams.api/package.json', { name: '@microsoft/teams.api', version: '2.0.14', type: 'module', types: 'index.d.ts' })
+  write('node_modules/@microsoft/teams.api/index.d.ts', 'export interface ChannelData { eventType?: string }\nexport declare class Client { send(): void }\n')
+  write(`${packagePath}/src/index.ts`, "export * from './teamsActivity.js'\n")
+  write(`${packagePath}/src/teamsActivity.ts`, "import type { ChannelData as TeamsChannelData } from '@microsoft/teams.api'\nexport function eventType(data: TeamsChannelData): string | undefined { return data.eventType }\n")
+  writeJson(`${packagePath}/teams-api-usage-manifest.json`, {
+    dependency: '@microsoft/teams.api',
+    declaredVersion: '2.0.14',
+    sourceRoot: 'src',
+    usages: [{
+      upstreamSymbol: 'ChannelData',
+      usage: 'parsed-model',
+      exposure: 'publicly-exposed',
+      propertiesRead: ['eventType'],
+      files: ['src/teamsActivity.ts']
+    }]
+  })
+  write(`${packagePath}/config/teams-capabilities.yaml`, `schemaVersion: 1
+dependency:
+  package: "@microsoft/teams.api"
+capabilities:
+  activity-data:
+    owners:
+      - "src/**"
+    upstreamAreas:
+      - "models.channel-data"
+    adoptionPolicy: "strict-compatibility"
+`)
+
+  if (git) {
+    runGit('init', '-b', 'main')
+    runGit('config', 'user.email', 'repo-doctor@example.test')
+    runGit('config', 'user.name', 'Repo Doctor')
+    runGit('add', '.')
+    runGit('commit', '-m', 'baseline')
+  }
+
+  return { root, write, read, readJson, writeJson, runGit }
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function rules (root, options) {
+  return checkTeamsApiMetadata(root, options).map(finding => finding.ruleId)
+}
+
+describe('Teams API metadata validation', () => {
+  it('accepts aligned imports, members, public exposure, and capability ownership', () => {
+    assert.deepEqual(checkTeamsApiMetadata(fixture().root), [])
+  })
+
+  it('detects missing aliased imports, stale files, and dependency versions', () => {
+    const repo = fixture()
+    const manifest = repo.readJson(`${packagePath}/teams-api-usage-manifest.json`)
+    manifest.declaredVersion = '2.0.13'
+    manifest.usages[0].upstreamSymbol = 'OtherSymbol'
+    manifest.usages[0].files.push('src/missing.ts')
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+
+    const findings = checkTeamsApiMetadata(repo.root)
+    assert.equal(findings.some(finding => finding.message.includes('declaredVersion')), true)
+    assert.equal(findings.some(finding => finding.message.includes('Direct @microsoft/teams.api import ChannelData')), true)
+    assert.equal(findings.some(finding => finding.message.includes('src/missing.ts')), true)
+  })
+
+  it('detects statically resolved members and public exposure missing from the manifest', () => {
+    const repo = fixture()
+    const manifest = repo.readJson(`${packagePath}/teams-api-usage-manifest.json`)
+    delete manifest.usages[0].propertiesRead
+    delete manifest.usages[0].exposure
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+
+    const findings = checkTeamsApiMetadata(repo.root)
+    assert.equal(findings.some(finding => finding.message.includes('ChannelData.eventType is statically read')), true)
+    assert.equal(findings.some(finding => finding.message.includes('not marked publicly exposed')), true)
+  })
+
+  it('detects statically resolved Teams API method calls', () => {
+    const repo = fixture()
+    repo.write(`${packagePath}/src/teamsActivity.ts`, "import type { ChannelData as TeamsChannelData } from '@microsoft/teams.api'\nimport { Client as TeamsClient } from '@microsoft/teams.api'\nexport function eventType(data: TeamsChannelData): string | undefined { return data.eventType }\nexport function send(client: TeamsClient): void { client.send() }\n")
+    const manifest = repo.readJson(`${packagePath}/teams-api-usage-manifest.json`)
+    manifest.usages.push({ upstreamSymbol: 'Client', usage: 'type-reference', exposure: 'publicly-exposed', files: ['src/teamsActivity.ts'] })
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, repo.read(`${packagePath}/config/teams-capabilities.yaml`).replace('      - "models.channel-data"', '      - "models.channel-data"\n      - "clients"'))
+
+    assert.equal(checkTeamsApiMetadata(repo.root).some(finding => finding.message.includes('Client.send is statically called')), true)
+  })
+
+  it('detects invalid capability owners and confidently mismatched upstream areas', () => {
+    const repo = fixture()
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, `schemaVersion: 1
+dependency:
+  package: "@microsoft/teams.api"
+capabilities:
+  activity-data:
+    owners:
+      - "src/missing/**"
+    upstreamAreas:
+      - "models.meeting"
+    adoptionPolicy: "strict-compatibility"
+`)
+    const findings = checkTeamsApiMetadata(repo.root)
+    assert.equal(findings.some(finding => finding.message.includes('matches no source files')), true)
+    assert.equal(findings.some(finding => finding.message.includes('has no capability owner')), true)
+  })
+
+  it('requires a usage-specific review and does not accept a capabilities-only change', () => {
+    const repo = fixture({ git: true })
+    repo.write(`${packagePath}/src/teamsActivity.ts`, `${repo.read(`${packagePath}/src/teamsActivity.ts`)}// implementation-only refactor\n`)
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, `${repo.read(`${packagePath}/config/teams-capabilities.yaml`)}\n`)
+
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-usage-review-missing'), true)
+  })
+
+  it('does not let unrelated manifest edits hide a removed direct import', () => {
+    const repo = fixture({ git: true })
+    repo.write(`${packagePath}/src/teamsActivity.ts`, 'export function eventType(data) { return data.eventType }\n')
+    const manifest = repo.readJson(`${packagePath}/teams-api-usage-manifest.json`)
+    manifest.usages[0].usageKinds = ['parsed-model']
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+
+    let findings = checkTeamsApiMetadata(repo.root, { baseRef: 'main' })
+    assert.equal(findings.some(finding => finding.message.includes('Removed direct Teams API import(s) remain recorded')), true)
+    assert.equal(findings.some(finding => finding.message.includes('marked publicly-exposed but no longer appears')), true)
+
+    manifest.usages[0].exposure = 'internal-only'
+    manifest.sourceReview = { outcome: 'no-usage-metadata-change', reason: 'The payload remains consumed dynamically.' }
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+    findings = checkTeamsApiMetadata(repo.root, { baseRef: 'main' })
+    assert.equal(findings.some(finding => finding.ruleId === 'compat/teams-api-usage-review-missing'), false)
+  })
+
+  it('accepts a changed, valid usage non-impact review and rejects empty or stale reviews', () => {
+    const repo = fixture({ git: true })
+    repo.write(`${packagePath}/src/teamsActivity.ts`, `${repo.read(`${packagePath}/src/teamsActivity.ts`)}// implementation-only refactor\n`)
+    const manifest = repo.readJson(`${packagePath}/teams-api-usage-manifest.json`)
+    manifest.sourceReview = { outcome: 'no-usage-metadata-change', reason: 'Only a comment changed.' }
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-usage-review-missing'), false)
+
+    manifest.sourceReview.reason = ''
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-usage-manifest-stale'), true)
+
+    manifest.sourceReview.reason = 'Only a comment changed.'
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+    repo.runGit('add', '.')
+    repo.runGit('commit', '-m', 'reviewed source change')
+    repo.write(`${packagePath}/src/teamsActivity.ts`, `${repo.read(`${packagePath}/src/teamsActivity.ts`)}// another refactor\n`)
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-usage-review-missing'), true)
+  })
+
+  it('requires capability review for structural source changes and accepts its own acknowledgment', () => {
+    const repo = fixture({ git: true })
+    repo.write(`${packagePath}/src/newFeature.ts`, 'export const enabled = true\n')
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-capabilities-review-missing'), true)
+
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, `${repo.read(`${packagePath}/config/teams-capabilities.yaml`)}\n`)
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-capabilities-review-missing'), true)
+
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, repo.read(`${packagePath}/config/teams-capabilities.yaml`).replace('  activity-data:\n', '  activity-data:\n    description: "Unrelated metadata edit"\n'))
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-capabilities-review-missing'), true)
+
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, repo.read(`${packagePath}/config/teams-capabilities.yaml`).replace('      - "src/**"', '      - "src/**"\n      - "src/newFeature.ts"'))
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-capabilities-review-missing'), false)
+
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, repo.read(`${packagePath}/config/teams-capabilities.yaml`).replace('      - "src/newFeature.ts"\n', ''))
+    repo.write(`${packagePath}/config/teams-capabilities.yaml`, `${repo.read(`${packagePath}/config/teams-capabilities.yaml`)}sourceReview:
+  outcome: "no-capability-metadata-change"
+  reason: "The new helper remains part of activity-data."
+`)
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-capabilities-review-missing'), false)
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-usage-review-missing'), false)
+  })
+
+  it('accepts reviews committed after the source change across a multi-commit branch', () => {
+    const repo = fixture({ git: true })
+    repo.runGit('checkout', '-b', 'feature')
+    repo.write(`${packagePath}/src/teamsActivity.ts`, `${repo.read(`${packagePath}/src/teamsActivity.ts`)}// refactor\n`)
+    repo.runGit('add', '.')
+    repo.runGit('commit', '-m', 'change source')
+    const manifest = repo.readJson(`${packagePath}/teams-api-usage-manifest.json`)
+    manifest.sourceReview = { outcome: 'no-usage-metadata-change', reason: 'No Teams API usage changed.' }
+    repo.writeJson(`${packagePath}/teams-api-usage-manifest.json`, manifest)
+    repo.runGit('add', '.')
+    repo.runGit('commit', '-m', 'review metadata')
+
+    assert.equal(rules(repo.root, { baseRef: 'main' }).includes('compat/teams-api-usage-review-missing'), false)
+  })
+})


### PR DESCRIPTION
## Description
This pull request introduces comprehensive improvements to Teams API drift detection and metadata validation in the repo, focusing on making Teams API usage and capability mapping more robust, reviewable, and maintainable. It adds new documentation, enhances the `repo-doctor` script with new rules and CLI options, and updates metadata files to reflect current API usage and ownership.

**Enhancements to Teams API drift detection and review:**

* Updated `repo-doctor` to:
  - Validate `teams-api-usage-manifest.json` and `teams-capabilities.yaml` for staleness and require explicit source review for ambiguous changes.
  - Accept a new `--base-ref` CLI argument to compare metadata against a specific Git reference, supporting pull request review scenarios. [[1]](diffhunk://#diff-c673027add895632858466fd15ba353b1b1139c53584445a4c9f76a46cd6257bR349-R351) [[2]](diffhunk://#diff-c673027add895632858466fd15ba353b1b1139c53584445a4c9f76a46cd6257bR435) [[3]](diffhunk://#diff-c673027add895632858466fd15ba353b1b1139c53584445a4c9f76a46cd6257bR451-R461) [[4]](diffhunk://#diff-c673027add895632858466fd15ba353b1b1139c53584445a4c9f76a46cd6257bL498-R537) [[5]](diffhunk://#diff-5d6a3e141c114fb7c9afb0a84bf4ad200b641d956438c454741a79eb567fa199R350-R355)
  - Integrate Teams API metadata validation into the main repository checks. [[1]](diffhunk://#diff-c673027add895632858466fd15ba353b1b1139c53584445a4c9f76a46cd6257bR8-R9) [[2]](diffhunk://#diff-c673027add895632858466fd15ba353b1b1139c53584445a4c9f76a46cd6257bR410)
* Added references to the new source review process in the Teams capabilities config.
* Added a new README (`scripts/teams-api-drift/README.md`) documenting how to maintain and review Teams API usage and capability metadata, including instructions for source review acknowledgments and when to update each metadata file.

**Metadata and ownership updates:**

* Updated `teams-api-usage-manifest.json`:
  - Bumped `@microsoft/teams.api` dependency version from `2.0.13` to `2.0.14`.
  - Marked many upstream symbols as `"publicly-exposed"` and updated their usage details and source files. [[1]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R16) [[2]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R26) [[3]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R38) [[4]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R50-R89) [[5]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R102-R110) [[6]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R129-R153) [[7]](diffhunk://#diff-dd3722c75cf4576fa3a5dee5e563c1384ff10f7c95320650154c9db5f2d97c44R165-R181)
* Updated `teams-capabilities.yaml`:
  - Adjusted ownership of key source files among capabilities, notably reassigning `src/teamsModelExtensions.ts` and adding `src/teamsActivity.ts` as an owner. [[1]](diffhunk://#diff-cdce8063bb69e1863fe525fd15081a799b3069305e028c41c877a43db9e83526R28-L26) [[2]](diffhunk://#diff-cdce8063bb69e1863fe525fd15081a799b3069305e028c41c877a43db9e83526R68) [[3]](diffhunk://#diff-cdce8063bb69e1863fe525fd15081a799b3069305e028c41c877a43db9e83526R79)

**CI and workflow improvements:**

* Modified the Azure DevOps CI pipeline to check out the repository with full history (`fetchDepth: 0`), which is required for accurate metadata drift checks.

These changes collectively ensure that Teams API usage and capability metadata remain accurate, reviewable, and aligned with the codebase, while making it easier for maintainers to track and review changes affecting Teams API compatibility.

## Testing
These images show some of the cases tested with the updated repo:doctor script.
<img width="1832" height="1396" alt="image" src="https://github.com/user-attachments/assets/1ff4fd22-273c-44a2-ae8b-9210647ef079" />
<img width="1816" height="1181" alt="image" src="https://github.com/user-attachments/assets/305e31dc-4ae8-4be3-967d-2f02e701cd30" />
