### PR TITLE
Add typing indicator telemetry span

### DIFF
--- a/packages/agents-hosting/src/app/agentApplication.ts
+++ b/packages/agents-hosting/src/app/agentApplication.ts
@@ -36,6 +36,7 @@ const TYPING_TIMER_STATE_KEY = Symbol('typingTimerState')
 type TypingTimerState = {
   timer?: NodeJS.Timeout
   lastSend: Promise<unknown>
+  notificationSequence: number
   stop: () => void
 }
 
@@ -882,6 +883,7 @@ export class AgentApplication<TState extends TurnState> {
 
     const state: TypingTimerState = {
       lastSend: Promise.resolve(),
+      notificationSequence: 0,
       stop: () => {
         if (state.timer) {
           clearTimeout(state.timer)
@@ -909,7 +911,8 @@ export class AgentApplication<TState extends TurnState> {
 
     const onTimeout = async () => {
       try {
-        state.lastSend = this.sendTypingActivity(context)
+        state.notificationSequence += 1
+        state.lastSend = this.sendTypingActivity(context, state.notificationSequence)
         await state.lastSend
       } catch (err: any) {
         logger.error(err)
@@ -942,11 +945,19 @@ export class AgentApplication<TState extends TurnState> {
     return streamingEntity?.streamType ?? activity.channelData?.streamType
   }
 
-  private async sendTypingActivity (context: TurnContext): Promise<ResourceResponse[] | undefined> {
+  private async sendTypingActivity (context: TurnContext, notificationSequence: number): Promise<ResourceResponse[] | undefined> {
     const conversationReference = context.activity.getConversationReference()
     const typingActivity = Activity.fromObject({ type: ActivityTypes.Typing }).applyConversationReference(conversationReference)
 
-    return await context.adapter.sendActivities(context, [typingActivity])
+    return await trace(AgentApplicationTraceDefinitions.typingIndicator, ({ record }) => {
+      record({
+        activityType: typingActivity.type,
+        channelId: typingActivity.channelId,
+        conversationId: typingActivity.conversation?.id,
+        notificationSequence,
+      })
+      return context.adapter.sendActivities(context, [typingActivity])
+    })
   }
 
   /**

--- a/packages/agents-hosting/src/observability/traces.ts
+++ b/packages/agents-hosting/src/observability/traces.ts
@@ -49,6 +49,23 @@ export const AgentApplicationTraceDefinitions = {
       span.setAttribute('agents.attachments.count', record.attachmentsCount ?? 0)
     }
   }),
+  typingIndicator: trace.define({
+    name: SpanNames.AGENTS_APP_TYPING_INDICATOR,
+    record: {
+      activityType: 'unknown',
+      channelId: 'unknown',
+      conversationId: 'unknown',
+      notificationSequence: 0,
+    },
+    end ({ span, record }) {
+      span.setAttributes({
+        'activity.type': record.activityType,
+        'activity.channel_id': record.channelId,
+        'activity.conversation_id': record.conversationId,
+        'typing.notification.sequence': record.notificationSequence,
+      })
+    }
+  }),
   beforeTurn: trace.define({
     name: SpanNames.AGENTS_APP_BEFORE_TURN,
     record: {},

--- a/packages/agents-hosting/test/observability/traces.test.ts
+++ b/packages/agents-hosting/test/observability/traces.test.ts
@@ -184,6 +184,36 @@ describe('trace definitions', () => {
       assert.deepEqual(span.attributes, { 'agents.attachments.count': 3 })
     })
 
+    it('should set activity attributes when a typing notification span ends', () => {
+      const span = endTrace(AgentApplicationTraceDefinitions.typingIndicator, {
+        activityType: 'typing',
+        channelId: 'webchat',
+        conversationId: 'conversation-id',
+        notificationSequence: 2,
+      })
+
+      assert.deepEqual(span.attributes, {
+        'activity.type': 'typing',
+        'activity.channel_id': 'webchat',
+        'activity.conversation_id': 'conversation-id',
+        'typing.notification.sequence': 2,
+      })
+    })
+
+    it('should set default activity attributes when a typing notification has no values', () => {
+      const span = endTrace(
+        AgentApplicationTraceDefinitions.typingIndicator,
+        AgentApplicationTraceDefinitions.typingIndicator.record
+      )
+
+      assert.deepEqual(span.attributes, {
+        'activity.type': 'unknown',
+        'activity.channel_id': 'unknown',
+        'activity.conversation_id': 'unknown',
+        'typing.notification.sequence': 0,
+      })
+    })
+
     it('should set route type attributes when a route handler ends', () => {
       const span = endTrace(AgentApplicationTraceDefinitions.routeHandler, {
         isInvoke: true,

--- a/packages/agents-telemetry/src/observability/constants.ts
+++ b/packages/agents-telemetry/src/observability/constants.ts
@@ -37,6 +37,7 @@ export const SpanNames = {
   AGENTS_APP_BEFORE_TURN: 'agents.app.before_turn',
   AGENTS_APP_AFTER_TURN: 'agents.app.after_turn',
   AGENTS_APP_DOWNLOAD_FILES: 'agents.app.download_files',
+  AGENTS_APP_TYPING_INDICATOR: 'agents.app.typing_indicator',
 
   // ConnectorClient
   CONNECTOR_SEND_TO_CONVERSATION: 'agents.connector.send_to_conversation',

--- a/packages/agents-telemetry/src/observability/trace.ts
+++ b/packages/agents-telemetry/src/observability/trace.ts
@@ -83,7 +83,16 @@ function createRecord<TRecord extends object, TActions extends object> (target: 
   return {
     set (values) {
       // TODO: use deep-merge strategy for Object and Array
-      Object.assign(state, values)
+      for (const key of Reflect.ownKeys(values)) {
+        if (!Object.prototype.propertyIsEnumerable.call(values, key)) {
+          continue
+        }
+
+        const value = Reflect.get(values, key)
+        if (value !== undefined) {
+          Reflect.set(state, key, value)
+        }
+      }
     },
     get () {
       return state as Readonly<TRecord>

--- a/packages/agents-telemetry/src/observability/trace.ts
+++ b/packages/agents-telemetry/src/observability/trace.ts
@@ -99,6 +99,7 @@ export function traceFactory (otel: OTel) {
  * @remarks
  * - Plain objects are recursively merged.
  * - Arrays are copied and replaced.
+ * - `undefined` values are ignored so definition defaults remain available.
  */
 function createRecord<TRecord extends object, TActions extends object> (target: TraceDefinition<TRecord, TActions>): TraceRecord<TRecord> {
   const state: Partial<TRecord> = target.record ? cloneRecordValue(target.record) : {}

--- a/packages/agents-telemetry/src/types.ts
+++ b/packages/agents-telemetry/src/types.ts
@@ -39,6 +39,7 @@ export type SpanName = typeof SpanNames[keyof typeof SpanNames]
  *
  * @remarks
  * - `set()` performs a shallow merge.
+ * - `set()` ignores `undefined` values so definition defaults remain available.
  * - `get()` returns the latest snapshot stored for the span.
  */
 export interface TraceRecord<TRecord extends object> {

--- a/packages/agents-telemetry/test/observability/trace.test.ts
+++ b/packages/agents-telemetry/test/observability/trace.test.ts
@@ -217,6 +217,24 @@ describe('traceFactory', () => {
     assert.deepStrictEqual(captured, { status: 'pending', count: 0 })
   })
 
+  it('record preserves default values when updates contain undefined', () => {
+    const { otel } = createMockOTel()
+    const trace = traceFactory(otel)
+    const symbolKey = Symbol('symbolKey')
+    let captured: any
+
+    trace(
+      {
+        name: SpanNames.ADAPTER_PROCESS,
+        record: { channelId: 'unknown', nullable: 'default' as string | null, [symbolKey]: 'default' },
+        end: ({ record }) => { captured = record },
+      },
+      ({ record }) => record({ channelId: undefined, nullable: null, [symbolKey]: 'updated' })
+    )
+
+    assert.deepStrictEqual(captured, { channelId: 'unknown', nullable: null, [symbolKey]: 'updated' })
+  })
+
   it('end callback receives duration', () => {
     const { otel } = createMockOTel()
     const trace = traceFactory(otel)


### PR DESCRIPTION
Fixes # 1252

## Description

Adds an `agents.app.typing_indicator` parent span for each automatic typing activity. Consumers can use a custom OpenTelemetry sampler to remove the typing span and all its child spans.

Each typing span includes:

- `activity.type`
- `activity.channel_id`
- `activity.conversation_id`
- `typing.notification.sequence`

A minimal sampler configuration is:

```ts
class TypingSampler implements Sampler {
  private readonly parentBased =
    new ParentBasedSampler({ root: new AlwaysOnSampler() })

  shouldSample (...args: Parameters<Sampler['shouldSample']>) {
    return args[2] === SpanNames.AGENTS_APP_TYPING_INDICATOR
      ? { decision: SamplingDecision.NOT_RECORD }
      : this.parentBased.shouldSample(...args)
  }

  toString () {
    return 'TypingSampler'
  }
}

const sdk = new NodeSDK({
  sampler: new TypingSampler(),
  traceExporter
})
```
The parent-based delegate removes descendants of the non-sampled typing span.

## Changes

### Typing telemetry

- Added a dedicated span around automatic typing sends.
- Kept adapter and connector spans as children.
- Added a per-turn notification sequence.
- Kept default attribute values in the trace definition.

### Trace records

- Updated record merging to ignore `undefined` values.
- Preserved support for `null`, falsy values, and symbol properties.

## Testing
The following image shows the new typing indicator span working as expected.
<img width="2512" height="1219" alt="imagen" src="https://github.com/user-attachments/assets/1ecf58ce-ac99-4505-8a3c-f8e7d7227b01" />
